### PR TITLE
Update yq to version 4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ uninstall: manifests kustomize ## Uninstall CRDs from a cluster
 
 .PHONY: deploy
 deploy: run-kind ## Deploy controller in the configured Kubernetes cluster in ~/.kube/config
-	@ act -j deploy -s KUBE_CONFIG_DATA='$(shell kind get kubeconfig | yq r - -j)'
+	@ act -j deploy -s KUBE_CONFIG_DATA='$(shell kind get kubeconfig | yq eval -j )'
 
 .PHONY: manifests
 # Produce CRDs that work back to Kubernetes 1.16 (so 'apiVersion: apiextensions.k8s.io/v1')


### PR DESCRIPTION
The latest V4 version of `yq` has new syntax,
this small change fixes issues caused by the migration.

Along with this change local `yq` should be updated to the latest release.
This can be done via brew: `brew upgrade yq` (https://pypi.org/project/yq/)

P.S. there is a solution which doesn't involve the update. The use of V3 is not recommended but possible.
In case V3 syntax is left as it is I suggest to update `start-guide.md` with: `brew install yq@3`