### PR TITLE
CLOUDP-82588: normalize K8s ids

### DIFF
--- a/pkg/util/kube/kube.go
+++ b/pkg/util/kube/kube.go
@@ -1,10 +1,23 @@
 package kube
 
 import (
+	"math"
+	"regexp"
+	"strings"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+// https://github.com/kubernetes/apimachinery/blob/master/pkg/util/validation/validation.go#L155
+var labelValueRegexp = regexp.MustCompile("[-a-z0-9._]")
+
+// https://github.com/kubernetes/apimachinery/blob/master/pkg/util/validation/validation.go#L177
+var identifierRegexp = regexp.MustCompile("[-a-z0-9.]")
+
+var alphanumericRegexp = regexp.MustCompile("[a-z0-9]")
 
 func ObjectKey(namespace, name string) client.ObjectKey {
 	return types.NamespacedName{Name: name, Namespace: namespace}
@@ -12,4 +25,58 @@ func ObjectKey(namespace, name string) client.ObjectKey {
 
 func ObjectKeyFromObject(obj metav1.Object) client.ObjectKey {
 	return ObjectKey(obj.GetNamespace(), obj.GetName())
+}
+
+// NormalizeIdentifier returns the 'name' "normalized" for the standard identifier in Kubernetes. All non-allowed symbols are replaced with
+// dashes.
+// See https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names
+func NormalizeIdentifier(name string) string {
+	if errs := validation.IsDNS1123Subdomain(name); len(errs) == 0 {
+		return name
+	}
+	return normalize(name, 253, identifierRegexp)
+}
+
+// NormalizeLabelValue returns the 'name' "normalized" for the label value. All non-allowed symbols are replaced with
+// dashes.
+// See https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names
+func NormalizeLabelValue(name string) string {
+	if errs := validation.IsValidLabelValue(name); len(errs) == 0 {
+		return name
+	}
+	return normalize(name, 63, labelValueRegexp)
+}
+
+// Dev note: the algorithm tries to replace the invalid characters with '-' (or simply omit it replacing is not possible)
+// Note, that this algorithm is not ideal - e.g. it won't fix the following: "a.#b" ("a._b" is still not a valid output - as
+// nonalphanumeric symbols cannot go together) though this doesn't intend to work in ALL the cases but in the MAJORITY instead
+func normalize(name string, limit int, regexp *regexp.Regexp) string {
+	name = strings.ToLower(name)
+	var sb strings.Builder
+	lastCharacterInvalid := false
+	for i, c := range name {
+		// edge cases - the first and last symbols can be only alphanumeric - we just skip those symbols
+		lastCharacterPosition := math.Min(float64(limit-1), float64(len(name)-1))
+		if i == 0 || i == int(lastCharacterPosition) {
+			if !alphanumericRegexp.MatchString(string(c)) {
+				continue
+			}
+		}
+		if i >= limit {
+			break
+		}
+		if !regexp.MatchString(string(c)) {
+			if lastCharacterInvalid {
+				// If the previous character was invalid - this means it could have been replaced with '-' and we cannot
+				// repeat such symbols
+				continue
+			}
+			sb.WriteRune('-')
+			lastCharacterInvalid = true
+		} else {
+			sb.WriteRune(c)
+			lastCharacterInvalid = false
+		}
+	}
+	return sb.String()
 }

--- a/pkg/util/kube/kube_test.go
+++ b/pkg/util/kube/kube_test.go
@@ -1,0 +1,83 @@
+package kube
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/util/validation"
+)
+
+func TestNormalizeIdentifier(t *testing.T) {
+	t.Run("Valid Identifier", func(t *testing.T) {
+		successCases := []string{
+			"a", "ab", "abc", "a1", "a-1", "a--1--2--b",
+			"a.a", "ab.a", "abc.a", "a1.a", "a-1.a", "a--1--2--b.a",
+			"a.1", "ab.1", "abc.1", "a1.1", "a-1.1", "a--1--2--b.1",
+			"0.a", "01.a", "012.a", "1a.a", "1-a.a", "1--a--b--2",
+			"a.b.c.d.e", "aa.bb.cc.dd.ee", "1.2.3.4.5", "11.22.33.44.55", strings.Repeat("a", 253),
+		}
+		for i := range successCases {
+			var normalized string
+			if normalized = NormalizeIdentifier(successCases[i]); normalized != successCases[i] {
+				t.Errorf("case[%d]: %q: the output is %q", i, successCases[i], normalized)
+			}
+			assert.Len(t, validation.IsDNS1123Subdomain(normalized), 0)
+		}
+	})
+	t.Run("Invalid Identifier", func(t *testing.T) {
+		successCases := [][]string{
+			{"a_b", "a-b"},
+			{"a__b", "a-b"},
+			{"a.b#c", "a.b-c"},
+			{"ab$", "ab"},
+			{"ab*c$d", "ab-c-d"},
+			{"a/b/c/", "a-b-c"},
+			{"*A*", "a"},
+			{"aa:bb:1", "aa-bb-1"},
+			{strings.Repeat("a", 254), strings.Repeat("a", 253)},
+		}
+		for i := range successCases {
+			var normalized string
+			if normalized = NormalizeIdentifier(successCases[i][0]); normalized != successCases[i][1] {
+				t.Errorf("case[%d]: %q: the output is %q (expected %q)", i, successCases[i][0], normalized, successCases[i][1])
+			}
+			assert.Len(t, validation.IsDNS1123Subdomain(normalized), 0, "case[%d]: %q: the output is %q", i, successCases[i][0], normalized)
+		}
+	})
+}
+func TestNormalizeLabelValue(t *testing.T) {
+	t.Run("Valid Label Value", func(t *testing.T) {
+		successCases := []string{
+			"a", "ab", "abc", "a1", "a-1", "a--1--2--b",
+			"a_b", "a.b",
+			strings.Repeat("a", 63),
+		}
+		for i := range successCases {
+			var normalized string
+			if normalized = NormalizeLabelValue(successCases[i]); normalized != successCases[i] {
+				t.Errorf("case[%d]: %q: the output is %q", i, successCases[i], normalized)
+			}
+			assert.Len(t, validation.IsValidLabelValue(normalized), 0)
+		}
+	})
+	t.Run("Invalid Label Value", func(t *testing.T) {
+		successCases := [][]string{
+			{"a.#b", "a.-b"},
+			{"ab#", "ab"},
+			{"ab*c$d", "ab-c-d"},
+			{"/a/b/c/", "a-b-c"},
+			{"A*", "a"},
+			{"aa:bb:1", "aa-bb-1"},
+			{strings.Repeat("a", 63) + "bb", strings.Repeat("a", 63)},
+			{strings.Repeat("a", 62) + "%", strings.Repeat("a", 62)},
+		}
+		for i := range successCases {
+			var normalized string
+			if normalized = NormalizeLabelValue(successCases[i][0]); normalized != successCases[i][1] {
+				t.Errorf("case[%d]: %q: the output is %q (expected %q)", i, successCases[i][0], normalized, successCases[i][1])
+			}
+			assert.Len(t, validation.IsValidLabelValue(normalized), 0)
+		}
+	})
+}


### PR DESCRIPTION
This PR prepares some groundwork for the next one that creates the Connection Secret.
As discussed with the team the name of the secrets will be:

`<project-name>-<cluster-name>-<db-user>` 

and also the secret will have the label for cluster name.

Taking the user input and using as K8s identifiers/label values is risky so some "normalization" work is done. 
