### PR TITLE
CLOUDP-80623: Improve Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,21 +1,11 @@
+# fix for some Linux distros (i.e. WSL)
+SHELL := /usr/bin/env bash
+
 # Current Operator version
 VERSION ?= 0.0.1
-# Default bundle image tag
-BUNDLE_IMG ?= controller-bundle:$(VERSION)
-# Options for 'bundle-build'
-ifneq ($(origin CHANNELS), undefined)
-BUNDLE_CHANNELS := --channels=$(CHANNELS)
-endif
-ifneq ($(origin DEFAULT_CHANNEL), undefined)
-BUNDLE_DEFAULT_CHANNEL := --default-channel=$(DEFAULT_CHANNEL)
-endif
-BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 
 # Image URL to use all building/pushing image targets
 IMG ?= controller:latest
-# Produce CRDs that work back to Kubernetes 1.16 (so 'apiVersion: apiextensions.k8s.io/v1')
-CRD_OPTIONS ?= "crd:crdVersions=v1"
-#CRD_OPTIONS ?= "crd:trivialVersions=true"
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -24,56 +14,69 @@ else
 GOBIN=$(shell go env GOBIN)
 endif
 
-all: manager
+.DEFAULT_GOAL := help
+.PHONY: help
+help: ## Show this help screen
+# adapted from https://github.com/operator-framework/operator-sdk
+	@echo 'Usage: make <OPTIONS> ... <TARGETS>'
+	@echo ''
+	@echo 'Available targets are:'
+	@echo ''
+	@awk 'BEGIN {FS = ":.*##"} /^[a-zA-Z0-9_-]+:.*?##/ { printf "  \033[36m%-25s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
-# Run integration tests
-ENVTEST_ASSETS_DIR = $(shell pwd)/testbin
-export ATLAS_ORG_ID=$(shell grep "ATLAS_ORG_ID" .actrc | cut -d "=" -f 2)
-export ATLAS_PUBLIC_KEY=$(shell grep "ATLAS_PUBLIC_KEY" .actrc | cut -d "=" -f 2)
-export ATLAS_PRIVATE_KEY=$(shell grep "ATLAS_PRIVATE_KEY" .actrc | cut -d "=" -f 2)
+.PHONY: all
+all: manager ## Build all binaries
+
+.PHONY: int-test
+int-test: ENVTEST_ASSETS_DIR = $(shell pwd)/testbin
+int-test: export ATLAS_ORG_ID=$(shell grep "ATLAS_ORG_ID" .actrc | cut -d "=" -f 2)
+int-test: export ATLAS_PUBLIC_KEY=$(shell grep "ATLAS_PUBLIC_KEY" .actrc | cut -d "=" -f 2)
+int-test: export ATLAS_PRIVATE_KEY=$(shell grep "ATLAS_PRIVATE_KEY" .actrc | cut -d "=" -f 2)
 # magical env that if specified makes the test output 0 on successful runs
 # https://github.com/onsi/ginkgo/blob/master/ginkgo/run_command.go#L130
-export GINKGO_EDITOR_INTEGRATION="true"
-int-test: generate manifests
+int-test: export GINKGO_EDITOR_INTEGRATION="true"
+int-test: generate manifests ## Run integration tests
 	mkdir -p $(ENVTEST_ASSETS_DIR)
 	test -f $(ENVTEST_ASSETS_DIR)/setup-envtest.sh || curl -sSLo $(ENVTEST_ASSETS_DIR)/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.8.0/hack/setup-envtest.sh
 	source $(ENVTEST_ASSETS_DIR)/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); ginkgo -v ./test/int -coverprofile cover.out
 
-# Build manager binary
-manager: generate fmt vet
+.PHONY: manager
+manager: generate fmt vet ## Build manager binary
 	go build -o bin/manager main.go
 
-# Run against the configured Kubernetes cluster in ~/.kube/config
-run: generate fmt vet manifests
+.PHONY: run
+run: generate fmt vet manifests ## Run against the configured Kubernetes cluster in ~/.kube/config
 	go run ./main.go
 
-# Uninstall CRDs from a cluster
-uninstall: manifests kustomize
+.PHONY: uninstall
+uninstall: manifests kustomize ## Uninstall CRDs from a cluster
 	$(KUSTOMIZE) build config/crd | kubectl delete -f -
 
-# Deploy controller in the configured Kubernetes cluster in ~/.kube/config
-deploy: run-kind
+.PHONY: deploy
+deploy: run-kind ## Deploy controller in the configured Kubernetes cluster in ~/.kube/config
 	@ act -j deploy -s KUBE_CONFIG_DATA='$(shell kind get kubeconfig | yq r - -j)'
 
-# Generate manifests e.g. CRD, RBAC etc.
-manifests: controller-gen
+.PHONY: manifests
+# Produce CRDs that work back to Kubernetes 1.16 (so 'apiVersion: apiextensions.k8s.io/v1')
+manifests: CRD_OPTIONS ?= "crd:crdVersions=v1"
+#manifests: CRD_OPTIONS ?= "crd:trivialVersions=true"
+manifests: controller-gen ## Generate manifests e.g. CRD, RBAC etc.
 	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 
-# Run go fmt against code
-fmt:
+.PHONY: fmt
+fmt: ## Run go fmt against code
 	go fmt ./...
 
-# Run go vet against code
-vet:
+.PHONY: vet
+vet: ## Run go vet against code
 	go vet ./...
 
-# Generate code
-generate: controller-gen
+.PHONY: generate
+generate: controller-gen ## Generate code
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
 
-# find or download controller-gen
-# download controller-gen if necessary
-controller-gen:
+.PHONY: controller-gen
+controller-gen: ## Find controller-gen or download it if necessary
 ifeq (, $(shell which controller-gen))
 	@{ \
 	set -e ;\
@@ -88,7 +91,8 @@ else
 CONTROLLER_GEN=$(shell which controller-gen)
 endif
 
-kustomize:
+.PHONY: kustomize
+kustomize: ## Find kustomize or download it if necessary
 ifeq (, $(shell which kustomize))
 	@{ \
 	set -e ;\
@@ -103,30 +107,38 @@ else
 KUSTOMIZE=$(shell which kustomize)
 endif
 
-# Generate bundle manifests and metadata, then validate generated files.
 .PHONY: bundle
-bundle: manifests kustomize
+ifneq ($(origin CHANNELS), undefined)
+bundle: BUNDLE_CHANNELS := --channels=$(CHANNELS)
+endif
+ifneq ($(origin DEFAULT_CHANNEL), undefined)
+bundle: BUNDLE_DEFAULT_CHANNEL := --default-channel=$(DEFAULT_CHANNEL)
+endif
+bundle: BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
+bundle: manifests kustomize ## Generate bundle manifests and metadata, then validate generated files
 	operator-sdk generate kustomize manifests -q
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
 	$(KUSTOMIZE) build config/manifests | operator-sdk generate bundle -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
 	operator-sdk bundle validate ./bundle
 
-# Build the bundle image.
 .PHONY: bundle-build
-bundle-build:
+# Default bundle image tag
+bundle-build: BUNDLE_IMG ?= controller-bundle:$(VERSION)
+bundle-build: ## Build the bundle image.
 	docker build -f bundle.Dockerfile -t $(BUNDLE_IMG) .
 
-#local k8s
-run-kind:
+.PHONY: run-kind
+run-kind: ## Create a local kind cluster
 ifeq ($(shell kind get clusters),kind)
 	@echo "create kind cluster: nothing to do"
 else
 	@bash ./scripts/create_kind_cluster.sh
 endif
 
-#local k8s
-stop-kind:
+.PHONY: stop-kind
+stop-kind: ## Stop the local kind cluster
 	kind delete cluster
 
-log:
+.PHONY: log
+log: ## View manager logs
 	kubectl logs deploy/mongodb-atlas-kubernetes-controller-manager manager -n mongodb-atlas-kubernetes-system -f


### PR DESCRIPTION
- Encapsulate most env variables to their respective targets, hopefully improving readability
- Add self-documentation via ##

New output when run without a target:
```
$ make
Usage: make <OPTIONS> ... <TARGETS>

Available targets are:

  help                       Show this help screen
  all                        Build all binaries
  int-test                   Run integration tests
  manager                    Build manager binary
  run                        Run against the configured Kubernetes cluster in ~/.kube/config
  uninstall                  Uninstall CRDs from a cluster
  deploy                     Deploy controller in the configured Kubernetes cluster in ~/.kube/config
  manifests                  Generate manifests e.g. CRD, RBAC etc.
  fmt                        Run go fmt against code
  vet                        Run go vet against code
  generate                   Generate code
  controller-gen             Find controller-gen or download it if necessary
  kustomize                  Find kustomize or download it if necessary
  bundle                     Generate bundle manifests and metadata, then validate generated files
  bundle-build               Build the bundle image.
  run-kind                   Create a local kind cluster
  stop-kind                  Stop the local kind cluster
  log                        View manager logs
```