### PR TITLE
docs: add SECURITY and CODE_OF_CONDUCT

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,5 @@
+# Code of Conduct
+
+This project has adopted the [MongoDB Code of Conduct](https://www.mongodb.com/community-code-of-conduct).
+If you see any violations of the above or have any other concerns or questions please contact us 
+using the following email alias: community-conduct@mongodb.com.

--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [2021] [MongoDB Inc.]
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,8 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Any security concerns or vulnerabilities discovered in one of MongoDB’s products or hosted services 
+can be responsibly disclosed by utilizing one of the methods described in our [create a vulnerability report](https://docs.mongodb.com/manual/tutorial/create-a-vulnerability-report/) docs page.
+
+While we greatly appreciate community reports regarding security issues, at this time MongoDB does not provide compensation for vulnerability reports.


### PR DESCRIPTION
This PR brings the repo in line with other mongodb public repos, main changes:
- add a SECURITY advisor
- add a CODE_OF_CONDUCT
- Correct the LICENSE file to keep the place holders 
