### PR TITLE
CLOUDP-86187: cluster update (replicationSpecs)

### DIFF
--- a/pkg/controller/atlascluster/cluster.go
+++ b/pkg/controller/atlascluster/cluster.go
@@ -108,10 +108,10 @@ func MergedCluster(atlasCluster mongodbatlas.Cluster, spec mdbv1.AtlasClusterSpe
 	if err = compat.JSONCopy(&result, spec); err != nil {
 		return
 	}
-
-	if err = compat.JSONSliceMerge(&result.ReplicationSpecs, spec.ReplicationSpecs); err != nil {
-		return
-	}
+	//
+	// if err = compat.JSONSliceMerge(&result.ReplicationSpecs, spec.ReplicationSpecs); err != nil {
+	//	return
+	//}
 
 	mergeRegionConfigs(result.ReplicationSpecs, spec.ReplicationSpecs)
 

--- a/pkg/controller/atlascluster/cluster.go
+++ b/pkg/controller/atlascluster/cluster.go
@@ -108,10 +108,6 @@ func MergedCluster(atlasCluster mongodbatlas.Cluster, spec mdbv1.AtlasClusterSpe
 	if err = compat.JSONCopy(&result, spec); err != nil {
 		return
 	}
-	//
-	// if err = compat.JSONSliceMerge(&result.ReplicationSpecs, spec.ReplicationSpecs); err != nil {
-	//	return
-	//}
 
 	mergeRegionConfigs(result.ReplicationSpecs, spec.ReplicationSpecs)
 

--- a/pkg/controller/atlascluster/cluster.go
+++ b/pkg/controller/atlascluster/cluster.go
@@ -133,6 +133,11 @@ func MergedCluster(atlasCluster mongodbatlas.Cluster, spec mdbv1.AtlasClusterSpe
 // explicitly - but may make sense to refactor this later if more maps are added (and all follow the same logic).
 func mergeRegionConfigs(atlasSpecs []mongodbatlas.ReplicationSpec, operatorSpecs []mdbv1.ReplicationSpec) {
 	for i, operatorSpec := range operatorSpecs {
+		if len(operatorSpec.RegionsConfig) == 0 {
+			// Edge case: if the operator doesn't specify regions configs - Atlas will put the default ones. We shouldn't
+			// remove it in this case.
+			continue
+		}
 		atlasSpec := atlasSpecs[i]
 		for key := range atlasSpec.RegionsConfig {
 			if _, ok := operatorSpec.RegionsConfig[key]; !ok {

--- a/pkg/controller/atlascluster/cluster.go
+++ b/pkg/controller/atlascluster/cluster.go
@@ -109,14 +109,11 @@ func MergedCluster(atlasCluster mongodbatlas.Cluster, spec mdbv1.AtlasClusterSpe
 		return
 	}
 
-	// TODO: might need to do this with other slices
-	if err = compat.JSONSliceMerge(&result.ReplicationSpecs, atlasCluster.ReplicationSpecs); err != nil {
-		return
-	}
-
 	if err = compat.JSONSliceMerge(&result.ReplicationSpecs, spec.ReplicationSpecs); err != nil {
 		return
 	}
+
+	mergeRegionConfigs(result.ReplicationSpecs, spec.ReplicationSpecs)
 
 	// According to the docs for 'providerSettings.regionName' (https://docs.atlas.mongodb.com/reference/api/clusters-create-one/):
 	// "Don't specify this parameter when creating a multi-region cluster using the replicationSpec object or a Global
@@ -128,6 +125,21 @@ func MergedCluster(atlasCluster mongodbatlas.Cluster, spec mdbv1.AtlasClusterSpe
 	}
 
 	return
+}
+
+// mergeRegionConfigs removes replicationSpecs[i].RegionsConfigs[key] from Atlas Cluster that are absent in Operator.
+// Dev idea: this could have been added into some more generic method like `JSONCopy` or something wrapping it to make
+// sure any Atlas map get redundant keys removed. So far there's only one map in Cluster ('RegionsConfig') so we'll do this
+// explicitly - but may make sense to refactor this later if more maps are added (and all follow the same logic).
+func mergeRegionConfigs(atlasSpecs []mongodbatlas.ReplicationSpec, operatorSpecs []mdbv1.ReplicationSpec) {
+	for i, operatorSpec := range operatorSpecs {
+		atlasSpec := atlasSpecs[i]
+		for key := range atlasSpec.RegionsConfig {
+			if _, ok := operatorSpec.RegionsConfig[key]; !ok {
+				delete(atlasSpec.RegionsConfig, key)
+			}
+		}
+	}
 }
 
 // ClustersEqual compares two Atlas Clusters

--- a/pkg/controller/atlascluster/cluster_test.go
+++ b/pkg/controller/atlascluster/cluster_test.go
@@ -87,6 +87,10 @@ func TestClusterMatchesSpec(t *testing.T) {
 				"US_EAST": {AnalyticsNodes: int64ptr(0), ElectableNodes: int64ptr(3), Priority: int64ptr(7), ReadOnlyNodes: int64ptr(0)}}},
 		}
 		operatorCluster := mdbv1.DefaultAWSCluster("test-ns", "project-name")
+		operatorCluster.Spec.ReplicationSpecs = []mdbv1.ReplicationSpec{{
+			NumShards: int64ptr(1),
+			ZoneName:  "zone1",
+		}}
 
 		merged, err := MergedCluster(*atlasCluster, operatorCluster.Spec)
 		assert.NoError(t, err)

--- a/pkg/controller/atlascluster/cluster_test.go
+++ b/pkg/controller/atlascluster/cluster_test.go
@@ -10,6 +10,11 @@ import (
 	mdbv1 "github.com/mongodb/mongodb-atlas-kubernetes/pkg/api/v1"
 )
 
+func init() {
+	logger, _ := zap.NewDevelopment()
+	zap.ReplaceGlobals(logger)
+}
+
 func TestClusterMatchesSpec(t *testing.T) {
 	t.Run("Clusters match (enums)", func(t *testing.T) {
 		atlasCluster := mongodbatlas.Cluster{
@@ -112,6 +117,43 @@ func TestClusterMatchesSpec(t *testing.T) {
 			ID:        "id",
 			NumShards: int64ptr(2),
 			ZoneName:  "zone5",
+			RegionsConfig: map[string]mongodbatlas.RegionsConfig{
+				"US_EAST": {AnalyticsNodes: int64ptr(0), ElectableNodes: int64ptr(3), Priority: int64ptr(7), ReadOnlyNodes: int64ptr(0)}}},
+		}
+		assert.Equal(t, expectedReplicationSpecs, merged.ReplicationSpecs)
+
+		equal := ClustersEqual(zap.S(), *atlasCluster, merged)
+		assert.False(t, equal)
+	})
+
+	t.Run("Clusters don't match - Operator removed the region", func(t *testing.T) {
+		atlasCluster, err := mdbv1.DefaultAWSCluster("test-ns", "project-name").Spec.Cluster()
+		assert.NoError(t, err)
+		atlasCluster.ReplicationSpecs = []mongodbatlas.ReplicationSpec{{
+			ID:        "id",
+			NumShards: int64ptr(1),
+			ZoneName:  "zone1",
+			RegionsConfig: map[string]mongodbatlas.RegionsConfig{
+				"US_EAST": {AnalyticsNodes: int64ptr(0), ElectableNodes: int64ptr(3), Priority: int64ptr(7), ReadOnlyNodes: int64ptr(0)},
+				"US_WEST": {AnalyticsNodes: int64ptr(2), ElectableNodes: int64ptr(5), Priority: int64ptr(6), ReadOnlyNodes: int64ptr(0)},
+			}},
+		}
+		operatorCluster := mdbv1.DefaultAWSCluster("test-ns", "project-name")
+		operatorCluster.Spec.ReplicationSpecs = []mdbv1.ReplicationSpec{{
+			NumShards: int64ptr(1),
+			ZoneName:  "zone1",
+			RegionsConfig: map[string]mdbv1.RegionsConfig{
+				"US_EAST": {AnalyticsNodes: int64ptr(0), ElectableNodes: int64ptr(3), Priority: int64ptr(7), ReadOnlyNodes: int64ptr(0)},
+			}},
+		}
+
+		merged, err := MergedCluster(*atlasCluster, operatorCluster.Spec)
+		assert.NoError(t, err)
+
+		expectedReplicationSpecs := []mongodbatlas.ReplicationSpec{{
+			ID:        "id",
+			NumShards: int64ptr(1),
+			ZoneName:  "zone1",
 			RegionsConfig: map[string]mongodbatlas.RegionsConfig{
 				"US_EAST": {AnalyticsNodes: int64ptr(0), ElectableNodes: int64ptr(3), Priority: int64ptr(7), ReadOnlyNodes: int64ptr(0)}}},
 		}

--- a/test/int/cluster_test.go
+++ b/test/int/cluster_test.go
@@ -24,7 +24,7 @@ import (
 const (
 	// Set this to true if you are debugging cluster creation.
 	// This may not help much if there was the update though...
-	ClusterDevMode = false
+	ClusterDevMode = true
 )
 
 var _ = Describe("AtlasCluster", func() {
@@ -242,7 +242,7 @@ var _ = Describe("AtlasCluster", func() {
 		})
 	})
 
-	Describe("Create/Update the cluster (more complex scenario)", func() {
+	FDescribe("Create/Update the cluster (more complex scenario)", func() {
 		It("Should be created", func() {
 			createdCluster = mdbv1.DefaultAWSCluster(namespace.Name, createdProject.Name)
 			createdCluster.Spec.ClusterType = mdbv1.TypeReplicaSet
@@ -280,10 +280,33 @@ var _ = Describe("AtlasCluster", func() {
 				// Apart from 'ID' all other fields are equal to the ones sent by the Operator
 				Expect(c.ReplicationSpecs).To(Equal(expectedReplicationSpecs))
 			}
-			By("Creating the Cluster", func() {
+
+			// By("Creating the Cluster", func() {
+			//	Expect(k8sClient.Create(context.Background(), createdCluster)).To(Succeed())
+			//
+			//	Eventually(testutil.WaitFor(k8sClient, createdCluster, status.TrueCondition(status.ReadyType), validateClusterCreatingFunc()),
+			//		1800, interval).Should(BeTrue())
+			//
+			//	doCommonStatusChecks()
+			//
+			//	checkAtlasState(replicationSpecsCheckFunc)
+			// })
+
+			By("Updating the cluster (multiple operations)", func() {
+				delete(createdCluster.Spec.ReplicationSpecs[0].RegionsConfig, "US_WEST_2")
+				createdCluster.Spec.ReplicationSpecs[0].RegionsConfig["US_WEST_1"] = mdbv1.RegionsConfig{AnalyticsNodes: int64ptr(0), ElectableNodes: int64ptr(2), Priority: int64ptr(6), ReadOnlyNodes: int64ptr(0)}
+				config := createdCluster.Spec.ReplicationSpecs[0].RegionsConfig["US_EAST_1"]
+				// Note, that Atlas has strict requirements to priorities - they must start with 7 and be in descending order over the regions
+				config.Priority = int64ptr(5)
+				createdCluster.Spec.ReplicationSpecs[0].RegionsConfig["US_EAST_1"] = config
+
+				createdCluster.Spec.ProviderSettings.AutoScaling.Compute.MaxInstanceSize = "M30"
+
 				Expect(k8sClient.Create(context.Background(), createdCluster)).To(Succeed())
 
-				Eventually(testutil.WaitFor(k8sClient, createdCluster, status.TrueCondition(status.ReadyType), validateClusterCreatingFunc()),
+				// performUpdate(80 * time.Minute)
+
+				Eventually(testutil.WaitFor(k8sClient, createdCluster, status.TrueCondition(status.ReadyType), validateClusterUpdatingFunc()),
 					1800, interval).Should(BeTrue())
 
 				doCommonStatusChecks()
@@ -485,7 +508,7 @@ var _ = Describe("AtlasCluster", func() {
 				Eventually(testutil.WaitFor(k8sClient, createdCluster, status.TrueCondition(status.ReadyType), validateClusterCreatingFunc()),
 					1800, interval).Should(BeTrue())
 
-				doCommonChecks()
+				doCommonStatusChecks()
 				checkAtlasState()
 			})
 


### PR DESCRIPTION
This PR adds more complicated scenarios for cluster update. It also fixes the problem when the removal of `replicationSpecs[i].regionsConfigs['X']` is not handled properly.