### PR TITLE
CLOUDP-86200: link to the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ The MongoDB Atlas Operator provides a native integration between the Kubernetes 
 > into applications deployed to Kubernetes. More features like private endpoints, backup management, LDAP/X.509 authentication, etc. 
 > are yet to come.
 
+The full documentation for the Operator can be found [here](https://docs.atlas.mongodb.com/atlas-operator/)
 
 ## Quick Start guide
 ### Step 1. Deploy Kubernetes operator using all in one config file


### PR DESCRIPTION
As a suggestion: to keep the quickstart section - otherwise the page looks too empty and also many people will benefit from the quickstart without going to the docs.