### PR TITLE
Removing gofumpt from the list of mandatory linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,7 +11,6 @@ linters:
     - exportloopref
     - gocritic
     - gocyclo
-    - gofumpt
     - goimports
     - goprintffuncname
     - gosec


### PR DESCRIPTION
As discussed with the team we won't use gofumpt as a mandatory linter.
It can be used locally still.