### PR TITLE
CLOUDP-79537: catch the API error if the project already exists

### DIFF
--- a/pkg/controller/atlas/api_error.go
+++ b/pkg/controller/atlas/api_error.go
@@ -3,4 +3,8 @@ package atlas
 const (
 	// Error codes that Atlas may return that we are concerned about
 	GroupExistsAPIErrorCode = "GROUP_ALREADY_EXISTS"
+
+	// The error that Atlas API returns if the GET request is sent to read the project that either doesn't exist
+	// or the user doesn't have permissions for
+	NotInGroup = "NOT_IN_GROUP"
 )

--- a/pkg/controller/atlasproject/project.go
+++ b/pkg/controller/atlasproject/project.go
@@ -3,10 +3,10 @@ package atlasproject
 import (
 	"context"
 	"errors"
+
 	mdbv1 "github.com/mongodb/mongodb-atlas-kubernetes/pkg/api/v1"
 	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/controller/atlas"
 	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/controller/workflow"
-	"github.com/prometheus/common/log"
 	"go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -34,8 +34,9 @@ func ensureProjectExists(ctx *workflow.Context, connection atlas.Connection, pro
 			return "", workflow.Terminate(workflow.ProjectNotCreatedInAtlas, err.Error())
 		}
 	}
+
 	if p == nil || p.ID == "" {
-		log.Error("Project or its project ID are empty")
+		ctx.Log.Error("Project or its project ID are empty")
 		return "", workflow.Terminate(workflow.Internal, "")
 	}
 	return p.ID, workflow.OK()

--- a/pkg/controller/atlasproject/project.go
+++ b/pkg/controller/atlasproject/project.go
@@ -2,10 +2,11 @@ package atlasproject
 
 import (
 	"context"
-
+	"errors"
 	mdbv1 "github.com/mongodb/mongodb-atlas-kubernetes/pkg/api/v1"
 	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/controller/atlas"
 	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/controller/workflow"
+	"github.com/prometheus/common/log"
 	"go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -18,23 +19,24 @@ func ensureProjectExists(ctx *workflow.Context, connection atlas.Connection, pro
 	// Try to find the project
 	p, _, err := client.Projects.GetOneProjectByName(context.Background(), project.Spec.Name)
 	if err != nil {
-		return "", workflow.Terminate(workflow.ProjectNotCreatedInAtlas, err.Error())
+		var apiError *mongodbatlas.ErrorResponse
+		if errors.As(err, &apiError) && apiError.ErrorCode == atlas.NotInGroup {
+			// Project doesn't exist? Try to create it
+			p = &mongodbatlas.Project{
+				OrgID: connection.OrgID,
+				Name:  project.Spec.Name,
+			}
+			if p, _, err = client.Projects.Create(context.Background(), p); err != nil {
+				return "", workflow.Terminate(workflow.ProjectNotCreatedInAtlas, err.Error())
+			}
+			ctx.Log.Infow("Created Atlas Project", "name", project.Spec.Name, "id", p.ID)
+		} else {
+			return "", workflow.Terminate(workflow.ProjectNotCreatedInAtlas, err.Error())
+		}
 	}
-	if p.ID != "" {
-		ctx.Log.Debugw("Found Atlas Project", "id", p.ID)
-		return p.ID, workflow.OK()
+	if p == nil || p.ID == "" {
+		log.Error("Project or its project ID are empty")
+		return "", workflow.Terminate(workflow.Internal, "")
 	}
-
-	// Otherwise try to create it
-	p = &mongodbatlas.Project{
-		OrgID: connection.OrgID,
-		Name:  project.Spec.Name,
-	}
-
-	if p, _, err = client.Projects.Create(context.Background(), p); err != nil {
-		return "", workflow.Terminate(workflow.ProjectNotCreatedInAtlas, err.Error())
-	}
-	ctx.Log.Infow("Created Atlas Project", "name", project.Spec.Name, "id", p.ID)
-
 	return p.ID, workflow.OK()
 }


### PR DESCRIPTION
There was a bug that the code didn't handle the "get project by name" properly. This returns 401 and it seems handling to error code is the best instead of HTTP header