### PR TITLE
Add .gitattributes for go.sum & go.mod

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+go.mod text eol=lf
+go.sum text eol=lf merge=union


### PR DESCRIPTION
This PR restricts line endings for `go.sum` & `go.mod`, as well as allows Github to auto-merge _most_ `go.sum` conflicts