### PR TITLE
CLOUDP-84457: fix for global secret

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -55,7 +55,7 @@ spec:
             cpu: 100m
             memory: 20Mi
         env:
-          - name: OPERATOR_NAME
+          - name: OPERATOR_POD_NAME
             valueFrom:
               fieldRef:
                 fieldPath: metadata.name

--- a/pkg/controller/atlas/connection.go
+++ b/pkg/controller/atlas/connection.go
@@ -26,15 +26,16 @@ type Connection struct {
 
 // ReadConnection reads Atlas API connection parameters from AtlasProject Secret or from the default Operator one if the
 // former is not specified
-func ReadConnection(log *zap.SugaredLogger, kubeClient client.Client, operatorPodObjectKey client.ObjectKey, projectOverrideSecretRef *client.ObjectKey) (Connection, error) {
+func ReadConnection(log *zap.SugaredLogger, kubeClient client.Client, operatorDeployment client.ObjectKey, projectOverrideSecretRef *client.ObjectKey) (Connection, error) {
 	if projectOverrideSecretRef != nil {
 		// TODO is it possible that part of connection (like orgID is still in the Operator level secret and needs to get merged?)
 		log.Infof("Reading Atlas API credentials from the AtlasProject Secret %s", projectOverrideSecretRef)
 		return readAtlasConnectionFromSecret(kubeClient, *projectOverrideSecretRef)
 	}
 
-	log.Debug("AtlasProject connection Secret is not specified - using the Operator one")
-	return readAtlasConnectionFromSecret(kubeClient, kube.ObjectKey(operatorPodObjectKey.Namespace, operatorPodObjectKey.Name+"-api-key"))
+	operatorAPISecret := kube.ObjectKey(operatorDeployment.Namespace, operatorDeployment.Name+"-api-key")
+	log.Debugf("AtlasProject connection Secret is not specified - using the Operator one: %v", operatorAPISecret)
+	return readAtlasConnectionFromSecret(kubeClient, operatorAPISecret)
 }
 
 func readAtlasConnectionFromSecret(kubeClient client.Client, secretRef client.ObjectKey) (Connection, error) {

--- a/pkg/controller/atlascluster/atlascluster_controller.go
+++ b/pkg/controller/atlascluster/atlascluster_controller.go
@@ -41,11 +41,11 @@ import (
 
 // AtlasClusterReconciler reconciles an AtlasCluster object
 type AtlasClusterReconciler struct {
-	Client      client.Client
-	Log         *zap.SugaredLogger
-	Scheme      *runtime.Scheme
-	AtlasDomain string
-	OperatorPod client.ObjectKey
+	Client                 client.Client
+	Log                    *zap.SugaredLogger
+	Scheme                 *runtime.Scheme
+	AtlasDomain            string
+	OperatorDeploymentName client.ObjectKey
 }
 
 // +kubebuilder:rbac:groups=atlas.mongodb.com,resources=atlasclusters,verbs=get;list;watch;create;update;patch;delete
@@ -75,7 +75,7 @@ func (r *AtlasClusterReconciler) Reconcile(context context.Context, req ctrl.Req
 		return result.ReconcileResult(), nil
 	}
 
-	connection, err := atlas.ReadConnection(log, r.Client, r.OperatorPod, project.ConnectionSecretObjectKey())
+	connection, err := atlas.ReadConnection(log, r.Client, r.OperatorDeploymentName, project.ConnectionSecretObjectKey())
 	if err != nil {
 		result := workflow.Terminate(workflow.AtlasCredentialsNotProvided, err.Error())
 		ctx.SetConditionFromResult(status.ClusterReadyType, result)
@@ -150,7 +150,7 @@ func (r *AtlasClusterReconciler) Delete(e event.DeleteEvent) error {
 		return errors.New("cannot read project resource")
 	}
 
-	connection, err := atlas.ReadConnection(log, r.Client, r.OperatorPod, project.ConnectionSecretObjectKey())
+	connection, err := atlas.ReadConnection(log, r.Client, r.OperatorDeploymentName, project.ConnectionSecretObjectKey())
 	if err != nil {
 		return err
 	}

--- a/pkg/util/kube/kube.go
+++ b/pkg/util/kube/kube.go
@@ -1,6 +1,7 @@
 package kube
 
 import (
+	"fmt"
 	"regexp"
 	"strings"
 
@@ -44,6 +45,20 @@ func NormalizeLabelValue(name string) string {
 		return name
 	}
 	return normalize(name, 63, nonLabelRegexp)
+}
+
+// ParseDeploymentNameFromPodName returns the name of Deployment by Pod Name. The Pods for Deployments have two hashes
+// parts as the first one is generated for the ReplicaSet resource created and the second - for the Pod itself.
+// Example:
+// - Deployment: "prometheus-adapter"
+// - ReplicaSet: "prometheus-adapter-65c6cb864f"
+// - Pod: "prometheus-adapter-797f946f88-97f2q"
+func ParseDeploymentNameFromPodName(podName string) (string, error) {
+	parts := strings.Split(podName, "-")
+	if len(parts) <= 2 {
+		return "", fmt.Errorf(`the Pod name must follow the format "<deployment_name>-797f946f88-97f2q" but got %s`, podName)
+	}
+	return strings.Join(parts[0:len(parts)-2], "-"), nil
 }
 
 // Dev note: the algorithm tries to replace the invalid characters with '-' (or simply omit it replacing is not possible)

--- a/pkg/util/kube/kube_test.go
+++ b/pkg/util/kube/kube_test.go
@@ -81,3 +81,29 @@ func TestNormalizeLabelValue(t *testing.T) {
 		}
 	})
 }
+
+func TestParseDeploymentNameFromPodName(t *testing.T) {
+	testCases := []struct {
+		in  string
+		out string
+	}{
+		{in: "prometheus-adapter-797f946f88-97f2q", out: "prometheus-adapter"},
+		{in: "cluster-monitoring-operator-686555c948-z2xrh", out: "cluster-monitoring-operator"},
+		{in: "mongodb-atlas-operator-cd75dc789-tdhvp", out: "mongodb-atlas-operator"},
+		{in: "somenondashed-cd75dc789-tdhvp", out: "somenondashed"},
+		{in: "notadeploymentpod-cd75dc789", out: ""},
+		{in: "notadeploymentpod", out: ""},
+		{in: "notadeploymentpod_cd75dc789", out: ""},
+		{in: "notadeploymentpod.cd75dc789", out: ""},
+	}
+	for _, tc := range testCases {
+		out, err := ParseDeploymentNameFromPodName(tc.in)
+		if tc.out != "" {
+			assert.Equal(t, tc.out, out, "in: %q, out: %q, (expected %q)", tc.in, out, tc.out)
+			assert.Nil(t, err)
+		}
+		if tc.out == "" {
+			assert.Error(t, err)
+		}
+	}
+}

--- a/test/int/integration_suite_test.go
+++ b/test/int/integration_suite_test.go
@@ -189,10 +189,10 @@ func prepareControllers() {
 	Expect(err).ToNot(HaveOccurred())
 
 	err = (&atlascluster.AtlasClusterReconciler{
-		Client:      k8sManager.GetClient(),
-		Log:         logger.Named("controllers").Named("AtlasCluster").Sugar(),
-		AtlasDomain: "https://cloud-qa.mongodb.com",
-		OperatorPod: kube.ObjectKey(namespace.Name, "atlas-operator"),
+		Client:                 k8sManager.GetClient(),
+		Log:                    logger.Named("controllers").Named("AtlasCluster").Sugar(),
+		AtlasDomain:            "https://cloud-qa.mongodb.com",
+		OperatorDeploymentName: kube.ObjectKey(namespace.Name, "atlas-operator"),
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 

--- a/test/int/project_test.go
+++ b/test/int/project_test.go
@@ -328,7 +328,7 @@ var _ = Describe("AtlasProject", func() {
 		})
 	})
 
-	FDescribe("Using the global Connection Secret", func() {
+	Describe("Using the global Connection Secret", func() {
 		It("Should Succeed", func() {
 			globalConnectionSecret := buildConnectionSecret("atlas-operator-api-key")
 			Expect(k8sClient.Create(context.Background(), &globalConnectionSecret)).To(Succeed())

--- a/test/int/project_test.go
+++ b/test/int/project_test.go
@@ -328,7 +328,7 @@ var _ = Describe("AtlasProject", func() {
 		})
 	})
 
-	Describe("Using the global Connection Secret", func() {
+	FDescribe("Using the global Connection Secret", func() {
 		It("Should Succeed", func() {
 			globalConnectionSecret := buildConnectionSecret("atlas-operator-api-key")
 			Expect(k8sClient.Create(context.Background(), &globalConnectionSecret)).To(Succeed())


### PR DESCRIPTION
This fixes the issue with "global secret" when Operator used the Pod name instead of deployment. In this case it expected the secret with the name "mongodb-atlas-operator-97cd985f5-whgrx-api-key" instead of "mongodb-atlas-operator-api-key"

No tests for this so far, checked manually:
```
2021-03-11T14:25:03.416Z	DEBUG	controllers.AtlasProject	AtlasProject connection Secret is not specified - using the Operator one: mongodb-atlas-system/mongodb-atlas-operator-api-key	{"atlasproject": "mongodb-atlas-system/my-project"}
```