### PR TITLE
CLOUDP-83733: more tests on clusters (create only)

### DIFF
--- a/pkg/controller/atlascluster/cluster_test.go
+++ b/pkg/controller/atlascluster/cluster_test.go
@@ -31,6 +31,16 @@ func TestClusterMatchesSpec(t *testing.T) {
 		equal := ClustersEqual(zap.S(), atlasCluster, merged)
 		assert.True(t, equal)
 	})
+	t.Run("Clusters don't match (enums)", func(t *testing.T) {
+		atlasClusterEnum := mongodbatlas.Cluster{ClusterType: "GEOSHARDED"}
+		operatorClusterEnum := mdbv1.AtlasClusterSpec{ClusterType: mdbv1.TypeReplicaSet}
+
+		merged, err := MergedCluster(atlasClusterEnum, operatorClusterEnum)
+		assert.NoError(t, err)
+
+		equal := ClustersEqual(zap.S(), atlasClusterEnum, merged)
+		assert.False(t, equal)
+	})
 	t.Run("Clusters match (ProviderSettings.RegionName ignored)", func(t *testing.T) {
 		common := mdbv1.DefaultAWSCluster("test-ns", "project-name")
 		// Note, that in reality it seems that Atlas nullifies ProviderSettings.RegionName only if RegionsConfig are specified
@@ -61,15 +71,53 @@ func TestClusterMatchesSpec(t *testing.T) {
 		equal := ClustersEqual(zap.S(), *atlasCluster, merged)
 		assert.False(t, equal)
 	})
+	t.Run("Clusters match when Atlas adds default ReplicationSpecs", func(t *testing.T) {
+		atlasCluster, err := mdbv1.DefaultAWSCluster("test-ns", "project-name").Spec.Cluster()
+		assert.NoError(t, err)
+		atlasCluster.ReplicationSpecs = []mongodbatlas.ReplicationSpec{{
+			ID:        "id",
+			NumShards: int64ptr(1),
+			ZoneName:  "zone1",
+			RegionsConfig: map[string]mongodbatlas.RegionsConfig{
+				"US_EAST": {AnalyticsNodes: int64ptr(0), ElectableNodes: int64ptr(3), Priority: int64ptr(7), ReadOnlyNodes: int64ptr(0)}}},
+		}
+		operatorCluster := mdbv1.DefaultAWSCluster("test-ns", "project-name")
 
-	t.Run("Clusters don't match (enums)", func(t *testing.T) {
-		atlasClusterEnum := mongodbatlas.Cluster{ClusterType: "GEOSHARDED"}
-		operatorClusterEnum := mdbv1.AtlasClusterSpec{ClusterType: mdbv1.TypeReplicaSet}
-
-		merged, err := MergedCluster(atlasClusterEnum, operatorClusterEnum)
+		merged, err := MergedCluster(*atlasCluster, operatorCluster.Spec)
 		assert.NoError(t, err)
 
-		equal := ClustersEqual(zap.S(), atlasClusterEnum, merged)
+		equal := ClustersEqual(zap.S(), *atlasCluster, merged)
+		assert.True(t, equal)
+	})
+	t.Run("Clusters don't match when Atlas adds default ReplicationSpecs and Operator overrides something", func(t *testing.T) {
+		atlasCluster, err := mdbv1.DefaultAWSCluster("test-ns", "project-name").Spec.Cluster()
+		assert.NoError(t, err)
+		atlasCluster.ReplicationSpecs = []mongodbatlas.ReplicationSpec{{
+			ID:        "id",
+			NumShards: int64ptr(1),
+			ZoneName:  "zone1",
+			RegionsConfig: map[string]mongodbatlas.RegionsConfig{
+				"US_EAST": {AnalyticsNodes: int64ptr(0), ElectableNodes: int64ptr(3), Priority: int64ptr(7), ReadOnlyNodes: int64ptr(0)}}},
+		}
+		operatorCluster := mdbv1.DefaultAWSCluster("test-ns", "project-name")
+		operatorCluster.Spec.ReplicationSpecs = []mdbv1.ReplicationSpec{{
+			NumShards: int64ptr(2),
+			ZoneName:  "zone5",
+		}}
+
+		merged, err := MergedCluster(*atlasCluster, operatorCluster.Spec)
+		assert.NoError(t, err)
+
+		expectedReplicationSpecs := []mongodbatlas.ReplicationSpec{{
+			ID:        "id",
+			NumShards: int64ptr(2),
+			ZoneName:  "zone5",
+			RegionsConfig: map[string]mongodbatlas.RegionsConfig{
+				"US_EAST": {AnalyticsNodes: int64ptr(0), ElectableNodes: int64ptr(3), Priority: int64ptr(7), ReadOnlyNodes: int64ptr(0)}}},
+		}
+		assert.Equal(t, expectedReplicationSpecs, merged.ReplicationSpecs)
+
+		equal := ClustersEqual(zap.S(), *atlasCluster, merged)
 		assert.False(t, equal)
 	})
 }

--- a/pkg/controller/atlascluster/cluster_test.go
+++ b/pkg/controller/atlascluster/cluster_test.go
@@ -25,21 +25,54 @@ func TestClusterMatchesSpec(t *testing.T) {
 			ClusterType: mdbv1.TypeGeoSharded,
 		}
 
-		merged, err := mergedCluster(atlasCluster, operatorCluster)
+		merged, err := MergedCluster(atlasCluster, operatorCluster)
 		assert.NoError(t, err)
 
-		equal := clustersEqual(zap.S(), atlasCluster, merged)
+		equal := ClustersEqual(zap.S(), atlasCluster, merged)
 		assert.True(t, equal)
+	})
+	t.Run("Clusters match (ProviderSettings.RegionName ignored)", func(t *testing.T) {
+		common := mdbv1.DefaultAWSCluster("test-ns", "project-name")
+		// Note, that in reality it seems that Atlas nullifies ProviderSettings.RegionName only if RegionsConfig are specified
+		// but it's ok not to overcomplicate
+		common.Spec.ReplicationSpecs = append(common.Spec.ReplicationSpecs, mdbv1.ReplicationSpec{
+			NumShards: int64ptr(2),
+		})
+		// Emulating Atlas behavior when it nullifies the ProviderSettings.RegionName
+		atlasCluster, err := common.DeepCopy().WithRegionName("").Spec.Cluster()
+		assert.NoError(t, err)
+		operatorCluster := common.DeepCopy()
+
+		merged, err := MergedCluster(*atlasCluster, operatorCluster.Spec)
+		assert.NoError(t, err)
+
+		equal := ClustersEqual(zap.S(), *atlasCluster, merged)
+		assert.True(t, equal)
+	})
+	t.Run("Clusters don't match (ProviderSettings.RegionName was changed)", func(t *testing.T) {
+		atlasCluster, err := mdbv1.DefaultAWSCluster("test-ns", "project-name").WithRegionName("US_WEST_1").Spec.Cluster()
+		assert.NoError(t, err)
+		// RegionName has changed and no ReplicationSpecs are specified (meaning ProviderSettings.RegionName is mandatory)
+		operatorCluster := mdbv1.DefaultAWSCluster("test-ns", "project-name").WithRegionName("EU_EAST_1")
+
+		merged, err := MergedCluster(*atlasCluster, operatorCluster.Spec)
+		assert.NoError(t, err)
+
+		equal := ClustersEqual(zap.S(), *atlasCluster, merged)
+		assert.False(t, equal)
 	})
 
 	t.Run("Clusters don't match (enums)", func(t *testing.T) {
 		atlasClusterEnum := mongodbatlas.Cluster{ClusterType: "GEOSHARDED"}
 		operatorClusterEnum := mdbv1.AtlasClusterSpec{ClusterType: mdbv1.TypeReplicaSet}
 
-		merged, err := mergedCluster(atlasClusterEnum, operatorClusterEnum)
+		merged, err := MergedCluster(atlasClusterEnum, operatorClusterEnum)
 		assert.NoError(t, err)
 
-		equal := clustersEqual(zap.S(), atlasClusterEnum, merged)
+		equal := ClustersEqual(zap.S(), atlasClusterEnum, merged)
 		assert.False(t, equal)
 	})
+}
+func int64ptr(i int64) *int64 {
+	return &i
 }

--- a/test/int/cluster_test.go
+++ b/test/int/cluster_test.go
@@ -62,7 +62,7 @@ var _ = Describe("AtlasCluster", func() {
 		By("Creating the project " + createdProject.Name)
 		Expect(k8sClient.Create(context.Background(), createdProject)).To(Succeed())
 		Eventually(testutil.WaitFor(k8sClient, createdProject, status.TrueCondition(status.ReadyType)),
-			20, interval).Should(BeTrue())
+			ProjectCreationTimeout, interval).Should(BeTrue())
 	})
 
 	AfterEach(func() {

--- a/test/int/cluster_test.go
+++ b/test/int/cluster_test.go
@@ -9,14 +9,22 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"go.mongodb.org/atlas/mongodbatlas"
+	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	mdbv1 "github.com/mongodb/mongodb-atlas-kubernetes/pkg/api/v1"
 	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/api/v1/status"
+	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/controller/atlascluster"
 	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/controller/workflow"
 	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/util/kube"
 	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/util/testutil"
+)
+
+const (
+	// Set this to true if you are debugging cluster creation.
+	// This may not help much if there was the update though...
+	ClusterDevMode = false
 )
 
 var _ = Describe("AtlasCluster", func() {
@@ -47,6 +55,10 @@ var _ = Describe("AtlasCluster", func() {
 		Expect(k8sClient.Create(context.Background(), &connectionSecret)).To(Succeed())
 
 		createdProject = mdbv1.DefaultProject(namespace.Name, connectionSecret.Name)
+		if ClusterDevMode {
+			// While developing tests we need to reuse the same project
+			createdProject.Spec.Name = "dev-test atlas-project"
+		}
 		By("Creating the project " + createdProject.Name)
 		Expect(k8sClient.Create(context.Background(), createdProject)).To(Succeed())
 		Eventually(testutil.WaitFor(k8sClient, createdProject, status.TrueCondition(status.ReadyType)),
@@ -54,6 +66,9 @@ var _ = Describe("AtlasCluster", func() {
 	})
 
 	AfterEach(func() {
+		if ClusterDevMode {
+			return
+		}
 		if createdProject != nil && createdProject.Status.ID != "" {
 			if createdCluster != nil {
 				By("Removing Atlas Cluster " + createdCluster.Name)
@@ -68,14 +83,18 @@ var _ = Describe("AtlasCluster", func() {
 		removeControllersAndNamespace()
 	})
 
-	doCommonChecks := func() {
+	doCommonStatusChecks := func() {
 		By("Checking observed Cluster state", func() {
+			atlasCluster, _, err := atlasClient.Clusters.Get(context.Background(), createdProject.Status.ID, createdCluster.Spec.Name)
+			Expect(err).ToNot(HaveOccurred())
+
 			Expect(createdCluster.Status.ConnectionStrings).NotTo(BeNil())
-			Expect(createdCluster.Status.ConnectionStrings.Standard).NotTo(BeNil())
-			Expect(createdCluster.Status.ConnectionStrings.StandardSrv).NotTo(BeNil())
-			Expect(createdCluster.Status.MongoDBVersion).NotTo(BeNil())
-			Expect(createdCluster.Status.MongoURIUpdated).NotTo(BeNil())
+			Expect(createdCluster.Status.ConnectionStrings.Standard).To(Equal(atlasCluster.ConnectionStrings.Standard))
+			Expect(createdCluster.Status.ConnectionStrings.StandardSrv).To(Equal(atlasCluster.ConnectionStrings.StandardSrv))
+			Expect(createdCluster.Status.MongoDBVersion).To(Equal(atlasCluster.MongoDBVersion))
+			Expect(createdCluster.Status.MongoURIUpdated).To(Equal(atlasCluster.MongoURIUpdated))
 			Expect(createdCluster.Status.StateName).To(Equal("IDLE"))
+			Expect(createdCluster.Status.Conditions).To(HaveLen(2))
 			Expect(createdCluster.Status.Conditions).To(ConsistOf(testutil.MatchConditions(
 				status.TrueCondition(status.ClusterReadyType),
 				status.TrueCondition(status.ReadyType),
@@ -90,14 +109,10 @@ var _ = Describe("AtlasCluster", func() {
 			atlasCluster, _, err := atlasClient.Clusters.Get(context.Background(), createdProject.Status.ID, createdCluster.Spec.Name)
 			Expect(err).ToNot(HaveOccurred())
 
-			createdAtlasCluster, err := createdCluster.Spec.Cluster()
+			mergedCluster, err := atlascluster.MergedCluster(*atlasCluster, createdCluster.Spec)
 			Expect(err).ToNot(HaveOccurred())
 
-			Expect(atlasCluster.Name).To(Equal(createdAtlasCluster.Name))
-			Expect(atlasCluster.Labels).To(ConsistOf(createdAtlasCluster.Labels))
-			Expect(atlasCluster.ProviderSettings.InstanceSizeName).To(Equal(createdAtlasCluster.ProviderSettings.InstanceSizeName))
-			Expect(atlasCluster.ProviderSettings.ProviderName).To(Equal(createdAtlasCluster.ProviderSettings.ProviderName))
-			Expect(atlasCluster.ProviderSettings.RegionName).To(Equal(createdAtlasCluster.ProviderSettings.RegionName))
+			Expect(atlascluster.ClustersEqual(zap.S(), *atlasCluster, mergedCluster)).To(BeTrue())
 
 			for _, check := range additionalChecks {
 				check(atlasCluster)
@@ -125,7 +140,7 @@ var _ = Describe("AtlasCluster", func() {
 				Eventually(testutil.WaitFor(k8sClient, createdCluster, status.TrueCondition(status.ReadyType), validateClusterCreatingFunc()),
 					30*time.Minute, interval).Should(BeTrue())
 
-				doCommonChecks()
+				doCommonStatusChecks()
 				checkAtlasState()
 			})
 
@@ -135,7 +150,7 @@ var _ = Describe("AtlasCluster", func() {
 				})
 				createdCluster.Spec.ClusterType = "SHARDED"
 				performUpdate(40 * time.Minute)
-				doCommonChecks()
+				doCommonStatusChecks()
 				checkAtlasState()
 			})
 		})
@@ -152,14 +167,14 @@ var _ = Describe("AtlasCluster", func() {
 				Eventually(testutil.WaitFor(k8sClient, createdCluster, status.TrueCondition(status.ReadyType), validateClusterCreatingFunc()),
 					1800, interval).Should(BeTrue())
 
-				doCommonChecks()
+				doCommonStatusChecks()
 				checkAtlasState()
 			})
 
 			By("Increasing InstanceSize", func() {
 				createdCluster.Spec.ProviderSettings.InstanceSizeName = "M30"
 				performUpdate(40 * time.Minute)
-				doCommonChecks()
+				doCommonStatusChecks()
 				checkAtlasState()
 			})
 		})
@@ -176,13 +191,12 @@ var _ = Describe("AtlasCluster", func() {
 				Eventually(testutil.WaitFor(k8sClient, createdCluster, status.TrueCondition(status.ReadyType), validateClusterCreatingFunc()),
 					1800, interval).Should(BeTrue())
 
-				doCommonChecks()
+				doCommonStatusChecks()
 				checkAtlasState()
 			})
 
 			By("Change cluster to GEOSHARDED", func() {
 				createdCluster.Spec.ClusterType = "GEOSHARDED"
-				createdCluster.Spec.ProviderSettings.RegionName = ""
 				createdCluster.Spec.ReplicationSpecs = []mdbv1.ReplicationSpec{
 					{
 						NumShards: int64ptr(1),
@@ -204,7 +218,46 @@ var _ = Describe("AtlasCluster", func() {
 					},
 				}
 				performUpdate(80 * time.Minute)
-				doCommonChecks()
+				doCommonStatusChecks()
+				checkAtlasState()
+			})
+		})
+	})
+
+	Describe("Create/Update the cluster (more complex scenario)", func() {
+		It("Should be created", func() {
+			createdCluster = mdbv1.DefaultAWSCluster(namespace.Name, createdProject.Name)
+			createdCluster.Spec.ClusterType = mdbv1.TypeReplicaSet
+			createdCluster.Spec.AutoScaling = &mdbv1.AutoScalingSpec{
+				Compute: &mdbv1.ComputeSpec{
+					Enabled:          boolptr(true),
+					ScaleDownEnabled: boolptr(true),
+				},
+			}
+			createdCluster.Spec.ProviderSettings.AutoScaling = &mdbv1.AutoScalingSpec{
+				Compute: &mdbv1.ComputeSpec{
+					MaxInstanceSize: "M20",
+					MinInstanceSize: "M10",
+				},
+			}
+			createdCluster.Spec.ProviderSettings.InstanceSizeName = "M10"
+			createdCluster.Spec.Labels = []mdbv1.LabelSpec{{Key: "createdBy", Value: "Atlas Operator"}}
+			createdCluster.Spec.ReplicationSpecs = []mdbv1.ReplicationSpec{{
+				NumShards: int64ptr(1),
+				ZoneName:  "Zone 1",
+				// One interesting thing: if the regionsConfig is not empty - Atlas nullifies the 'providerSettings.regionName' field
+				RegionsConfig: map[string]mdbv1.RegionsConfig{
+					"US_EAST_1": {AnalyticsNodes: int64ptr(0), ElectableNodes: int64ptr(1), Priority: int64ptr(6), ReadOnlyNodes: int64ptr(0)},
+					"US_WEST_2": {AnalyticsNodes: int64ptr(0), ElectableNodes: int64ptr(2), Priority: int64ptr(7), ReadOnlyNodes: int64ptr(0)},
+				}}}
+
+			By(fmt.Sprintf("Creating the Cluster %s", kube.ObjectKeyFromObject(createdCluster)), func() {
+				Expect(k8sClient.Create(context.Background(), createdCluster)).To(Succeed())
+
+				Eventually(testutil.WaitFor(k8sClient, createdCluster, status.TrueCondition(status.ReadyType), validateClusterCreatingFunc()),
+					1800, interval).Should(BeTrue())
+
+				doCommonStatusChecks()
 				checkAtlasState()
 			})
 		})
@@ -241,7 +294,7 @@ var _ = Describe("AtlasCluster", func() {
 				Eventually(testutil.WaitFor(k8sClient, createdCluster, status.TrueCondition(status.ReadyType)),
 					20*time.Minute, interval).Should(BeTrue())
 
-				doCommonChecks()
+				doCommonStatusChecks()
 				checkAtlasState()
 			})
 		})
@@ -255,21 +308,21 @@ var _ = Describe("AtlasCluster", func() {
 				Eventually(testutil.WaitFor(k8sClient, createdCluster, status.TrueCondition(status.ReadyType), validateClusterCreatingFunc()),
 					1800, interval).Should(BeTrue())
 
-				doCommonChecks()
+				doCommonStatusChecks()
 				checkAtlasState()
 			})
 
 			By("Updating the Cluster labels", func() {
 				createdCluster.Spec.Labels = []mdbv1.LabelSpec{{Key: "int-test", Value: "true"}}
 				performUpdate(20 * time.Minute)
-				doCommonChecks()
+				doCommonStatusChecks()
 				checkAtlasState()
 			})
 
 			By("Updating the Cluster backups settings", func() {
 				createdCluster.Spec.ProviderBackupEnabled = boolptr(true)
 				performUpdate(20 * time.Minute)
-				doCommonChecks()
+				doCommonStatusChecks()
 				checkAtlasState(func(c *mongodbatlas.Cluster) {
 					Expect(c.ProviderBackupEnabled).To(Equal(createdCluster.Spec.ProviderBackupEnabled))
 				})
@@ -278,7 +331,7 @@ var _ = Describe("AtlasCluster", func() {
 			By("Decreasing the Cluster disk size", func() {
 				createdCluster.Spec.DiskSizeGB = intptr(10)
 				performUpdate(20 * time.Minute)
-				doCommonChecks()
+				doCommonStatusChecks()
 				checkAtlasState(func(c *mongodbatlas.Cluster) {
 					Expect(*c.DiskSizeGB).To(BeEquivalentTo(*createdCluster.Spec.DiskSizeGB))
 
@@ -290,7 +343,7 @@ var _ = Describe("AtlasCluster", func() {
 			By("Pausing the cluster", func() {
 				createdCluster.Spec.Paused = boolptr(true)
 				performUpdate(20 * time.Minute)
-				doCommonChecks()
+				doCommonStatusChecks()
 				checkAtlasState(func(c *mongodbatlas.Cluster) {
 					Expect(c.Paused).To(Equal(createdCluster.Spec.Paused))
 				})
@@ -319,14 +372,14 @@ var _ = Describe("AtlasCluster", func() {
 			By("Unpausing the cluster", func() {
 				createdCluster.Spec.Paused = boolptr(false)
 				performUpdate(20 * time.Minute)
-				doCommonChecks()
+				doCommonStatusChecks()
 				checkAtlasState(func(c *mongodbatlas.Cluster) {
 					Expect(c.Paused).To(Equal(createdCluster.Spec.Paused))
 				})
 			})
 
 			By("Checking that modifications were applied after unpausing", func() {
-				doCommonChecks()
+				doCommonStatusChecks()
 				checkAtlasState(func(c *mongodbatlas.Cluster) {
 					Expect(c.ProviderBackupEnabled).To(Equal(createdCluster.Spec.ProviderBackupEnabled))
 				})
@@ -358,7 +411,7 @@ var _ = Describe("AtlasCluster", func() {
 				By("Fixing the Cluster", func() {
 					createdCluster.Spec.ProviderSettings.AutoScaling = nil
 					performUpdate(20 * time.Minute)
-					doCommonChecks()
+					doCommonStatusChecks()
 					checkAtlasState()
 				})
 			})
@@ -386,7 +439,7 @@ var _ = Describe("AtlasCluster", func() {
 				By("Fixing the Cluster", func() {
 					createdCluster.Spec.ProviderSettings.InstanceSizeName = oldSizeName
 					performUpdate(20 * time.Minute)
-					doCommonChecks()
+					doCommonStatusChecks()
 					checkAtlasState()
 				})
 			})

--- a/test/int/dbuser_test.go
+++ b/test/int/dbuser_test.go
@@ -78,7 +78,7 @@ var _ = Describe("AtlasDatabaseUser", func() {
 
 			Expect(k8sClient.Create(context.Background(), createdProject)).To(Succeed())
 			Eventually(testutil.WaitFor(k8sClient, createdProject, status.TrueCondition(status.ReadyType)),
-				20, interval).Should(BeTrue())
+				ProjectCreationTimeout, interval).Should(BeTrue())
 		})
 	})
 

--- a/test/int/project_test.go
+++ b/test/int/project_test.go
@@ -22,6 +22,10 @@ import (
 	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/util/testutil"
 )
 
+const (
+	ProjectCreationTimeout = 30
+)
+
 var _ = Describe("AtlasProject", func() {
 	const interval = time.Second * 1
 
@@ -83,7 +87,7 @@ var _ = Describe("AtlasProject", func() {
 			Expect(k8sClient.Create(context.Background(), expectedProject)).ToNot(HaveOccurred())
 
 			Eventually(testutil.WaitFor(k8sClient, createdProject, status.TrueCondition(status.ReadyType)),
-				20, interval).Should(BeTrue())
+				ProjectCreationTimeout, interval).Should(BeTrue())
 
 			checkAtlasProjectIsReady()
 
@@ -100,7 +104,7 @@ var _ = Describe("AtlasProject", func() {
 
 			expectedCondition := status.FalseCondition(status.ProjectReadyType).WithReason(string(workflow.AtlasCredentialsNotProvided))
 			Eventually(testutil.WaitFor(k8sClient, createdProject, expectedCondition),
-				20, interval).Should(BeTrue())
+				ProjectCreationTimeout, interval).Should(BeTrue())
 
 			expectedConditionsMatchers := testutil.MatchConditions(
 				status.FalseCondition(status.ProjectReadyType),
@@ -129,7 +133,7 @@ var _ = Describe("AtlasProject", func() {
 			Expect(k8sClient.Create(context.Background(), expectedProject)).ToNot(HaveOccurred())
 
 			Eventually(testutil.WaitFor(k8sClient, createdProject, status.TrueCondition(status.ReadyType)),
-				20, interval).Should(BeTrue())
+				ProjectCreationTimeout, interval).Should(BeTrue())
 
 			// Updating (the existing project is expected to be read from Atlas)
 			By("Updating the project")
@@ -138,7 +142,7 @@ var _ = Describe("AtlasProject", func() {
 			Expect(k8sClient.Update(context.Background(), createdProject)).To(Succeed())
 
 			Eventually(testutil.WaitFor(k8sClient, createdProject, status.TrueCondition(status.ReadyType)),
-				20, interval).Should(BeTrue())
+				ProjectCreationTimeout, interval).Should(BeTrue())
 
 			Expect(testutil.ReadAtlasResource(k8sClient, createdProject)).To(BeTrue())
 			Expect(createdProject.Status.Conditions).To(ContainElement(testutil.MatchCondition(status.TrueCondition(status.ProjectReadyType))))
@@ -168,10 +172,10 @@ var _ = Describe("AtlasProject", func() {
 				Expect(k8sClient.Create(context.Background(), secondProject)).ToNot(HaveOccurred())
 
 				Eventually(testutil.WaitFor(k8sClient, createdProject, status.TrueCondition(status.ReadyType)),
-					20, interval).Should(BeTrue())
+					ProjectCreationTimeout, interval).Should(BeTrue())
 
 				Eventually(testutil.WaitFor(k8sClient, secondProject, status.TrueCondition(status.ReadyType)),
-					20, interval).Should(BeTrue())
+					ProjectCreationTimeout, interval).Should(BeTrue())
 			})
 			By("Breaking the Connection Secret", func() {
 				connectionSecret = buildConnectionSecret("my-atlas-key")
@@ -181,9 +185,9 @@ var _ = Describe("AtlasProject", func() {
 				// Both projects are expected to get to Failed state right away
 				expectedCondition := status.FalseCondition(status.ProjectReadyType).WithReason(string(workflow.ProjectNotCreatedInAtlas))
 				Eventually(testutil.WaitFor(k8sClient, createdProject, expectedCondition),
-					20, interval).Should(BeTrue())
+					ProjectCreationTimeout, interval).Should(BeTrue())
 				Eventually(testutil.WaitFor(k8sClient, secondProject, expectedCondition),
-					20, interval).Should(BeTrue())
+					ProjectCreationTimeout, interval).Should(BeTrue())
 			})
 			By("Fixing the Connection Secret", func() {
 				connectionSecret = buildConnectionSecret("my-atlas-key")
@@ -191,9 +195,9 @@ var _ = Describe("AtlasProject", func() {
 
 				// Both projects are expected to recover
 				Eventually(testutil.WaitFor(k8sClient, createdProject, status.TrueCondition(status.ReadyType)),
-					20, interval).Should(BeTrue())
+					ProjectCreationTimeout, interval).Should(BeTrue())
 				Eventually(testutil.WaitFor(k8sClient, secondProject, status.TrueCondition(status.ReadyType)),
-					20, interval).Should(BeTrue())
+					ProjectCreationTimeout, interval).Should(BeTrue())
 			})
 		})
 	})
@@ -205,7 +209,7 @@ var _ = Describe("AtlasProject", func() {
 			Expect(k8sClient.Create(context.Background(), createdProject)).ToNot(HaveOccurred())
 
 			Eventually(testutil.WaitFor(k8sClient, createdProject, status.TrueCondition(status.ReadyType), validateNoErrorsIPAccessListDuringCreate),
-				20, interval).Should(BeTrue())
+				ProjectCreationTimeout, interval).Should(BeTrue())
 
 			checkAtlasProjectIsReady()
 			checkExpiredAccessLists([]project.IPAccessList{})
@@ -220,7 +224,7 @@ var _ = Describe("AtlasProject", func() {
 			Expect(k8sClient.Create(context.Background(), createdProject)).ToNot(HaveOccurred())
 
 			Eventually(testutil.WaitFor(k8sClient, createdProject, status.TrueCondition(status.ReadyType), validateNoErrorsIPAccessListDuringCreate),
-				20, interval).Should(BeTrue())
+				ProjectCreationTimeout, interval).Should(BeTrue())
 
 			checkAtlasProjectIsReady()
 			checkExpiredAccessLists([]project.IPAccessList{})
@@ -236,7 +240,7 @@ var _ = Describe("AtlasProject", func() {
 			Expect(k8sClient.Create(context.Background(), createdProject)).ToNot(HaveOccurred())
 
 			Eventually(testutil.WaitFor(k8sClient, createdProject, status.TrueCondition(status.ReadyType), validateNoErrorsIPAccessListDuringCreate),
-				20, interval).Should(BeTrue())
+				ProjectCreationTimeout, interval).Should(BeTrue())
 
 			checkAtlasProjectIsReady()
 			checkExpiredAccessLists([]project.IPAccessList{expiredList})
@@ -255,7 +259,7 @@ var _ = Describe("AtlasProject", func() {
 			Expect(k8sClient.Create(context.Background(), createdProject)).ToNot(HaveOccurred())
 
 			Eventually(testutil.WaitFor(k8sClient, createdProject, status.FalseCondition(status.IPAccessListReadyType)),
-				20, interval).Should(BeTrue())
+				ProjectCreationTimeout, interval).Should(BeTrue())
 
 			ipAccessFailedCondition := status.FalseCondition(status.IPAccessListReadyType).
 				WithReason(string(workflow.ProjectIPNotCreatedInAtlas)).
@@ -281,7 +285,7 @@ var _ = Describe("AtlasProject", func() {
 				Expect(k8sClient.Create(context.Background(), createdProject)).To(Succeed())
 
 				Eventually(testutil.WaitFor(k8sClient, createdProject, status.TrueCondition(status.ReadyType), validateNoErrorsIPAccessListDuringCreate),
-					20, interval).Should(BeTrue())
+					ProjectCreationTimeout, interval).Should(BeTrue())
 			})
 			By("Updating the IP Access List comment and delete date", func() {
 				// Just a note: Atlas doesn't allow to make the "permanent" entity "temporary". But it works the other way
@@ -290,7 +294,7 @@ var _ = Describe("AtlasProject", func() {
 				Expect(k8sClient.Update(context.Background(), createdProject)).To(Succeed())
 
 				Eventually(testutil.WaitFor(k8sClient, createdProject, status.TrueCondition(status.ReadyType), validateNoErrorsIPAccessListDuringUpdate),
-					20, interval).Should(BeTrue())
+					ProjectCreationTimeout, interval).Should(BeTrue())
 
 				checkAtlasProjectIsReady()
 				checkExpiredAccessLists([]project.IPAccessList{})
@@ -308,7 +312,7 @@ var _ = Describe("AtlasProject", func() {
 				Expect(k8sClient.Create(context.Background(), createdProject)).ToNot(HaveOccurred())
 
 				Eventually(testutil.WaitFor(k8sClient, createdProject, status.TrueCondition(status.ReadyType), validateNoErrorsIPAccessListDuringCreate),
-					20, interval).Should(BeTrue())
+					ProjectCreationTimeout, interval).Should(BeTrue())
 			})
 			By("Updating the IP Access List IPAddress", func() {
 				twoDaysLater := time.Now().Add(time.Hour * 48).Format("2006-01-02T15:04:05Z")
@@ -319,7 +323,7 @@ var _ = Describe("AtlasProject", func() {
 				Expect(k8sClient.Update(context.Background(), createdProject)).To(Succeed())
 
 				Eventually(testutil.WaitFor(k8sClient, createdProject, status.TrueCondition(status.ReadyType), validateNoErrorsIPAccessListDuringUpdate),
-					20, interval).Should(BeTrue())
+					ProjectCreationTimeout, interval).Should(BeTrue())
 
 				checkAtlasProjectIsReady()
 				checkExpiredAccessLists([]project.IPAccessList{})
@@ -339,7 +343,7 @@ var _ = Describe("AtlasProject", func() {
 			Expect(k8sClient.Create(context.Background(), createdProject)).To(Succeed())
 
 			Eventually(testutil.WaitFor(k8sClient, createdProject, status.TrueCondition(status.ReadyType)),
-				20, interval).Should(BeTrue())
+				ProjectCreationTimeout, interval).Should(BeTrue())
 
 			expectedConditionsMatchers := testutil.MatchConditions(
 				status.TrueCondition(status.ProjectReadyType),
@@ -356,7 +360,7 @@ var _ = Describe("AtlasProject", func() {
 				Expect(k8sClient.Create(context.Background(), createdProject)).ToNot(HaveOccurred())
 
 				Eventually(testutil.WaitFor(k8sClient, createdProject, status.FalseCondition(status.ReadyType)),
-					20, interval).Should(BeTrue())
+					ProjectCreationTimeout, interval).Should(BeTrue())
 
 				expectedConditionsMatchers := testutil.MatchConditions(
 					status.FalseCondition(status.ProjectReadyType).WithReason(string(workflow.AtlasCredentialsNotProvided)),
@@ -371,7 +375,7 @@ var _ = Describe("AtlasProject", func() {
 				Expect(k8sClient.Create(context.Background(), &globalConnectionSecret)).To(Succeed())
 
 				Eventually(testutil.WaitFor(k8sClient, createdProject, status.TrueCondition(status.ReadyType)),
-					20, interval).Should(BeTrue())
+					ProjectCreationTimeout, interval).Should(BeTrue())
 			})
 		})
 	})


### PR DESCRIPTION
This PR focuses on more complicated testing of the clusters. Due to the size only the creation is happening - the update will be addressed in the next PR (found some issues there).

The changes were reviewed and agreed on with Pavel p2p.

* fixed the situation when the user specifies the `providerSettings.regionName` together with `replicationSpecs`. In this case Atlas accepts the update request but erazes the former field so the infinite reconciliation happens as `ClustersEqual` method constantly returns false.
* added more checks to the integration test to check all the fields
* more unit tests to make sure the `MergedCluster` and `ClustersEqual` work correctly
* increased the timeout for project create/update as 20 seconds is not enough often