### PR TITLE
CLOUDP-82590: validate 'scopes' field in AtlasDatabaseUser 

### DIFF
--- a/pkg/api/v1/atlasdatabaseuser_types.go
+++ b/pkg/api/v1/atlasdatabaseuser_types.go
@@ -226,6 +226,10 @@ func (p *AtlasDatabaseUser) WithScope(scopeType ScopeType, name string) *AtlasDa
 	p.Spec.Scopes = append(p.Spec.Scopes, ScopeSpec{Name: name, Type: scopeType})
 	return p
 }
+func (p *AtlasDatabaseUser) ClearScopes() *AtlasDatabaseUser {
+	p.Spec.Scopes = make([]ScopeSpec, 0)
+	return p
+}
 
 func DefaultDBUser(namespace, username, projectName string) *AtlasDatabaseUser {
 	return NewDBUser(namespace, username, username, projectName).WithRole("clusterMonitor", "admin", "")

--- a/pkg/controller/workflow/reason.go
+++ b/pkg/controller/workflow/reason.go
@@ -31,4 +31,5 @@ const (
 	DatabaseUserNotUpdatedInAtlas           ConditionReason = "DatabaseUserNotUpdatedInAtlas"
 	DatabaseUserConnectionSecretsNotCreated ConditionReason = "DatabaseUserConnectionSecretsNotCreated"
 	DatabaseUserClustersAppliedChanges      ConditionReason = "ClustersAppliedDatabaseUsersChanges"
+	DatabaseUserInvalidSpec                 ConditionReason = "DatabaseUserInvalidSpec"
 )


### PR DESCRIPTION
The PR adds validation code for `scopes` field in AtlasDatabaseUser spec. The reconciliation fails if the cluster with this name doesn't exist in Atlas.

Some customer-facing logic: it's ok if the AtlasCluster and AtlasDatabaseUser are created in parallel (say both configs are in the same script) - in this case AtlasDatabaseUser validation may fail the first time as the Cluster may not exist yet - the retry will fix the problem which should be ok.