### PR TITLE
CLOUDP-86590: using M2 clusters for some tests

### DIFF
--- a/pkg/api/v1/atlascluster_types.go
+++ b/pkg/api/v1/atlascluster_types.go
@@ -349,6 +349,10 @@ func (c *AtlasCluster) WithInstanceSize(name string) *AtlasCluster {
 	c.Spec.ProviderSettings.InstanceSizeName = name
 	return c
 }
+func (c *AtlasCluster) WithBackingProvider(name string) *AtlasCluster {
+	c.Spec.ProviderSettings.BackingProviderName = name
+	return c
+}
 
 // Lightweight makes the cluster work with small shared instance M2. This is useful for non-cluster tests (e.g.
 // database users) and saves some money for the company.
@@ -358,17 +362,20 @@ func (c *AtlasCluster) Lightweight() *AtlasCluster {
 	switch c.Spec.ProviderSettings.ProviderName {
 	case ProviderAWS:
 		{
-			c.WithRegionName("EU_WEST_1")
+			c.WithRegionName("US_EAST_1")
 		}
 	case ProviderAzure:
 		{
-			c.WithRegionName("EUROPE_NORTH")
+			c.WithRegionName("US_EAST_2")
 		}
 	case ProviderGCP:
 		{
-			c.WithRegionName("WESTERN_EUROPE")
+			c.WithRegionName("CENTRAL_US")
 		}
 	}
+	// Changing provider to tenant as this is shared now
+	c.WithBackingProvider(string(c.Spec.ProviderSettings.ProviderName))
+	c.WithProviderName(ProviderTenant)
 	return c
 }
 

--- a/pkg/api/v1/atlascluster_types.go
+++ b/pkg/api/v1/atlascluster_types.go
@@ -345,6 +345,33 @@ func (c *AtlasCluster) WithRegionName(name string) *AtlasCluster {
 	return c
 }
 
+func (c *AtlasCluster) WithInstanceSize(name string) *AtlasCluster {
+	c.Spec.ProviderSettings.InstanceSizeName = name
+	return c
+}
+
+// Lightweight makes the cluster work with small shared instance M2. This is useful for non-cluster tests (e.g.
+// database users) and saves some money for the company.
+func (c *AtlasCluster) Lightweight() *AtlasCluster {
+	c.WithInstanceSize("M2")
+	// M2 is restricted to some set of regions only - we need to ensure them
+	switch c.Spec.ProviderSettings.ProviderName {
+	case ProviderAWS:
+		{
+			c.WithRegionName("EU_WEST_1")
+		}
+	case ProviderAzure:
+		{
+			c.WithRegionName("EUROPE_NORTH")
+		}
+	case ProviderGCP:
+		{
+			c.WithRegionName("WESTERN_EUROPE")
+		}
+	}
+	return c
+}
+
 func DefaultGCPCluster(namespace, projectName string) *AtlasCluster {
 	return NewCluster(namespace, "test-cluster-gcp-k8s", "test-cluster-gcp").
 		WithProjectName(projectName).

--- a/test/int/dbuser_test.go
+++ b/test/int/dbuser_test.go
@@ -32,7 +32,7 @@ import (
 )
 
 const (
-	DevMode             = true
+	DevMode             = false
 	UserPasswordSecret  = "user-password-secret"
 	DBUserPassword      = "Passw0rd!"
 	UserPasswordSecret2 = "second-user-password-secret"

--- a/test/int/dbuser_test.go
+++ b/test/int/dbuser_test.go
@@ -177,11 +177,11 @@ var _ = Describe("AtlasDatabaseUser", func() {
 					// The user created lacks read/write roles
 					err := tryWrite(createdProject.ID(), *createdClusterAzure, *createdDBUser, "test", "operatortest")
 					Expect(err).To(HaveOccurred())
-					Expect(err.Error()).To(MatchRegexp("not authorized"))
+					Expect(err.Error()).To(MatchRegexp("user is not allowed"))
 
 					err = tryWrite(createdProject.ID(), *createdClusterAWS, *createdDBUser, "test", "operatortest")
 					Expect(err).To(HaveOccurred())
-					Expect(err.Error()).To(MatchRegexp("not authorized"))
+					Expect(err.Error()).To(MatchRegexp("user is not allowed"))
 				})
 			})
 			By("Update database user - give readWrite permissions", func() {

--- a/test/int/dbuser_test.go
+++ b/test/int/dbuser_test.go
@@ -260,7 +260,7 @@ var _ = Describe("AtlasDatabaseUser", func() {
 
 					err := tryWrite(createdProject.ID(), *createdClusterAzure, *secondDBUser, "test", "someNotAllowedCollection")
 					Expect(err).To(HaveOccurred())
-					Expect(err.Error()).To(MatchRegexp("not authorized"))
+					Expect(err.Error()).To(MatchRegexp("user is not allowed"))
 				})
 				By("Removing Second user", func() {
 					Expect(k8sClient.Delete(context.Background(), secondDBUser)).To(Succeed())

--- a/test/int/dbuser_test.go
+++ b/test/int/dbuser_test.go
@@ -143,10 +143,10 @@ var _ = Describe("AtlasDatabaseUser", func() {
 	Describe("Create/Update two users, two clusters", func() {
 		It("They should be created successfully", func() {
 			By("Creating clusters", func() {
-				createdClusterAWS = mdbv1.DefaultAWSCluster(namespace.Name, createdProject.Name)
+				createdClusterAWS = mdbv1.DefaultAWSCluster(namespace.Name, createdProject.Name).Lightweight()
 				Expect(k8sClient.Create(context.Background(), createdClusterAWS)).ToNot(HaveOccurred())
 
-				createdClusterAzure = mdbv1.DefaultAzureCluster(namespace.Name, createdProject.Name)
+				createdClusterAzure = mdbv1.DefaultAzureCluster(namespace.Name, createdProject.Name).Lightweight()
 				Expect(k8sClient.Create(context.Background(), createdClusterAzure)).ToNot(HaveOccurred())
 
 				Eventually(testutil.WaitFor(k8sClient, createdClusterAWS, status.TrueCondition(status.ReadyType), validateClusterCreatingFunc()),
@@ -297,7 +297,7 @@ var _ = Describe("AtlasDatabaseUser", func() {
 				checkNumberOfConnectionSecrets(k8sClient, *createdProject, 0)
 			})
 			By("Creating cluster", func() {
-				createdClusterAWS = mdbv1.DefaultAWSCluster(namespace.Name, createdProject.Name)
+				createdClusterAWS = mdbv1.DefaultAWSCluster(namespace.Name, createdProject.Name).Lightweight()
 				Expect(k8sClient.Create(context.Background(), createdClusterAWS)).ToNot(HaveOccurred())
 
 				// We don't wait for the full cluster creation - only when it has started the process
@@ -330,7 +330,7 @@ var _ = Describe("AtlasDatabaseUser", func() {
 	Describe("Check the password Secret is watched", func() {
 		It("Should succeed", func() {
 			By("Creating clusters", func() {
-				createdClusterAWS = mdbv1.DefaultAWSCluster(namespace.Name, createdProject.Name)
+				createdClusterAWS = mdbv1.DefaultAWSCluster(namespace.Name, createdProject.Name).Lightweight()
 				Expect(k8sClient.Create(context.Background(), createdClusterAWS)).ToNot(HaveOccurred())
 
 				Eventually(testutil.WaitFor(k8sClient, createdClusterAWS, status.TrueCondition(status.ReadyType), validateClusterCreatingFunc()),
@@ -383,10 +383,10 @@ var _ = Describe("AtlasDatabaseUser", func() {
 	Describe("Change database users (make sure all stale secrets are removed)", func() {
 		It("Should succeed", func() {
 			By("Creating AWS and Azure clusters", func() {
-				createdClusterAWS = mdbv1.DefaultAWSCluster(namespace.Name, createdProject.Name)
+				createdClusterAWS = mdbv1.DefaultAWSCluster(namespace.Name, createdProject.Name).Lightweight()
 				Expect(k8sClient.Create(context.Background(), createdClusterAWS)).ToNot(HaveOccurred())
 
-				createdClusterAzure = mdbv1.DefaultAzureCluster(namespace.Name, createdProject.Name)
+				createdClusterAzure = mdbv1.DefaultAzureCluster(namespace.Name, createdProject.Name).Lightweight()
 				Expect(k8sClient.Create(context.Background(), createdClusterAzure)).ToNot(HaveOccurred())
 
 				Eventually(testutil.WaitFor(k8sClient, createdClusterAWS, status.TrueCondition(status.ReadyType), validateClusterCreatingFunc()),
@@ -447,7 +447,7 @@ var _ = Describe("AtlasDatabaseUser", func() {
 	Describe("Check the user expiration", func() {
 		It("Should succeed", func() {
 			By("Creating a AWS cluster", func() {
-				createdClusterAWS = mdbv1.DefaultAWSCluster(namespace.Name, createdProject.Name)
+				createdClusterAWS = mdbv1.DefaultAWSCluster(namespace.Name, createdProject.Name).Lightweight()
 				Expect(k8sClient.Create(context.Background(), createdClusterAWS)).To(Succeed())
 
 				Eventually(testutil.WaitFor(k8sClient, createdClusterAWS, status.TrueCondition(status.ReadyType), validateClusterCreatingFunc()),

--- a/test/int/dbuser_test.go
+++ b/test/int/dbuser_test.go
@@ -32,12 +32,13 @@ import (
 )
 
 const (
-	DevMode             = false
+	DevMode             = true
 	UserPasswordSecret  = "user-password-secret"
 	DBUserPassword      = "Passw0rd!"
 	UserPasswordSecret2 = "second-user-password-secret"
 	DBUserPassword2     = "H@lla#!"
-	DBUserUpdateTimeout = 100
+	// M2 clusters take longer time to apply changes
+	DBUserUpdateTimeout = 150
 )
 
 var _ = Describe("AtlasDatabaseUser", func() {

--- a/test/int/project_test.go
+++ b/test/int/project_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	ProjectCreationTimeout = 30
+	ProjectCreationTimeout = 40
 )
 
 var _ = Describe("AtlasProject", func() {


### PR DESCRIPTION
Using M2 cluster instances for user integration tests

As a result of this optimization the tests finish in 10 minutes instead of 20