### PR TITLE
CLOUDP-84352: generate OLM bundle during release process

### DIFF
--- a/.github/actions/gen-install-scripts/Dockerfile
+++ b/.github/actions/gen-install-scripts/Dockerfile
@@ -5,14 +5,20 @@ ENV KUBECTL_VERSION 1.18.12
 # Install
 RUN curl -L https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl -o /usr/bin/kubectl && \
     chmod +x /usr/bin/kubectl
+
 RUN cd /usr/local/bin &&\
     curl -L https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh | bash
+
 RUN CONTROLLER_GEN_TMP_DIR=$(mktemp -d) && \
     cd $CONTROLLER_GEN_TMP_DIR && \
     go mod init tmp && \
     go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.4.1 && \
     rm -rf $CONTROLLER_GEN_TMP_DIR && \
     CONTROLLER_GEN=${GOBIN}/controller-gen
+
+RUN curl -LO https://github.com/operator-framework/operator-sdk/releases/download/v1.4.2/operator-sdk_linux_amd64 && \
+    chmod +x operator-sdk_linux_amd64 && \
+    mv operator-sdk_linux_amd64 /usr/local/bin/operator-sdk
 
 # Copies your code file from your action repository to the filesystem path `/` of the container
 COPY entrypoint.sh /home/entrypoint.sh

--- a/.github/actions/gen-install-scripts/action.yml
+++ b/.github/actions/gen-install-scripts/action.yml
@@ -4,6 +4,9 @@ inputs:
   IMAGE_URL:
     description: "Operator image"
     required: true
+  VERSION:
+    description: "Version of the Operator"
+    required: true
   ENV:
     description: "Kustomize patch name (enviroment configuration patch)"
     required: true

--- a/.github/actions/gen-install-scripts/entrypoint.sh
+++ b/.github/actions/gen-install-scripts/entrypoint.sh
@@ -39,5 +39,5 @@ cp config/crd/bases/* "${crds_dir}"
 
 # CSV bundle
 operator-sdk generate kustomize manifests -q --apis-dir=pkg/api
-kustomize build --load-restrictor LoadRestrictionsNone config/manifests | operator-sdk generate bundle -q --overwrite --version "${VERSION}"
+kustomize build --load-restrictor LoadRestrictionsNone config/manifests | operator-sdk generate bundle -q --overwrite --version "${INPUT_VERSION}"
 operator-sdk bundle validate ./bundle

--- a/.github/actions/gen-install-scripts/entrypoint.sh
+++ b/.github/actions/gen-install-scripts/entrypoint.sh
@@ -19,6 +19,7 @@ cd -
 
 which kustomize
 kustomize version
+
 # all-in-one
 kustomize build --load-restrictor LoadRestrictionsNone "config/release/${INPUT_ENV}/allinone" > "${target_dir}/all-in-one.yaml"
 echo "Created all-in-one config"
@@ -36,4 +37,7 @@ echo "Created namespaced config"
 # crds
 cp config/crd/bases/* "${crds_dir}"
 
-
+# CSV bundle
+operator-sdk generate kustomize manifests -q --apis-dir=pkg/api
+kustomize build --load-restrictor LoadRestrictionsNone config/manifests | operator-sdk generate bundle -q --overwrite --version "${VERSION}"
+operator-sdk bundle validate ./bundle

--- a/.github/actions/gen-install-scripts/entrypoint.sh
+++ b/.github/actions/gen-install-scripts/entrypoint.sh
@@ -39,5 +39,11 @@ cp config/crd/bases/* "${crds_dir}"
 
 # CSV bundle
 operator-sdk generate kustomize manifests -q --apis-dir=pkg/api
-kustomize build --load-restrictor LoadRestrictionsNone config/manifests | operator-sdk generate bundle -q --overwrite --version "${INPUT_VERSION}"
+
+# We pass the version only for non-dev deployments (it's ok to have "0.0.0" for dev)
+if [[ "${INPUT_ENV}" == "dev" ]]; then
+  kustomize build --load-restrictor LoadRestrictionsNone config/manifests | operator-sdk generate bundle -q --overwrite
+else
+  kustomize build --load-restrictor LoadRestrictionsNone config/manifests | operator-sdk generate bundle -q --overwrite --version "${INPUT_VERSION}"
+fi
 operator-sdk bundle validate ./bundle

--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -52,6 +52,13 @@ jobs:
         PATH_TO_COMMIT: "bundle"
         DESTINATION_BRANCH: "release/${{ env.VERSION }}"
 
+    - name: Commit and push bundle dockerfile
+      uses: ./.github/actions/push-files
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        PATH_TO_COMMIT: "bundle.Dockerfile"
+        DESTINATION_BRANCH: "release/${{ env.VERSION }}"
+
     - name: Create PR
       uses: ./.github/actions/create-pr
       env:

--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -49,7 +49,7 @@ jobs:
       uses: ./.github/actions/push-files
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        FILE_TO_COMMIT: "bundle"
+        PATH_TO_COMMIT: "bundle"
         DESTINATION_BRANCH: "release/${{ env.VERSION }}"
 
     - name: Create PR

--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -30,6 +30,7 @@ jobs:
       uses: ./.github/actions/gen-install-scripts
       with:
         IMAGE_URL: ${{ env.DOCKER_RELEASE_REPO }}:${{ env.VERSION }}
+        VERSION: ${{ env.VERSION }}
         ENV: prod
 
     - name: Create branch and push it
@@ -42,6 +43,13 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         PATH_TO_COMMIT: "deploy"
+        DESTINATION_BRANCH: "release/${{ env.VERSION }}"
+
+    - name: Commit and push bundle directory
+      uses: ./.github/actions/push-files
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        FILE_TO_COMMIT: "bundle"
         DESTINATION_BRANCH: "release/${{ env.VERSION }}"
 
     - name: Create PR

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,6 +97,7 @@ jobs:
       uses: ./.github/actions/gen-install-scripts
       with:
         IMAGE_URL: ${{ env.DOCKER_REPO }}:${{ steps.prepare.outputs.tag }}
+        VERSION: ${{ steps.prepare.outputs.tag }}
         ENV: dev
 
     - name: Set properties


### PR DESCRIPTION
Adds support for bundle generation during the release

I generated the [release branch](https://github.com/mongodb/mongodb-atlas-kubernetes/pull/159) and tried to install it into the OLM. Everything was ok, though the deployment didn't succeed (which makes sense as we haven't released the new image yet)
I edited the deployment and change the image to `mongodb/mongodb-atlas-kubernetes-operator-prerelease:CLOUDP-84352-olm-bundle-release-5a84c7e` - after this it succeeded.

```
➜  mongodb-atlas-kubernetes git:(release/0.21.0) make bundle-build BUNDLE_IMG=antonlisovenko/test-bundle:v0.21.0
docker build -f bundle.Dockerfile -t antonlisovenko/test-bundle:v0.21.0 .
Sending build context to Docker daemon  379.5MB
Step 1/14 : FROM scratch
 --->
Step 2/14 : LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 ---> Using cache
 ---> 5bb15576e1aa
Step 3/14 : LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 ---> Using cache
 ---> f7bfa3d4de1f
Step 4/14 : LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 ---> Using cache
 ---> 5a5c6a07766a
Step 5/14 : LABEL operators.operatorframework.io.bundle.package.v1=mongodb-atlas-kubernetes
 ---> Using cache
 ---> b3a6dd30e587
Step 6/14 : LABEL operators.operatorframework.io.bundle.channels.v1=alpha
 ---> Using cache
 ---> 85cbe6e050cb
Step 7/14 : LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.4.2
 ---> Using cache
 ---> 605f9617fa7e
Step 8/14 : LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 ---> Using cache
 ---> 136c7742d732
Step 9/14 : LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
 ---> Using cache
 ---> 24a3be949a42
Step 10/14 : LABEL operators.operatorframework.io.test.config.v1=tests/scorecard/
 ---> Using cache
 ---> 2027c774a5a1
Step 11/14 : LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1
 ---> Using cache
 ---> f956b4df2d52
Step 12/14 : COPY bundle/manifests /manifests/
 ---> 3e8d86e1e3f1
Step 13/14 : COPY bundle/metadata /metadata/
 ---> 3e3975beadc2
Step 14/14 : COPY bundle/tests/scorecard /tests/scorecard/
 ---> a8db17e082fa
Successfully built a8db17e082fa
Successfully tagged antonlisovenko/test-bundle:v0.21.0

➜  mongodb-atlas-kubernetes git:(release/0.21.0) make docker-push IMG=antonlisovenko/test-bundle:v0.21.0
docker push antonlisovenko/test-bundle:v0.21.0
The push refers to repository [docker.io/antonlisovenko/test-bundle]
0613c024591e: Pushed
26cfdd49c98a: Pushed
a219fe8c2cc6: Pushed
v0.21.0: digest: sha256:b17684226ec07e45a775326ef7492f05a41b1ba6a9ae2525d8d5c23bcd06e9ed size: 939

➜  mongodb-atlas-kubernetes git:(release/0.21.0) operator-sdk run bundle docker.io/antonlisovenko/test-bundle:v0.21.0
INFO[0007] Successfully created registry pod: docker-io-antonlisovenko-test-bundle-v0-21-0
INFO[0007] Created CatalogSource: mongodb-atlas-kubernetes-catalog
INFO[0008] OperatorGroup "operator-sdk-og" created
INFO[0008] Created Subscription: mongodb-atlas-kubernetes-v0-21-0-sub
INFO[0013] Approved InstallPlan install-nbv62 for the Subscription: mongodb-atlas-kubernetes-v0-21-0-sub
INFO[0013] Waiting for ClusterServiceVersion "default/mongodb-atlas-kubernetes.v0.21.0" to reach 'Succeeded' phase
INFO[0013]   Waiting for ClusterServiceVersion "default/mongodb-atlas-kubernetes.v0.21.0" to appear
INFO[0024]   Found ClusterServiceVersion "default/mongodb-atlas-kubernetes.v0.21.0" phase: Pending
INFO[0025]   Found ClusterServiceVersion "default/mongodb-atlas-kubernetes.v0.21.0" phase: InstallReady
INFO[0026]   Found ClusterServiceVersion "default/mongodb-atlas-kubernetes.v0.21.0" phase: Installing
FATA[0120] Failed to run bundle: error waiting for CSV to install: timed out waiting for the condition
```