### PR TITLE
CLOUDP-81188: fix deletion of Atlas Cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,28 @@
 # MongoDB Atlas Operator
 Welcome to MongoDB Atlas Operator - the Operator allowing to manage Atlas Clusters from Kubernetes.
 
+> Current Status: *pre-alpha*. We are currently working on the initial set of features that will give users the opportunity to
+provision Atlas projects, clusters and database users using Kubernetes Specifications and bind connection information 
+into the applications deployed to Kubernetes.   
+
+## Installation / Upgrade
+
+### Using Kubernetes config files
+
+```
+kubectl apply -f  <link to all_in_one>
+```
+
+## Create Atlas Cluster
+
+In order to work with Atlas you'll need to provide the authentication information that would allow the Atlas Operator
+communicate with Atlas API. You need to create the secret first:
+
+```
+kubectl create secret generic my-atlas-key \
+         --from-literal="orgId=<the_atlas_organization_id>" \
+         --from-literal="publicApiKey=<the_atlas_api_public_key>" \
+         --from-literal="privateApiKey=<the_atlas_api_private_key>" \
+         -n <your_namespace>
+```
+

--- a/pkg/controller/atlas/api_error.go
+++ b/pkg/controller/atlas/api_error.go
@@ -7,4 +7,7 @@ const (
 	// The error that Atlas API returns if the GET request is sent to read the project that either doesn't exist
 	// or the user doesn't have permissions for
 	NotInGroup = "NOT_IN_GROUP"
+
+	// Error indicates that the project is being removed while it still has clusters
+	CannotCloseGroupActiveAtlasCluster = "CANNOT_CLOSE_GROUP_ACTIVE_ATLAS_CLUSTERS"
 )

--- a/pkg/controller/atlascluster/atlascluster_controller.go
+++ b/pkg/controller/atlascluster/atlascluster_controller.go
@@ -58,7 +58,7 @@ func (r *AtlasClusterReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error
 	}
 	ctx := customresource.MarkReconciliationStarted(r.Client, cluster, log)
 
-	log.Infow("-> Starting AtlasCluster reconciliation", "spec", cluster.Spec)
+	log.Infow("-> Starting AtlasCluster reconciliation", "spec", cluster.Spec, "generation", cluster.Generation, "status", cluster.Status)
 	defer statushandler.Update(ctx, r.Client, cluster)
 
 	project := &mdbv1.AtlasProject{}
@@ -135,12 +135,12 @@ func (r *AtlasClusterReconciler) Delete(obj runtime.Object) error {
 		return errors.New("cannot read Atlas connection")
 	}
 
-	client, err := atlas.Client(connection, log)
+	atlasClient, err := atlas.Client(connection, log)
 	if err != nil {
 		return fmt.Errorf("cannot build Atlas client: %w", err)
 	}
 
-	_, err = client.Clusters.Delete(context.Background(), project.Status.ID, cluster.Name)
+	_, err = atlasClient.Clusters.Delete(context.Background(), project.Status.ID, cluster.Spec.Name)
 	if err != nil {
 		return fmt.Errorf("cannot delete Atlas cluster: %w", err)
 	}

--- a/pkg/util/testutil/customresources.go
+++ b/pkg/util/testutil/customresources.go
@@ -21,8 +21,8 @@ func WaitFor(k8sClient client.Client, createdResource mdbv1.AtlasCustomResource,
 			return false
 		}
 		// Atlas Operator hasn't started working yet
+		fmt.Printf("Generation: %+v, observed Generation: %+v\n", createdResource.GetGeneration(), createdResource.GetStatus().GetObservedGeneration())
 		if createdResource.GetGeneration() != createdResource.GetStatus().GetObservedGeneration() {
-			fmt.Printf("Generation: %+v, observed Generation: %+v\n", createdResource.GetGeneration(), createdResource.GetStatus().GetObservedGeneration())
 			return false
 		}
 

--- a/pkg/util/testutil/customresources.go
+++ b/pkg/util/testutil/customresources.go
@@ -22,6 +22,7 @@ func WaitFor(k8sClient client.Client, createdResource mdbv1.AtlasCustomResource,
 		}
 		// Atlas Operator hasn't started working yet
 		if createdResource.GetGeneration() != createdResource.GetStatus().GetObservedGeneration() {
+			fmt.Printf("Generation: %+v, observed Generation: %+v\n", createdResource.GetGeneration(), createdResource.GetStatus().GetObservedGeneration())
 			return false
 		}
 

--- a/test/int/cluster_test.go
+++ b/test/int/cluster_test.go
@@ -78,7 +78,7 @@ var _ = Describe("AtlasCluster", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	FDescribe("Create/Update the cluster", func() {
+	Describe("Create/Update the cluster", func() {
 		It("Should Succeed", func() {
 			expectedCluster := testAtlasCluster(namespace.Name, "test-cluster", createdProject.Name)
 

--- a/test/int/cluster_test.go
+++ b/test/int/cluster_test.go
@@ -69,7 +69,8 @@ var _ = Describe("AtlasCluster", func() {
 			}
 			By("Removing Atlas Project " + createdProject.Status.ID)
 			// This is a bit strange but the delete request right after the cluster is removed may fail with "Still active cluster" error
-			// UI shows the cluster being deleted though. Seems to be the issue only for GCP clusters.
+			// UI shows the cluster being deleted though. Seems to be the issue only if removal is done using API,
+			// if the cluster is terminated using UI - it stays in "Deleting" state
 			Eventually(removeAtlasProject(createdProject.Status.ID), 600, interval).Should(BeTrue())
 		}
 

--- a/test/int/cluster_test.go
+++ b/test/int/cluster_test.go
@@ -2,17 +2,20 @@ package int
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
 
 	mdbv1 "github.com/mongodb/mongodb-atlas-kubernetes/pkg/api/v1"
 	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/api/v1/status"
+	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/controller/atlas"
 	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/controller/workflow"
 	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/util/kube"
 	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/util/testutil"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"go.mongodb.org/atlas/mongodbatlas"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -59,13 +62,15 @@ var _ = Describe("AtlasCluster", func() {
 	AfterEach(func() {
 		if createdProject != nil && createdProject.Status.ID != "" {
 			if createdCluster != nil {
-				By("Removing Atlas Cluster " + createdCluster.Spec.Name)
-				_, _ = atlasClient.Clusters.Delete(context.Background(), createdProject.Status.ID, createdCluster.Spec.Name)
+				By("Removing Atlas Cluster " + createdCluster.Name)
+				Expect(k8sClient.Delete(context.Background(), createdCluster)).To(Succeed())
+
+				Eventually(checkAtlasClusterRemoved(createdProject.Status.ID, createdCluster.Name), 600, interval).Should(BeTrue())
 			}
-			// TODO need to wait for the cluster to get removed
-			// By("Removing Atlas Project " + createdProject.Status.ID)
-			// _, err := atlasClient.Projects.Delete(context.Background(), createdProject.Status.ID)
-			// Expect(err).ToNot(HaveOccurred())
+			By("Removing Atlas Project " + createdProject.Status.ID)
+			// This is a bit strange but the delete request right after the cluster is removed may fail with "Still active cluster" error
+			// UI shows the cluster being deleted though. Seems to be the issue only for GCP clusters.
+			Eventually(removeAtlasProject(createdProject.Status.ID), 600, interval).Should(BeTrue())
 		}
 
 		By("Removing the namespace " + namespace.Name)
@@ -73,7 +78,7 @@ var _ = Describe("AtlasCluster", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	Describe("Create/Update/Delete the cluster", func() {
+	FDescribe("Create/Update the cluster", func() {
 		It("Should Succeed", func() {
 			expectedCluster := testAtlasCluster(namespace.Name, "test-cluster", createdProject.Name)
 
@@ -137,16 +142,12 @@ var _ = Describe("AtlasCluster", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(atlasCluster.Name).To(Equal(createdAtlasCluster.Name))
+			print(createdCluster.Labels)
+			print(createdAtlasCluster.Labels)
 			Expect(atlasCluster.Labels).To(Equal(createdAtlasCluster.Labels))
 			Expect(atlasCluster.ProviderSettings.InstanceSizeName).To(Equal(createdAtlasCluster.ProviderSettings.InstanceSizeName))
 			Expect(atlasCluster.ProviderSettings.ProviderName).To(Equal(createdAtlasCluster.ProviderSettings.ProviderName))
 			Expect(atlasCluster.ProviderSettings.RegionName).To(Equal(createdAtlasCluster.ProviderSettings.RegionName))
-
-			By("Deleting the cluster")
-			err = k8sClient.Delete(context.Background(), createdCluster)
-			Expect(err).ToNot(HaveOccurred())
-
-			Eventually(checkAtlasDeleteStarted(createdProject.Status.ID, createdCluster.Name), 1200, interval).Should(BeTrue())
 		})
 	})
 })
@@ -182,7 +183,7 @@ func testAtlasCluster(namespace, name, projectName string) *mdbv1.AtlasCluster {
 			Namespace: namespace,
 		},
 		Spec: mdbv1.AtlasClusterSpec{
-			Name:    "test-cluster",
+			Name:    "test-atlas-cluster",
 			Project: mdbv1.ResourceRef{Name: projectName},
 			ProviderSettings: &mdbv1.ProviderSettingsSpec{
 				InstanceSizeName: "M10",
@@ -192,18 +193,31 @@ func testAtlasCluster(namespace, name, projectName string) *mdbv1.AtlasCluster {
 		},
 	}
 }
-func checkAtlasDeleteStarted(projectID string, clusterName string) func() bool {
+
+// checkAtlasClusterRemoved returns true if the Atlas Cluster is removed from Atlas. Note the behavior: the cluster
+// is removed from Atlas as soon as the DELETE API call has been made. This is different from the case when the
+// cluster is terminated from UI (in this case GET request succeeds while the cluster is being terminated)
+func checkAtlasClusterRemoved(projectID string, clusterName string) func() bool {
 	return func() bool {
-		c, r, err := atlasClient.Clusters.Get(context.Background(), projectID, clusterName)
+		_, r, err := atlasClient.Clusters.Get(context.Background(), projectID, clusterName)
 		if err != nil {
-			// cluster already deleted - that's fine for us
 			if r != nil && r.StatusCode == http.StatusNotFound {
 				return true
 			}
+		}
+		return false
+	}
+}
 
+func removeAtlasProject(projectID string) func() bool {
+	return func() bool {
+		_, err := atlasClient.Projects.Delete(context.Background(), projectID)
+		if err != nil {
+			var apiError *mongodbatlas.ErrorResponse
+			Expect(errors.As(err, &apiError)).To(BeTrue())
+			Expect(apiError.ErrorCode).To(Equal(atlas.CannotCloseGroupActiveAtlasCluster))
 			return false
 		}
-
-		return c.StateName == "DELETING" || c.StateName == "DELETED"
+		return true
 	}
 }


### PR DESCRIPTION
This fixes cluster deletion: uses the `spec.Name` instead of the resource `Name`.

Also moves the testing logic for cluster deletion to `afterRun` to avoid double calls to cluster removal. Then waits until the cluster is removed and removes the project