### PR TITLE
Fix "make deploy"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,8 +87,8 @@ uninstall: manifests kustomize ## Uninstall CRDs from a cluster
 	$(KUSTOMIZE) build config/crd | kubectl delete -f -
 
 .PHONY: deploy
-deploy: run-kind ## Deploy controller in the configured Kubernetes cluster in ~/.kube/config
-	@ act -j deploy -s KUBE_CONFIG_DATA='$(shell kind get kubeconfig | yq eval -j )'
+deploy: generate manifests run-kind ## Deploy controller in the configured Kubernetes cluster in ~/.kube/config
+	@./scripts/deploy.sh
 
 .PHONY: manifests
 # Produce CRDs that work back to Kubernetes 1.16 (so 'apiVersion: apiextensions.k8s.io/v1')

--- a/docs/dev/start-guide.md
+++ b/docs/dev/start-guide.md
@@ -16,8 +16,10 @@ pre-commit install # from the root of the project
 1. Copy the default Github Actions environment for local run: `cp .env.sample .env`
 1. Update the .actrc - specify your Atlas connectivity data (orgId, keys)
 1. Build and deploy the Operator into the K8s cluster: `make deploy`
-1. Create an AtlasProject: `kubectl apply -f config/samples/atlasproject.yaml` (note, that the secret `my-atlas-key` is
+1. Create an AtlasProject: `kubectl apply -f config/samples/atlas_v1_atlasproject.yaml` (note, that Atlas connection secrets are
  created during running `make deploy`)
+1. Create an AtlasCluster: `kubectl apply -f config/samples/atlas_v1_atlascluster.yaml`
+1. Create an AtlasDatabaseUser: `kubectl apply -f config/samples/atlas_v1_atlasdatabaseuser.yaml`
    
 Some more details about using `act` can be found in [HOWTO.md](../../.github/HOWTO.md)
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+set -eou pipefail
+
+kubectl version
+
+image="localhost:5000/mongodb-atlas-kubernetes-operator"
+docker build -t "${image}" .
+docker push "${image}"
+
+#Prepare CRDs
+controller-gen crd:crdVersions=v1 rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+
+#Installing the CRD,Operator,Role
+ns=mongodb-atlas-system
+kubectl delete deployment mongodb-atlas-operator -n "${ns}" || true # temporary
+cd config/manager && kustomize edit set image controller="${image}"
+cd - && kustomize build --load-restrictor LoadRestrictionsNone config/release/dev/allinone | kubectl apply -f -
+
+# Ensuring the Atlas credentials Secret
+public_key=$(grep "ATLAS_PUBLIC_KEY" .actrc | cut -d "=" -f 2)
+private_key=$(grep "ATLAS_PRIVATE_KEY" .actrc | cut -d "=" -f 2)
+org_id=$(grep "ATLAS_ORG_ID" .actrc | cut -d "=" -f 2)
+
+# both global and project keys
+kubectl delete secrets my-atlas-key --ignore-not-found -n "${ns}"
+kubectl create secret generic my-atlas-key --from-literal="orgId=${org_id}" --from-literal="publicApiKey=${public_key}" --from-literal="privateApiKey=${private_key}" -n "${ns}"
+kubectl delete secrets mongodb-atlas-operator-api-key --ignore-not-found -n "${ns}"
+kubectl create secret generic mongodb-atlas-operator-api-key --from-literal="orgId=${org_id}" --from-literal="publicApiKey=${public_key}" --from-literal="privateApiKey=${private_key}" -n "${ns}"
+
+label="app.kubernetes.io/instance=mongodb-atlas-kubernetes-operator"
+# Wait for the Operator to start
+cmd="while ! kubectl -n ${ns} get pods -l $label -o jsonpath={.items[0].status.phase} 2>/dev/null | grep -q Running ; do printf .; sleep 1; done"
+timeout --foreground "1m" bash -c "${cmd}" || true
+if ! kubectl -n "${ns}" get pods -l "$label" -o 'jsonpath="{.items[0].status.phase}"' | grep -q "Running"; then
+    echo "Operator hasn't reached RUNNING state after 1 minute. The full yaml configuration for the pod is:"
+    kubectl -n "${ns}" get pods -l "$label" -o yaml
+
+    echo "Operator failed to start, exiting"
+    exit 1
+fi


### PR DESCRIPTION
Our `make deploy` is broken - for some reasons `act -j ..` doesn't work for local custom actions.
Changed this to a script directly - this is anyway faster than calling `act`