### PR TITLE
CLOUDP-82588: list secrets by cluster or username

### DIFF
--- a/pkg/controller/connectionsecret/ensuresecret.go
+++ b/pkg/controller/connectionsecret/ensuresecret.go
@@ -60,11 +60,11 @@ func fillSecret(secret *corev1.Secret, projectID string, clusterName string, dat
 
 	secret.Labels = map[string]string{ProjectLabelKey: projectID, ClusterLabelKey: kube.NormalizeLabelValue(clusterName)}
 
-	secret.StringData = map[string]string{
-		connectionSecretStdKey:    connURL,
-		connectionSecretStdSrvKey: srvConnURL,
-		userNameKey:               data.dbUserName,
-		passwordKey:               data.password,
+	secret.Data = map[string][]byte{
+		connectionSecretStdKey:    []byte(connURL),
+		connectionSecretStdSrvKey: []byte(srvConnURL),
+		userNameKey:               []byte(data.dbUserName),
+		passwordKey:               []byte(data.password),
 	}
 	return nil
 }

--- a/pkg/controller/connectionsecret/ensuresecret_test.go
+++ b/pkg/controller/connectionsecret/ensuresecret_test.go
@@ -83,19 +83,17 @@ func validateSecret(t *testing.T, fakeClient client.Client, namespace, projectNa
 	err := fakeClient.Get(context.Background(), kube.ObjectKey(namespace, secretName), &secret)
 	assert.NoError(t, err)
 
-	expectedData := map[string]string{
-		"connectionString.standard":    buildConnectionURL(data.connURL, data.dbUserName, data.password),
-		"connectionString.standardSrv": buildConnectionURL(data.srvConnURL, data.dbUserName, data.password),
-		"username":                     data.dbUserName,
-		"password":                     data.password,
+	expectedData := map[string][]byte{
+		"connectionString.standard":    []byte(buildConnectionURL(data.connURL, data.dbUserName, data.password)),
+		"connectionString.standardSrv": []byte(buildConnectionURL(data.srvConnURL, data.dbUserName, data.password)),
+		"username":                     []byte(data.dbUserName),
+		"password":                     []byte(data.password),
 	}
 	expectedLabels := map[string]string{
 		"atlas.mongodb.com/project-id":   projectID,
 		"atlas.mongodb.com/cluster-name": clusterName,
 	}
-	// Dev note: it seems that when using fake client there is no serialization/deserialization happening, so we can
-	// read from `secret.StringData` directly (not applicable for the real k8s cluster)
-	assert.Equal(t, expectedData, secret.StringData)
+	assert.Equal(t, expectedData, secret.Data)
 	assert.Equal(t, expectedLabels, secret.Labels)
 
 	return secret

--- a/pkg/controller/connectionsecret/listsecrets.go
+++ b/pkg/controller/connectionsecret/listsecrets.go
@@ -38,16 +38,12 @@ func list(k8sClient client.Client, namespace, projectID, clusterName, dbUserName
 			result = append(result, s)
 		}
 		if dbUserName != "" {
-			secretData := make(map[string]string)
-			for k, v := range s.Data {
-				secretData[k] = string(v)
-			}
-			var userName string
+			var userName []byte
 			var ok bool
-			if userName, ok = secretData[userNameKey]; !ok {
+			if userName, ok = s.Data[userNameKey]; !ok {
 				return nil, fmt.Errorf("secret %v is broken: missing the mandatory field %s", s.Name, userNameKey)
 			}
-			if userName == dbUserName {
+			if string(userName) == dbUserName {
 				result = append(result, s)
 			}
 		}

--- a/pkg/controller/connectionsecret/listsecrets.go
+++ b/pkg/controller/connectionsecret/listsecrets.go
@@ -1,0 +1,56 @@
+package connectionsecret
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/util/kube"
+)
+
+// ListByClusterName returns all secrets in the specified namespace that have labels for 'projectID' and 'clusterName'
+func ListByClusterName(k8sClient client.Client, namespace, projectID, clusterName string) ([]corev1.Secret, error) {
+	return list(k8sClient, namespace, projectID, clusterName, "")
+}
+
+// ListByUserName returns all secrets in the specified namespace that have label for 'projectID' and data for 'userName'
+func ListByUserName(k8sClient client.Client, namespace, projectID, userName string) ([]corev1.Secret, error) {
+	return list(k8sClient, namespace, projectID, "", userName)
+}
+
+func list(k8sClient client.Client, namespace, projectID, clusterName, dbUserName string) ([]corev1.Secret, error) {
+	secrets := corev1.SecretList{}
+	var result []corev1.Secret
+	if err := k8sClient.List(context.Background(), &secrets, client.InNamespace(namespace)); err != nil {
+		return nil, err
+	}
+
+	for _, s := range secrets.Items {
+		if value, ok := s.Labels[ProjectLabelKey]; !ok || value != projectID {
+			continue
+		}
+		if _, ok := s.Labels[ClusterLabelKey]; !ok {
+			continue
+		}
+		if clusterName != "" && s.Labels[ClusterLabelKey] == kube.NormalizeLabelValue(clusterName) {
+			result = append(result, s)
+		}
+		if dbUserName != "" {
+			secretData := make(map[string]string)
+			for k, v := range s.Data {
+				secretData[k] = string(v)
+			}
+			var userName string
+			var ok bool
+			if userName, ok = secretData[userNameKey]; !ok {
+				return nil, fmt.Errorf("secret %v is broken: missing the mandatory field %s", s.Name, userNameKey)
+			}
+			if userName == dbUserName {
+				result = append(result, s)
+			}
+		}
+	}
+	return result, nil
+}

--- a/pkg/controller/connectionsecret/listsecrets_test.go
+++ b/pkg/controller/connectionsecret/listsecrets_test.go
@@ -69,6 +69,21 @@ func TestListConnectionSecrets(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, []string{"p1-c1-user2"}, getSecretsNames(secrets))
 	})
+	t.Run("Special symbols in names", func(t *testing.T) {
+		// Fake client
+		scheme := runtime.NewScheme()
+		utilruntime.Must(corev1.AddToScheme(scheme))
+		utilruntime.Must(mdbv1.AddToScheme(scheme))
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+		data := dataForSecret()
+		data.dbUserName = "user1"
+		assert.NoError(t, Ensure(fakeClient, "testNs", "#nice project!", "603e7bf38a94956835659ae5", "the cluster@thecompany.com/", data))
+
+		secrets, err := ListByClusterName(fakeClient, "testNs", "603e7bf38a94956835659ae5", "the cluster@thecompany.com/")
+		assert.NoError(t, err)
+		assert.Equal(t, []string{"nice-project-the-cluster-thecompany.com-user1"}, getSecretsNames(secrets))
+	})
 }
 
 func getSecretsNames(secrets []corev1.Secret) []string {

--- a/pkg/controller/connectionsecret/listsecrets_test.go
+++ b/pkg/controller/connectionsecret/listsecrets_test.go
@@ -1,0 +1,80 @@
+package connectionsecret
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	mdbv1 "github.com/mongodb/mongodb-atlas-kubernetes/pkg/api/v1"
+)
+
+func TestListConnectionSecrets(t *testing.T) {
+	t.Run("General Check", func(t *testing.T) {
+		// Fake client
+		scheme := runtime.NewScheme()
+		utilruntime.Must(corev1.AddToScheme(scheme))
+		utilruntime.Must(mdbv1.AddToScheme(scheme))
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+		// c1, user1
+		data := dataForSecret()
+		data.dbUserName = "user1"
+		assert.NoError(t, Ensure(fakeClient, "testNs", "p1", "603e7bf38a94956835659ae5", "c1", data))
+
+		// c1, user2
+		data = dataForSecret()
+		data.dbUserName = "user2"
+		assert.NoError(t, Ensure(fakeClient, "testNs", "p1", "603e7bf38a94956835659ae5", "c1", data))
+
+		// c2, user1
+		data = dataForSecret()
+		data.dbUserName = "user1"
+		assert.NoError(t, Ensure(fakeClient, "testNs", "p1", "603e7bf38a94956835659ae5", "c2", data))
+
+		// c1, user1 but different project (p2)
+		data = dataForSecret()
+		data.dbUserName = "user1"
+		assert.NoError(t, Ensure(fakeClient, "testNs", "p2", "some-other-project-id", "c1", data))
+
+		// c1, user1 but different namespace
+		data = dataForSecret()
+		data.dbUserName = "user1"
+		assert.NoError(t, Ensure(fakeClient, "otherNs", "p1", "603e7bf38a94956835659ae5", "c1", data))
+
+		secrets, err := ListByClusterName(fakeClient, "testNs", "603e7bf38a94956835659ae5", "c1")
+		assert.NoError(t, err)
+		assert.Equal(t, []string{"p1-c1-user1", "p1-c1-user2"}, getSecretsNames(secrets))
+
+		secrets, err = ListByClusterName(fakeClient, "testNs", "603e7bf38a94956835659ae5", "c2")
+		assert.NoError(t, err)
+		assert.Equal(t, []string{"p1-c2-user1"}, getSecretsNames(secrets))
+
+		secrets, err = ListByClusterName(fakeClient, "testNs", "603e7bf38a94956835659ae5", "c3")
+		assert.NoError(t, err)
+		assert.Len(t, getSecretsNames(secrets), 0)
+
+		secrets, err = ListByClusterName(fakeClient, "testNs", "non-existent-project-id", "c1")
+		assert.NoError(t, err)
+		assert.Len(t, getSecretsNames(secrets), 0)
+
+		secrets, err = ListByUserName(fakeClient, "testNs", "603e7bf38a94956835659ae5", "user1")
+		assert.NoError(t, err)
+		assert.Equal(t, []string{"p1-c1-user1", "p1-c2-user1"}, getSecretsNames(secrets))
+
+		secrets, err = ListByUserName(fakeClient, "testNs", "603e7bf38a94956835659ae5", "user2")
+		assert.NoError(t, err)
+		assert.Equal(t, []string{"p1-c1-user2"}, getSecretsNames(secrets))
+	})
+}
+
+func getSecretsNames(secrets []corev1.Secret) []string {
+	res := make([]string, 0)
+	for _, secret := range secrets {
+		res = append(res, secret.Name)
+	}
+	return res
+}


### PR DESCRIPTION
This PR depends on https://github.com/mongodb/mongodb-atlas-kubernetes/pull/145

This PR adds support for getting the connection secrets either by cluster name or by user name.

This will be necessary while cleaning the secrets on changes (mostly removals) of cluster/dbUser resources