### PR TITLE
CLOUDP-82709: watch password secrets

### DIFF
--- a/config/crd/bases/atlas.mongodb.com_atlasdatabaseusers.yaml
+++ b/config/crd/bases/atlas.mongodb.com_atlasdatabaseusers.yaml
@@ -188,6 +188,9 @@ spec:
               connectionSecrets:
                 additionalProperties:
                   type: string
+                description: ConnectionSecrets defines all the Secrets for the current
+                  database user that were created by the Atlas Operator and which
+                  provide the Atlas clusters connectivity information
                 type: object
               observedGeneration:
                 description: ObservedGeneration indicates the generation of the resource
@@ -197,6 +200,8 @@ spec:
                 format: int64
                 type: integer
               passwordVersion:
+                description: PasswordVersion is the 'ResourceVersion' of the password
+                  Secret that the Atlas Operator is aware of
                 type: string
             required:
             - conditions

--- a/config/crd/bases/atlas.mongodb.com_atlasdatabaseusers.yaml
+++ b/config/crd/bases/atlas.mongodb.com_atlasdatabaseusers.yaml
@@ -196,6 +196,8 @@ spec:
                   reconciliation of the resource.
                 format: int64
                 type: integer
+              passwordVersion:
+                type: string
             required:
             - conditions
             type: object

--- a/main.go
+++ b/main.go
@@ -103,11 +103,12 @@ func main() {
 	}
 
 	if err = (&atlasdatabaseuser.AtlasDatabaseUserReconciler{
-		Client:      mgr.GetClient(),
-		Log:         logger.Named("controllers").Named("AtlasDatabaseUser").Sugar(),
-		Scheme:      mgr.GetScheme(),
-		AtlasDomain: config.AtlasDomain,
-		OperatorPod: operatorPod,
+		Client:          mgr.GetClient(),
+		Log:             logger.Named("controllers").Named("AtlasDatabaseUser").Sugar(),
+		Scheme:          mgr.GetScheme(),
+		AtlasDomain:     config.AtlasDomain,
+		ResourceWatcher: watch.NewResourceWatcher(),
+		OperatorPod:     operatorPod,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "AtlasDatabaseUser")
 		os.Exit(1)

--- a/pkg/api/v1/atlasdatabaseuser_types.go
+++ b/pkg/api/v1/atlasdatabaseuser_types.go
@@ -132,6 +132,14 @@ func (p AtlasDatabaseUser) AtlasProjectObjectKey() client.ObjectKey {
 	return kube.ObjectKey(p.Namespace, p.Spec.Project.Name)
 }
 
+func (p AtlasDatabaseUser) PasswordSecretObjectKey() *client.ObjectKey {
+	if p.Spec.PasswordSecret != nil {
+		key := kube.ObjectKey(p.Namespace, p.Spec.PasswordSecret.Name)
+		return &key
+	}
+	return nil
+}
+
 func (p *AtlasDatabaseUser) GetStatus() status.Status {
 	return p.Status
 }
@@ -153,9 +161,13 @@ func (p *AtlasDatabaseUser) ReadPassword(kubeClient client.Client) (string, erro
 		if err := kubeClient.Get(context.Background(), kube.ObjectKey(p.Namespace, p.Spec.PasswordSecret.Name), secret); err != nil {
 			return "", err
 		}
-		if p, exist := secret.Data["password"]; !exist {
+		p, exist := secret.Data["password"]
+		switch {
+		case !exist:
 			return "", fmt.Errorf("secret %s is invalid: it doesn't contain 'password' field", secret.Name)
-		} else {
+		case len(p) == 0:
+			return "", fmt.Errorf("secret %s is invalid: the 'password' field is empty", secret.Name)
+		default:
 			return string(p), nil
 		}
 	}

--- a/pkg/api/v1/atlasdatabaseuser_types.go
+++ b/pkg/api/v1/atlasdatabaseuser_types.go
@@ -158,7 +158,7 @@ func (p *AtlasDatabaseUser) UpdateStatus(conditions []status.Condition, options 
 func (p *AtlasDatabaseUser) ReadPassword(kubeClient client.Client) (string, error) {
 	if p.Spec.PasswordSecret != nil {
 		secret := &corev1.Secret{}
-		if err := kubeClient.Get(context.Background(), kube.ObjectKey(p.Namespace, p.Spec.PasswordSecret.Name), secret); err != nil {
+		if err := kubeClient.Get(context.Background(), *p.PasswordSecretObjectKey(), secret); err != nil {
 			return "", err
 		}
 		p, exist := secret.Data["password"]

--- a/pkg/api/v1/status/atlasdatabaseuser.go
+++ b/pkg/api/v1/status/atlasdatabaseuser.go
@@ -11,8 +11,15 @@ func AtlasDatabaseUserSecretsOption(clusters2Secrets map[string]string) AtlasDat
 	}
 }
 
+func AtlasDatabaseUserPasswordVersion(passwordVersion string) AtlasDatabaseUserStatusOption {
+	return func(s *AtlasDatabaseUserStatus) {
+		s.PasswordVersion = passwordVersion
+	}
+}
+
 // AtlasDatabaseUserStatus defines the observed state of AtlasProject
 type AtlasDatabaseUserStatus struct {
 	Common            `json:",inline"`
 	ConnectionSecrets map[string]string `json:"connectionSecrets,omitempty"`
+	PasswordVersion   string            `json:"passwordVersion,omitempty"`
 }

--- a/pkg/api/v1/status/atlasdatabaseuser.go
+++ b/pkg/api/v1/status/atlasdatabaseuser.go
@@ -19,7 +19,10 @@ func AtlasDatabaseUserPasswordVersion(passwordVersion string) AtlasDatabaseUserS
 
 // AtlasDatabaseUserStatus defines the observed state of AtlasProject
 type AtlasDatabaseUserStatus struct {
-	Common            `json:",inline"`
+	Common `json:",inline"`
+	// ConnectionSecrets defines all the Secrets for the current database user that were created by the Atlas Operator
+	// and which provide the Atlas clusters connectivity information
 	ConnectionSecrets map[string]string `json:"connectionSecrets,omitempty"`
-	PasswordVersion   string            `json:"passwordVersion,omitempty"`
+	// PasswordVersion is the 'ResourceVersion' of the password Secret that the Atlas Operator is aware of
+	PasswordVersion string `json:"passwordVersion,omitempty"`
 }

--- a/pkg/controller/atlasproject/atlasproject_controller.go
+++ b/pkg/controller/atlasproject/atlasproject_controller.go
@@ -72,8 +72,9 @@ func (r *AtlasProjectReconciler) Reconcile(context context.Context, req ctrl.Req
 		return result.ReconcileResult(), nil
 	}
 	if project.ConnectionSecretObjectKey() != nil {
+		// Note, that we are not watching the global connection secret - seems there is no point in reconciling all
+		// the projects once that secret is changed
 		r.EnsureResourcesAreWatched(req.NamespacedName, "Secret", log, *project.ConnectionSecretObjectKey())
-		// TODO CLOUDP-80516: the "global" connection secret also needs to be watched
 	}
 	ctx := customresource.MarkReconciliationStarted(r.Client, project, log)
 

--- a/test/int/dbuser_test.go
+++ b/test/int/dbuser_test.go
@@ -247,6 +247,10 @@ var _ = Describe("AtlasDatabaseUser", func() {
 
 				Expect(k8sClient.Update(context.Background(), secondDBUser)).ToNot(HaveOccurred())
 
+				// First we need to wait for "such cluster doesn't exist in Atlas" error to be gone
+				Eventually(testutil.WaitFor(k8sClient, secondDBUser, status.FalseCondition(status.DatabaseUserReadyType).WithReason(string(workflow.DatabaseUserClustersAppliedChanges))),
+					20, interval).Should(BeTrue())
+
 				Eventually(testutil.WaitFor(k8sClient, secondDBUser, status.TrueCondition(status.ReadyType), validateDatabaseUserUpdatingFunc()),
 					80, interval).Should(BeTrue())
 
@@ -344,7 +348,7 @@ var _ = Describe("AtlasDatabaseUser", func() {
 				Expect(k8sClient.Create(context.Background(), createdClusterGCP)).ToNot(HaveOccurred())
 
 				Eventually(testutil.WaitFor(k8sClient, createdClusterGCP, status.TrueCondition(status.ReadyType), validateClusterCreatingFunc()),
-					500, interval).Should(BeTrue())
+					1800, interval).Should(BeTrue())
 			})
 			createdDBUser = mdbv1.DefaultDBUser(namespace.Name, "test-db-user", createdProject.Name).WithPasswordSecret(UserPasswordSecret)
 			var connSecretInitial corev1.Secret

--- a/test/int/integration_suite_test.go
+++ b/test/int/integration_suite_test.go
@@ -197,10 +197,11 @@ func prepareControllers() {
 	Expect(err).ToNot(HaveOccurred())
 
 	err = (&atlasdatabaseuser.AtlasDatabaseUserReconciler{
-		Client:      k8sManager.GetClient(),
-		Log:         logger.Named("controllers").Named("AtlasDatabaseUser").Sugar(),
-		AtlasDomain: "https://cloud-qa.mongodb.com",
-		OperatorPod: kube.ObjectKey(namespace.Name, "atlas-operator"),
+		Client:          k8sManager.GetClient(),
+		Log:             logger.Named("controllers").Named("AtlasDatabaseUser").Sugar(),
+		AtlasDomain:     "https://cloud-qa.mongodb.com",
+		ResourceWatcher: watch.NewResourceWatcher(),
+		OperatorPod:     kube.ObjectKey(namespace.Name, "atlas-operator"),
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
Depends on https://github.com/mongodb/mongodb-atlas-kubernetes/pull/172

This PR adds the code to watch the database user passwords Secrets. As soon as those secrets are changed by the user - the db user reconciliation is triggered and the update request is sent to Atlas.

Note, that to support this we have to keep the state of the password secret in the database user status. This is necessary as the controller needs to know when the passwords have changed as current "compare db users specs" code won't give this information (Atlas doesn't return passwords for db users in GET requests). 