### PR TITLE
CLOUDP-84606: helm support

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -49,11 +49,11 @@ spec:
         imagePullPolicy: Always
         resources:
           limits:
-            cpu: 100m
-            memory: 100Mi
+            cpu: 500m
+            memory: 256Mi
           requests:
             cpu: 100m
-            memory: 20Mi
+            memory: 50Mi
         env:
           - name: OPERATOR_POD_NAME
             valueFrom:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -25,6 +25,7 @@ spec:
       securityContext:
         runAsNonRoot: true
         runAsUser: 2000
+      serviceAccountName: operator
       containers:
       - command:
         - /manager

--- a/config/managerwithproxy/manager_auth_proxy_patch.yaml
+++ b/config/managerwithproxy/manager_auth_proxy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/config/rbac/clusterwide/auth_proxy_role_binding.yaml
+++ b/config/rbac/clusterwide/auth_proxy_role_binding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: proxy-role
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: mongodb-atlas-operator
   namespace: system

--- a/config/rbac/clusterwide/auth_proxy_role_binding.yaml
+++ b/config/rbac/clusterwide/auth_proxy_role_binding.yaml
@@ -8,5 +8,4 @@ roleRef:
   name: proxy-role
 subjects:
 - kind: ServiceAccount
-  name: mongodb-atlas-operator
-  namespace: system
+  name: operator

--- a/config/rbac/clusterwide/kustomization.yaml
+++ b/config/rbac/clusterwide/kustomization.yaml
@@ -1,6 +1,7 @@
 resources:
 - role.yaml
 - role_binding.yaml
+- ../service_account.yaml
 - ../leader_election_role.yaml
 - ../leader_election_role_binding.yaml
 # Comment the following 4 lines if you want to disable
@@ -8,5 +9,5 @@ resources:
 # which protects your /metrics endpoint.
 - auth_proxy_role.yaml
 - auth_proxy_role_binding.yaml
-- ../auth_proxy_client_clusterrole.yaml
+#- ../auth_proxy_client_clusterrole.yaml
 - ../auth_proxy_service.yaml

--- a/config/rbac/clusterwide/role_binding.yaml
+++ b/config/rbac/clusterwide/role_binding.yaml
@@ -8,5 +8,4 @@ roleRef:
   name: manager-role
 subjects:
   - kind: ServiceAccount
-    name: mongodb-atlas-operator
-    namespace: system
+    name: operator

--- a/config/rbac/clusterwide/role_binding.yaml
+++ b/config/rbac/clusterwide/role_binding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: manager-role
 subjects:
   - kind: ServiceAccount
-    name: default
+    name: mongodb-atlas-operator
     namespace: system

--- a/config/rbac/leader_election_role_binding.yaml
+++ b/config/rbac/leader_election_role_binding.yaml
@@ -8,5 +8,4 @@ roleRef:
   name: leader-election-role
 subjects:
 - kind: ServiceAccount
-  name: mongodb-atlas-operator
-  namespace: system
+  name: operator

--- a/config/rbac/leader_election_role_binding.yaml
+++ b/config/rbac/leader_election_role_binding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: leader-election-role
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: mongodb-atlas-operator
   namespace: system

--- a/config/rbac/namespaced/auth_proxy_role_binding.yaml
+++ b/config/rbac/namespaced/auth_proxy_role_binding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: proxy-role
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: mongodb-atlas-operator
   namespace: system

--- a/config/rbac/namespaced/auth_proxy_role_binding.yaml
+++ b/config/rbac/namespaced/auth_proxy_role_binding.yaml
@@ -8,5 +8,4 @@ roleRef:
   name: proxy-role
 subjects:
 - kind: ServiceAccount
-  name: mongodb-atlas-operator
-  namespace: system
+  name: operator

--- a/config/rbac/namespaced/kustomization.yaml
+++ b/config/rbac/namespaced/kustomization.yaml
@@ -1,6 +1,7 @@
 resources:
 - role.yaml
 - role_binding.yaml
+- ../service_account.yaml
 - ../leader_election_role.yaml
 - ../leader_election_role_binding.yaml
 # Comment the following 4 lines if you want to disable
@@ -8,5 +9,5 @@ resources:
 # which protects your /metrics endpoint.
 - auth_proxy_role.yaml
 - auth_proxy_role_binding.yaml
-- ../auth_proxy_client_clusterrole.yaml
+#- ../auth_proxy_client_clusterrole.yaml
 - ../auth_proxy_service.yaml

--- a/config/rbac/namespaced/role_binding.yaml
+++ b/config/rbac/namespaced/role_binding.yaml
@@ -8,5 +8,4 @@ roleRef:
   name: manager-role
 subjects:
 - kind: ServiceAccount
-  name: mongodb-atlas-operator
-  namespace: system
+  name: operator

--- a/config/rbac/namespaced/role_binding.yaml
+++ b/config/rbac/namespaced/role_binding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: manager-role
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: mongodb-atlas-operator
   namespace: system

--- a/config/rbac/service_account.yaml
+++ b/config/rbac/service_account.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: mongodb-atlas-operator
+  name: operator

--- a/config/rbac/service_account.yaml
+++ b/config/rbac/service_account.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: mongodb-atlas-operator

--- a/config/release/base/namespaced/manager_watched_namespace_patch.json
+++ b/config/release/base/namespaced/manager_watched_namespace_patch.json
@@ -2,7 +2,7 @@
   {"op": "add",
     "path": "/spec/template/spec/containers/1/env/0",
     "value": {
-      "name": "WATCHED_NAMESPACE",
+      "name": "WATCH_NAMESPACE",
       "valueFrom": {
         "fieldRef": {
           "fieldPath": "metadata.namespace"

--- a/deploy/namespaced/namespaced-config.yaml
+++ b/deploy/namespaced/namespaced-config.yaml
@@ -264,11 +264,11 @@ spec:
           periodSeconds: 10
         resources:
           limits:
-            cpu: 500m
-            memory: 256Mi
+            cpu: 100m
+            memory: 100Mi
           requests:
             cpu: 100m
-            memory: 50Mi
+            memory: 20Mi
         securityContext:
           allowPrivilegeEscalation: false
       securityContext:

--- a/deploy/namespaced/namespaced-config.yaml
+++ b/deploy/namespaced/namespaced-config.yaml
@@ -264,11 +264,11 @@ spec:
           periodSeconds: 10
         resources:
           limits:
-            cpu: 100m
-            memory: 100Mi
+            cpu: 500m
+            memory: 256Mi
           requests:
             cpu: 100m
-            memory: 20Mi
+            memory: 50Mi
         securityContext:
           allowPrivilegeEscalation: false
       securityContext:

--- a/main.go
+++ b/main.go
@@ -156,7 +156,7 @@ func parseConfiguration(log *zap.SugaredLogger) Config {
 
 	// dev note: we pass the watched namespace as the env variable to use the Kubernetes Downward API. Unfortunately
 	// there is no way to use it for container arguments
-	watchedNamespace := os.Getenv("WATCHED_NAMESPACE")
+	watchedNamespace := os.Getenv("WATCH_NAMESPACE")
 	if watchedNamespace != "" {
 		log.Infof("The Operator is watching the namespace %s", watchedNamespace)
 	}


### PR DESCRIPTION
This PR makes the changes to align the configuration with the Helm chart (https://github.com/mongodb/helm-charts/pull/25):
* adds support for the service account
* increases the limits resources
* doesn't create the CluterRole `metrics-reader` as it's not required by the Operator
* renames `WATCHED_NAMESPACE` to `WATCH_NAMESPACE` as the later is a standard naming in the other operators