### PR TITLE
CLOUDP-84606: common labels for K8s configs

### DIFF
--- a/.github/actions/deploy/entrypoint.sh
+++ b/.github/actions/deploy/entrypoint.sh
@@ -20,12 +20,13 @@ cd - && kustomize build --load-restrictor LoadRestrictionsNone config/release/de
 kubectl delete secrets my-atlas-key --ignore-not-found -n "${ns}"
 kubectl create secret generic my-atlas-key --from-literal="orgId=${INPUT_ATLAS_ORG_ID}" --from-literal="publicApiKey=${INPUT_ATLAS_PUBLIC_KEY}" --from-literal="privateApiKey=${INPUT_ATLAS_PRIVATE_KEY}" -n "${ns}"
 
+label="app.kubernetes.io/instance=mongodb-atlas-kubernetes-operator"
 # Wait for the Operator to start
-cmd="while ! kubectl -n ${ns} get pods -l control-plane=controller-manager -o jsonpath={.items[0].status.phase} 2>/dev/null | grep -q Running ; do printf .; sleep 1; done"
+cmd="while ! kubectl -n ${ns} get pods -l $label -o jsonpath={.items[0].status.phase} 2>/dev/null | grep -q Running ; do printf .; sleep 1; done"
 timeout --foreground "1m" bash -c "${cmd}" || true
-if ! kubectl -n "${ns}" get pods -l "control-plane=controller-manager" -o 'jsonpath="{.items[0].status.phase}"' | grep -q "Running"; then
+if ! kubectl -n "${ns}" get pods -l "$label" -o 'jsonpath="{.items[0].status.phase}"' | grep -q "Running"; then
     echo "Operator hasn't reached RUNNING state after 1 minute. The full yaml configuration for the pod is:"
-    kubectl -n "${ns}" get pods -l "control-plane=controller-manager" -o yaml
+    kubectl -n "${ns}" get pods -l "$label" -o yaml
 
     echo "Operator failed to start, exiting"
     exit 1

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  labels:
-    control-plane: controller-manager
   name: system
 ---
 apiVersion: apps/v1
@@ -10,17 +8,13 @@ kind: Deployment
 metadata:
   name: operator
   namespace: system
-  labels:
-    control-plane: operator
 spec:
   selector:
     matchLabels:
-      control-plane: controller-manager
   replicas: 1
   template:
     metadata:
       labels:
-        control-plane: controller-manager
     spec:
       securityContext:
         runAsNonRoot: true

--- a/config/managerwithproxy/kustomization.yaml
+++ b/config/managerwithproxy/kustomization.yaml
@@ -1,8 +1,6 @@
-# Labels to add to all resources and selectors.
-#commonLabels:
-#  app.kubernetes.io/component: controller
-#  app.kubernetes.io/name: mongodb-atlas-kubernetes-operator
-#  app.kubernetes.io/instance: mongodb-atlas-kubernetes-operator
+#
+# This is the main source of config for Deployment that is reused by all the configurations in 'release' folder
+#
 
 resources:
 - ../manager

--- a/config/rbac/auth_proxy_service.yaml
+++ b/config/rbac/auth_proxy_service.yaml
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  labels:
-    control-plane: controller-manager
   name: controller-manager-metrics-service
   namespace: system
 spec:
@@ -10,5 +8,3 @@ spec:
   - name: https
     port: 8443
     targetPort: https
-  selector:
-    control-plane: controller-manager

--- a/config/release/base/allinone/kustomization.yaml
+++ b/config/release/base/allinone/kustomization.yaml
@@ -2,6 +2,12 @@ namespace: mongodb-atlas-system
 
 namePrefix: mongodb-atlas-
 
+# Labels to add to all resources and selectors.
+commonLabels:
+  app.kubernetes.io/component: controller
+  app.kubernetes.io/name: mongodb-atlas-kubernetes-operator
+  app.kubernetes.io/instance: mongodb-atlas-kubernetes-operator
+
 resources:
 - ../../../managerwithproxy
 - ../../../crd

--- a/config/release/base/clusterwide/kustomization.yaml
+++ b/config/release/base/clusterwide/kustomization.yaml
@@ -2,6 +2,11 @@ namespace: mongodb-atlas-system
 
 namePrefix: mongodb-atlas-
 
+# Labels to add to all resources and selectors.
+commonLabels:
+  app.kubernetes.io/component: controller
+  app.kubernetes.io/name: mongodb-atlas-kubernetes-operator
+  app.kubernetes.io/instance: mongodb-atlas-kubernetes-operator
 
 resources:
 - ../../../managerwithproxy

--- a/config/release/base/namespaced/kustomization.yaml
+++ b/config/release/base/namespaced/kustomization.yaml
@@ -2,6 +2,12 @@ namespace: mongodb-atlas-system
 
 namePrefix: mongodb-atlas-
 
+# Labels to add to all resources and selectors.
+commonLabels:
+  app.kubernetes.io/component: controller
+  app.kubernetes.io/name: mongodb-atlas-kubernetes-operator
+  app.kubernetes.io/instance: mongodb-atlas-kubernetes-operator
+
 resources:
 - ../../../managerwithproxy
 - ../../../rbac/namespaced

--- a/config/webhook/service.yaml
+++ b/config/webhook/service.yaml
@@ -8,5 +8,3 @@ spec:
   ports:
     - port: 443
       targetPort: 9443
-  selector:
-    control-plane: controller-manager

--- a/test/e2e/cli/kube/kubectl.go
+++ b/test/e2e/cli/kube/kubectl.go
@@ -26,7 +26,7 @@ func GenKubeVersion(fullVersion string) string {
 // GetPodStatus status.phase
 func GetPodStatus(ns string) func() string {
 	return func() string {
-		session := cli.Execute("kubectl", "get", "pods", "-l", "control-plane=controller-manager", "-o", "jsonpath={.items[0].status.phase}", "-n", ns)
+		session := cli.Execute("kubectl", "get", "pods", "-l", "app.kubernetes.io/instance=mongodb-atlas-kubernetes-operator", "-o", "jsonpath={.items[0].status.phase}", "-n", ns)
 		return string(session.Wait("1m").Out.Contents())
 	}
 }
@@ -34,7 +34,7 @@ func GetPodStatus(ns string) func() string {
 // DescribeOperatorPod performs "kubectl describe" to get Operator pod information
 func DescribeOperatorPod(ns string) func() string {
 	return func() string {
-		session := cli.Execute("kubectl", "describe", "pods", "-l", "control-plane=controller-manager", "-n", ns)
+		session := cli.Execute("kubectl", "describe", "pods", "-l", "app.kubernetes.io/instance=mongodb-atlas-kubernetes-operator", "-n", ns)
 		return string(session.Wait("1m").Out.Contents())
 	}
 }


### PR DESCRIPTION
This PR adds support for common labels for all kubernetes resources created during installation. 

So after running `kustomize build .` the resources will get this set of labels:

```
  apiVersion: v1
  kind: Service
  metadata:
    creationTimestamp: "2021-03-29T09:00:33Z"
    labels:
      app.kubernetes.io/component: controller
      app.kubernetes.io/instance: mongodb-atlas-kubernetes-operator
      app.kubernetes.io/name: mongodb-atlas-kubernetes-operator
```