### PR TITLE
CLOUDP-79534: don't reconcile if the Project has been removed

### DIFF
--- a/pkg/controller/atlasproject/atlasproject_controller.go
+++ b/pkg/controller/atlasproject/atlasproject_controller.go
@@ -17,16 +17,13 @@ limitations under the License.
 package atlasproject
 
 import (
-	"context"
-	"time"
-
 	mdbv1 "github.com/mongodb/mongodb-atlas-kubernetes/pkg/api/v1"
 	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/api/v1/status"
 	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/controller/atlas"
+	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/controller/customresource"
 	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/controller/statushandler"
 	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/controller/watch"
 	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/controller/workflow"
-	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/util/kube"
 	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -49,10 +46,10 @@ func (r *AtlasProjectReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error
 	log := r.Log.With("atlasproject", req.NamespacedName)
 
 	project := &mdbv1.AtlasProject{}
-	if err := r.Client.Get(context.Background(), kube.ObjectKey(req.Namespace, req.Name), project); err != nil {
-		log.Error(err, "Failed to read the AtlasProject")
-		return reconcile.Result{RequeueAfter: time.Second * 10}, nil
+	if result := customresource.GetResource(r.Client, req, project, log); result != nil {
+		return *result, nil
 	}
+
 	ctx := workflow.NewContext(log)
 
 	log.Infow("-> Starting AtlasProject reconciliation", "spec", project.Spec)

--- a/pkg/controller/atlasproject/atlasproject_controller.go
+++ b/pkg/controller/atlasproject/atlasproject_controller.go
@@ -46,8 +46,8 @@ func (r *AtlasProjectReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error
 	log := r.Log.With("atlasproject", req.NamespacedName)
 
 	project := &mdbv1.AtlasProject{}
-	if result := customresource.GetResource(r.Client, req, project, log); result != nil {
-		return *result, nil
+	if result := customresource.GetResource(r.Client, req, project, log); !result.IsOk() {
+		return result.ReconcileResult(), nil
 	}
 
 	ctx := workflow.NewContext(log)

--- a/pkg/controller/customresource/customresource.go
+++ b/pkg/controller/customresource/customresource.go
@@ -1,0 +1,30 @@
+package customresource
+
+import (
+	"context"
+	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/controller/workflow"
+	"go.uber.org/zap"
+	apiErrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// GetResource queries the Custom Resource 'request.NamespacedName' and populates the 'resource' pointer.
+// Note the logic: any reconcile result different from nil should be considered as "terminal" and will stop reconciliation
+// right away (the pointer will be empty). Otherwise the pointer 'resource' will always reference the existing resource
+func GetResource(client client.Client, request reconcile.Request, resource runtime.Object, log *zap.SugaredLogger) *reconcile.Result {
+	err := client.Get(context.Background(), request.NamespacedName, resource)
+	if err != nil {
+		if apiErrors.IsNotFound(err) {
+			// Request object not found, could have been deleted after reconcile request.
+			// Return and don't requeue
+			log.Debugf("Object %s doesn't exist, was it deleted after reconcile request?", request.NamespacedName)
+			return &reconcile.Result{}
+		}
+		// Error reading the object - requeue the request.
+		log.Errorf("Failed to query object %s: %s", request.NamespacedName, err)
+		return &reconcile.Result{RequeueAfter: workflow.DefaultRetry}
+	}
+	return nil
+}

--- a/pkg/controller/customresource/customresource.go
+++ b/pkg/controller/customresource/customresource.go
@@ -2,6 +2,7 @@ package customresource
 
 import (
 	"context"
+
 	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/controller/workflow"
 	"go.uber.org/zap"
 	apiErrors "k8s.io/apimachinery/pkg/api/errors"

--- a/pkg/controller/workflow/result.go
+++ b/pkg/controller/workflow/result.go
@@ -17,6 +17,7 @@ type Result struct {
 	reason       ConditionReason
 }
 
+// OK indicates that the reconciliation logic can proceed further
 func OK() Result {
 	return Result{
 		done:         false,
@@ -24,12 +25,26 @@ func OK() Result {
 	}
 }
 
+// Terminate indicates that the reconciliation logic cannot proceed and needs to be finished (and possibly requeued)
+// 'reason' and 'message' indicate the error state and are supposed to be reflected in the `conditions` for the
+// reconciled Custom Resource
 func Terminate(reason ConditionReason, message string) Result {
 	return Result{done: true, requeueAfter: DefaultRetry, reason: reason, message: message}
 }
 
-func (r *Result) WithRetry(retry time.Duration) *Result {
+// TerminateSilently indicates that the reconciliation logic cannot proceed and needs to be finished (and possibly requeued)
+// The status of the reconciled Custom Resource is not supposed to be updated.
+func TerminateSilently() Result {
+	return Result{done: true, requeueAfter: DefaultRetry}
+}
+
+func (r Result) WithRetry(retry time.Duration) Result {
 	r.requeueAfter = retry
+	return r
+}
+
+func (r Result) WithoutRetry() Result {
+	r.requeueAfter = -1
 	return r
 }
 

--- a/pkg/controller/workflow/result.go
+++ b/pkg/controller/workflow/result.go
@@ -6,7 +6,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-const defaultRetry = time.Second * 10
+const DefaultRetry = time.Second * 10
 
 type ConditionReason string
 
@@ -25,7 +25,7 @@ func OK() Result {
 }
 
 func Terminate(reason ConditionReason, message string) Result {
-	return Result{done: true, requeueAfter: defaultRetry, reason: reason, message: message}
+	return Result{done: true, requeueAfter: DefaultRetry, reason: reason, message: message}
 }
 
 func (r *Result) WithRetry(retry time.Duration) *Result {


### PR DESCRIPTION
This PR handles the situation when the AtlasProject CR has been removed - no retry must happen in this case.

Note, that handling the deletion for the AtlasProject in Atlas is a TODO as we need to investigate all the scenarios (removing the project if there are dependent clusters for example)