### PR TITLE
CLOUDP-82593: lower sync period

### DIFF
--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ import (
 	"flag"
 	"log"
 	"os"
+	"time"
 
 	"github.com/go-logr/zapr"
 	"go.uber.org/zap"
@@ -63,6 +64,7 @@ func main() {
 	config := parseConfiguration(logger.Sugar())
 	ctrl.SetLogger(zapr.NewLogger(logger))
 
+	syncPeriod := time.Hour * 3
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 scheme,
 		MetricsBindAddress:     config.MetricsAddr,
@@ -71,6 +73,7 @@ func main() {
 		LeaderElection:         config.EnableLeaderElection,
 		LeaderElectionID:       "06d035fb.mongodb.com",
 		Namespace:              config.WatchedNamespaces,
+		SyncPeriod:             &syncPeriod,
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")

--- a/test/int/integration_suite_test.go
+++ b/test/int/integration_suite_test.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/go-logr/zapr"
 	. "github.com/onsi/ginkgo"
@@ -172,10 +173,14 @@ func prepareControllers() {
 
 	ctrl.SetLogger(zapr.NewLogger(logger))
 
+	// Note on the syncPeriod - decreasing this to a smaller time allows to test its work for the long-running tests
+	// (clusters, database users). The prod value is much higher
+	syncPeriod := time.Minute * 30
 	k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme:             scheme.Scheme,
 		Namespace:          namespace.Name,
 		MetricsBindAddress: "0",
+		SyncPeriod:         &syncPeriod,
 	})
 	Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
As discussed before we need to decrease the sync period to support marking resources (IP Access Lists, database users) as expired sooner than later.