### PR TITLE
CLOUDP-82591: support removing the database users

### DIFF
--- a/config/crd/bases/atlas.mongodb.com_atlasdatabaseusers.yaml
+++ b/config/crd/bases/atlas.mongodb.com_atlasdatabaseusers.yaml
@@ -185,6 +185,10 @@ spec:
                   - type
                   type: object
                 type: array
+              connectionSecrets:
+                additionalProperties:
+                  type: string
+                type: object
               observedGeneration:
                 description: ObservedGeneration indicates the generation of the resource
                   specification that the Atlas Operator is aware of. The Atlas Operator

--- a/pkg/controller/atlascluster/atlascluster_controller.go
+++ b/pkg/controller/atlascluster/atlascluster_controller.go
@@ -165,7 +165,7 @@ func (r *AtlasClusterReconciler) Delete(e event.DeleteEvent) error {
 		return fmt.Errorf("cannot delete Atlas cluster: %w", err)
 	}
 
-	log.Infow("Started Atlas cluster deletion process", "projectID", project.Status.ID, "clusterName", cluster.Name)
+	log.Infow("Started Atlas cluster deletion process", "projectID", project.Status.ID, "clusterName", cluster.Spec.Name)
 
 	return nil
 }

--- a/test/int/dbuser_test.go
+++ b/test/int/dbuser_test.go
@@ -155,8 +155,8 @@ var _ = Describe("AtlasDatabaseUser", func() {
 					checkNumberOfConnectionSecrets(k8sClient, *createdProject, 2)
 
 					expectedSecretsInStatus := map[string]string{
-						"test-cluster-aws": "dev-test-atlas-project-test-cluster-aws-test-db-user",
-						"test-cluster-gcp": "dev-test-atlas-project-test-cluster-gcp-test-db-user",
+						"test-cluster-aws": connSecretname("-test-cluster-aws-test-db-user"),
+						"test-cluster-gcp": connSecretname("-test-cluster-gcp-test-db-user"),
 					}
 					Expect(createdDBUser.Status.ConnectionSecrets).To(Equal(expectedSecretsInStatus))
 				})


### PR DESCRIPTION
Adds support for database user removal. Ensures connection secrets are removed as well.

In addition checks for the database user statuses to contain connection secrets information - this was missed in the previous PR