### PR TITLE
CLOUDP-78443: GitHub action for running unit tests

### DIFF
--- a/.github/workflows/push-test.yml
+++ b/.github/workflows/push-test.yml
@@ -42,6 +42,16 @@ jobs:
     steps:
       - uses: actions/checkout@v2.3.1
 
-      - name: Unit test
-        run: |
-          echo "Unit test"
+      - name: Cache multiple paths
+        uses: actions/cache@v2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-build-${{ hashFiles('**/go.sum') }}
+
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '1.15.6'
+      - run: go version
+      - name: Run testing
+        run: CGO_ENABLED=0 go test -v $(go list ./pkg/...)

--- a/test/int/suite_test.go
+++ b/test/int/suite_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controller
+package int
 
 import (
 	"path/filepath"


### PR DESCRIPTION
Running unit tests from GitHub action.
So far I've moved the `suite_test.go` to `tests/int` to separate such tests from unit tests. This will be reviewed later when we address integration tests.

Note, that running locally using `act -j unit-test` is super-slow as Go is installed each time - this may be addressed in future