### PR TITLE
Moving test files

### DIFF
--- a/test/int/integration_suite_test.go
+++ b/test/int/integration_suite_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package project
+package int
 
 import (
 	"net/http"
@@ -70,7 +70,7 @@ var _ = BeforeSuite(func(done Done) {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths: []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
+		CRDDirectoryPaths: []string{filepath.Join("..", "..", "config", "crd", "bases")},
 	}
 
 	atlasClient, connection = prepareAtlasClient()

--- a/test/int/project_test.go
+++ b/test/int/project_test.go
@@ -1,4 +1,4 @@
-package project
+package int
 
 import (
 	"context"


### PR DESCRIPTION
Rejected the idea of having a package per int test as it seems logical to have a single `suite_test.go`  per all the tests and avoid duplication of `project_suite_test.go`, `cluster_suite_test.go` (as they will all be the same)