### PR TITLE
Add golangci-lint settings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,88 @@
+linters:
+  enable:
+    - bodyclose
+    - deadcode
+    - depguard
+    - dogsled
+    - dupl
+    - errcheck
+    - errorlint
+    - exportloopref
+    # - gochecknoinits
+    # - gochecknoglobals
+    - gocritic
+    - gocyclo
+    - gofumpt
+    - goimports
+    - goprintffuncname
+    - gosec
+    - gosimple
+    - govet
+    - ineffassign
+    - interfacer
+    - misspell
+    # - nlreturn
+    - nolintlint
+    - noctx
+    - prealloc
+    - rowserrcheck
+    - scopelint
+    - staticcheck
+    - structcheck
+    - stylecheck
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+    - varcheck
+    - whitespace
+    # - wrapcheck
+issues:
+  exclude-use-default: false
+  exclude:
+    # EXC0001 errcheck: Almost all programs ignore errors on these functions and in most cases it's ok
+    - Error return value of .((os\.)?std(out|err)\..*|.*Close|.*Flush|os\.Remove(All)?|.*print(f|ln)?|os\.(Un)?Setenv). is not checked
+
+    # EXC0002 golint: Annoying issue about not having a comment. The rare codebase has such comments
+    # - (comment on exported (method|function|type|const)|should have( a package)? comment|comment should be of the form)
+
+    # EXC0003 golint: False positive when tests are defined in package 'test'
+    - func name will be used as test\.Test.* by other packages, and that stutters; consider calling this
+
+    # EXC0004 govet: Common false positives
+    - (possible misuse of unsafe.Pointer|should have signature)
+
+    # EXC0005 staticcheck: Developers tend to write in C-style with an explicit 'break' in a 'switch', so it's ok to ignore
+    # - ineffective break statement. Did you mean to break out of the outer loop
+
+    # EXC0006 gosec: Too many false-positives on 'unsafe' usage
+    - Use of unsafe calls should be audited
+
+    # EXC0007 gosec: Too many false-positives for parametrized shell calls
+    - Subprocess launch(ed with variable|ing should be audited)
+
+    # EXC0008 gosec: Duplicated errcheck checks
+    - (G104|G307)
+
+    # EXC0009 gosec: Too many issues in popular repos
+    # - (Expect directory permissions to be 0750 or less|Expect file permissions to be 0600 or less)
+    # EXC0010 gosec: False positive is triggered by 'src, err := ioutil.ReadFile(filename)'
+    # - Potential file inclusion via variable
+    # EXC0011 stylecheck: Annoying issue about not having a comment. The rare codebase has such comments
+    # - (comment on exported (method|function|type|const)|should have( a package)? comment|comment should be of the form)
+
+    - at least one file in a package should have a package comment
+
+  exclude-rules:
+    - path: test
+      linters:
+        - gocyclo
+        - gochecknoglobals
+        - wrapcheck
+        - nlreturn
+    - path: main.go
+      linters:
+        - gochecknoglobals
+        - wrapcheck
+  max-issues-per-linter: 0
+  max-same-issues: 0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,5 @@
 linters:
+  disable-all: true
   enable:
     - bodyclose
     - deadcode
@@ -8,8 +9,6 @@ linters:
     - errcheck
     - errorlint
     - exportloopref
-    # - gochecknoinits
-    # - gochecknoglobals
     - gocritic
     - gocyclo
     - gofumpt
@@ -19,14 +18,11 @@ linters:
     - gosimple
     - govet
     - ineffassign
-    - interfacer
     - misspell
-    # - nlreturn
     - nolintlint
     - noctx
     - prealloc
     - rowserrcheck
-    - scopelint
     - staticcheck
     - structcheck
     - stylecheck
@@ -36,7 +32,11 @@ linters:
     - unused
     - varcheck
     - whitespace
-    # - wrapcheck
+
+linters-settings:
+  misspell:
+    locale: US
+
 issues:
   exclude-use-default: false
   exclude:

--- a/main.go
+++ b/main.go
@@ -18,11 +18,13 @@ package main
 
 import (
 	"flag"
+	"os"
+
 	"github.com/go-logr/zapr"
 	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/controller/altascluster"
 	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/controller/atlasproject"
 	"go.uber.org/zap"
-	"os"
+
 	ctrzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"k8s.io/apimachinery/pkg/runtime"

--- a/pkg/api/v1/atlascustomresource.go
+++ b/pkg/api/v1/atlascustomresource.go
@@ -6,6 +6,7 @@ import (
 )
 
 //+k8s:deepcopy-gen=false
+
 // AtlasCustomResource is the interface common for all Atlas entities
 type AtlasCustomResource interface {
 	runtime.Object

--- a/pkg/api/v1/atlasproject_types.go
+++ b/pkg/api/v1/atlasproject_types.go
@@ -78,6 +78,7 @@ type AtlasProject struct {
 }
 
 // +kubebuilder:object:root=true
+
 // AtlasProjectList contains a list of AtlasProject
 type AtlasProjectList struct {
 	metav1.TypeMeta `json:",inline"`

--- a/pkg/controller/atlas/api_error.go
+++ b/pkg/controller/atlas/api_error.go
@@ -2,5 +2,5 @@ package atlas
 
 const (
 	// Error codes that Atlas may return that we are concerned about
-	GroupExistsApiErrorCode = "GROUP_ALREADY_EXISTS"
+	GroupExistsAPIErrorCode = "GROUP_ALREADY_EXISTS"
 )

--- a/pkg/controller/atlas/connection.go
+++ b/pkg/controller/atlas/connection.go
@@ -11,9 +11,9 @@ import (
 )
 
 const (
-	orgIdKey      = "orgId"
-	publicApiKey  = "publicApiKey"
-	privateApiKey = "privateApiKey"
+	orgIDKey      = "orgId"
+	publicAPIKey  = "publicApiKey"
+	privateAPIKey = "privateApiKey"
 )
 
 // Connection encapsulates Atlas connectivity information that is necessary to perform API requests
@@ -59,7 +59,7 @@ func readAtlasConnectionFromSecret(kubeClient client.Client, secretRef client.Ob
 
 func validateConnectionSecret(secretRef client.ObjectKey, secretData map[string]string) error {
 	var missingFields []string
-	requiredKeys := []string{orgIdKey, publicApiKey, privateApiKey}
+	requiredKeys := []string{orgIDKey, publicAPIKey, privateAPIKey}
 
 	for _, key := range requiredKeys {
 		if _, ok := secretData[key]; !ok {

--- a/pkg/util/set/identifiable_test.go
+++ b/pkg/util/set/identifiable_test.go
@@ -6,21 +6,21 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-type someId struct {
+type someID struct {
 	// name is a "key" field used for merging
 	name string
 	// some other property. Indicates which exactly object was returned by an aggregation operation
 	property string
 }
 
-func newSome(name, property string) someId {
-	return someId{
+func newSome(name, property string) someID {
+	return someID{
 		name:     name,
 		property: property,
 	}
 }
 
-func (s someId) Identifier() interface{} {
+func (s someID) Identifier() interface{} {
 	return s.name
 }
 
@@ -61,8 +61,8 @@ func Test_SetDifferenceCovariant(t *testing.T) {
 	twoLeft := newSome("2", "left")
 	twoRight := newSome("2", "right")
 	threeRight := newSome("3", "right")
-	leftNotIdentifiable := []someId{oneLeft, twoLeft}
-	rightNotIdentifiable := []someId{twoRight, threeRight}
+	leftNotIdentifiable := []someID{oneLeft, twoLeft}
+	rightNotIdentifiable := []someID{twoRight, threeRight}
 
 	assert.Equal(t, []Identifiable{oneLeft}, Difference(leftNotIdentifiable, rightNotIdentifiable))
 	assert.Equal(t, []Identifiable{threeRight}, Difference(rightNotIdentifiable, leftNotIdentifiable))
@@ -110,8 +110,8 @@ func Test_SetIntersectionCovariant(t *testing.T) {
 
 	// check reflection magic to solve lack of covariance in go. The arrays are declared as '[]someId' instead of
 	// '[]Identifiable'
-	leftNotIdentifiable := []someId{oneLeft, twoLeft}
-	rightNotIdentifiable := []someId{oneRight, twoRight, threeRight}
+	leftNotIdentifiable := []someID{oneLeft, twoLeft}
+	rightNotIdentifiable := []someID{oneRight, twoRight, threeRight}
 
 	assert.Equal(t, [][]Identifiable{pair(oneLeft, oneRight), pair(twoLeft, twoRight)}, Intersection(leftNotIdentifiable, rightNotIdentifiable))
 	assert.Equal(t, [][]Identifiable{pair(oneRight, oneLeft), pair(twoRight, twoLeft)}, Intersection(rightNotIdentifiable, leftNotIdentifiable))

--- a/test/int/suite_test.go
+++ b/test/int/suite_test.go
@@ -37,9 +37,11 @@ import (
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
-var cfg *rest.Config
-var k8sClient client.Client
-var testEnv *envtest.Environment
+var (
+	cfg       *rest.Config
+	k8sClient client.Client
+	testEnv   *envtest.Environment
+)
 
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)


### PR DESCRIPTION
This PR adds a set of linter rules almost as strict as was used in `atlas-osb`; some rules were relaxed due to the differences in architecture (use of `init()` functions, global variables, etc.)