### PR TITLE
Optionally logging HTTP request body

### DIFF
--- a/pkg/util/httputil/loggedclient.go
+++ b/pkg/util/httputil/loggedclient.go
@@ -1,6 +1,9 @@
 package httputil
 
 import (
+	"bytes"
+	"encoding/json"
+	"io"
 	"net/http"
 	"time"
 
@@ -10,18 +13,22 @@ import (
 // LoggingTransport is the option adding logging capability to an http Client
 func LoggingTransport(log *zap.SugaredLogger) ClientOpt {
 	return func(c *http.Client) error {
-		c.Transport = &loggedRoundTripper{rt: c.Transport, log: log}
+		c.Transport = &loggedRoundTripper{rt: c.Transport, log: log, logBody: false}
 		return nil
 	}
 }
 
 type loggedRoundTripper struct {
-	rt  http.RoundTripper
-	log *zap.SugaredLogger
+	rt      http.RoundTripper
+	log     *zap.SugaredLogger
+	logBody bool
 }
 
 func (l *loggedRoundTripper) RoundTrip(request *http.Request) (*http.Response, error) {
 	startTime := time.Now()
+	if l.logBody && request.Body != nil {
+		l.writeBodyToLog(request.GetBody)
+	}
 	response, err := l.rt.RoundTrip(request)
 	duration := time.Since(startTime)
 	l.logResponse(request, response, err, duration)
@@ -37,4 +44,26 @@ func (l loggedRoundTripper) logResponse(req *http.Request, res *http.Response, e
 	} else {
 		l.log.Debugf("HTTP Request (%s) %s [time (ms): %d, status: %d]", req.Method, req.URL, duration, res.StatusCode)
 	}
+}
+
+func (l loggedRoundTripper) writeBodyToLog(body func() (io.ReadCloser, error)) {
+	bodyCopy, err := body()
+	if err != nil {
+		l.log.Error(err)
+		return
+	}
+	buf := new(bytes.Buffer)
+	_, err = buf.ReadFrom(bodyCopy)
+	if err != nil {
+		l.log.Errorf("Failed to read to buffer: %s", err)
+		return
+	}
+	var prettyJSON bytes.Buffer
+	err = json.Indent(&prettyJSON, buf.Bytes(), "", "\t")
+	if err != nil {
+		l.log.Errorf("JSON parse error: %s", err)
+		return
+	}
+
+	l.log.Debugf(">> \n%s \n", prettyJSON.String())
 }


### PR DESCRIPTION
This PR adds the capability to log all non-empty request bodies sent to Atlas. This flag is hardcoded in the code and serves solely for dev/debugging purposes. One use case is when we need to intercept some API calls we make to Atlas to file HELP tickets. This allows to reproduce the payload we send to them.