### PR TITLE
CLOUDP-87735: global secret configuration

### DIFF
--- a/main.go
+++ b/main.go
@@ -89,14 +89,12 @@ func main() {
 		os.Exit(1)
 	}
 
-	operatorPod := operatorDeploymentObjectKey()
-
 	if err = (&atlascluster.AtlasClusterReconciler{
-		Client:                 mgr.GetClient(),
-		Log:                    logger.Named("controllers").Named("AtlasCluster").Sugar(),
-		Scheme:                 mgr.GetScheme(),
-		AtlasDomain:            config.AtlasDomain,
-		OperatorDeploymentName: operatorPod,
+		Client:          mgr.GetClient(),
+		Log:             logger.Named("controllers").Named("AtlasCluster").Sugar(),
+		Scheme:          mgr.GetScheme(),
+		AtlasDomain:     config.AtlasDomain,
+		GlobalAPISecret: config.GlobalAPISecret,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "AtlasCluster")
 		os.Exit(1)
@@ -108,7 +106,7 @@ func main() {
 		Scheme:          mgr.GetScheme(),
 		AtlasDomain:     config.AtlasDomain,
 		ResourceWatcher: watch.NewResourceWatcher(),
-		OperatorPod:     operatorPod,
+		GlobalAPISecret: config.GlobalAPISecret,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "AtlasProject")
 		os.Exit(1)
@@ -120,7 +118,7 @@ func main() {
 		Scheme:          mgr.GetScheme(),
 		AtlasDomain:     config.AtlasDomain,
 		ResourceWatcher: watch.NewResourceWatcher(),
-		OperatorPod:     operatorPod,
+		GlobalAPISecret: config.GlobalAPISecret,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "AtlasDatabaseUser")
 		os.Exit(1)
@@ -149,19 +147,25 @@ type Config struct {
 	MetricsAddr          string
 	WatchedNamespaces    string
 	ProbeAddr            string
+	GlobalAPISecret      client.ObjectKey
 }
 
 // ParseConfiguration fills the 'OperatorConfig' from the flags passed to the program
 func parseConfiguration(log *zap.SugaredLogger) Config {
+	var globalAPISecretName string
 	config := Config{}
 	flag.StringVar(&config.AtlasDomain, "atlas-domain", "https://cloud.mongodb.com", "the Atlas URL domain name (no slash in the end).")
 	flag.StringVar(&config.MetricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&config.ProbeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
+	flag.StringVar(&globalAPISecretName, "global-api-secret-name", "", "The name of the Secret that contains Atlas API keys. "+
+		"It is used by the Operator if AtlasProject configuration doesn't contain API key reference. Defaults to <deployment_name>-api-key.")
 	flag.BoolVar(&config.EnableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
 
 	flag.Parse()
+
+	config.GlobalAPISecret = operatorGlobalKeySecretOrDefault(globalAPISecretName)
 
 	// dev note: we pass the watched namespace as the env variable to use the Kubernetes Downward API. Unfortunately
 	// there is no way to use it for container arguments
@@ -173,18 +177,23 @@ func parseConfiguration(log *zap.SugaredLogger) Config {
 	return config
 }
 
-func operatorDeploymentObjectKey() client.ObjectKey {
-	operatorPodName := os.Getenv("OPERATOR_POD_NAME")
-	if operatorPodName == "" {
-		log.Fatal(`"OPERATOR_POD_NAME" environment variable must be set!`)
+func operatorGlobalKeySecretOrDefault(secretNameOverride string) client.ObjectKey {
+	secretName := secretNameOverride
+	if secretName == "" {
+		operatorPodName := os.Getenv("OPERATOR_POD_NAME")
+		if operatorPodName == "" {
+			log.Fatal(`"OPERATOR_POD_NAME" environment variable must be set!`)
+		}
+		deploymentName, err := kube.ParseDeploymentNameFromPodName(operatorPodName)
+		if err != nil {
+			log.Fatalf(`Failed to get Operator Deployment name from "OPERATOR_POD_NAME" environment variable: %s`, err.Error())
+		}
+		secretName = deploymentName + "-api-key"
 	}
 	operatorNamespace := os.Getenv("OPERATOR_NAMESPACE")
 	if operatorNamespace == "" {
 		log.Fatal(`"OPERATOR_NAMESPACE" environment variable must be set!`)
 	}
-	deploymentName, err := kube.ParseDeploymentNameFromPodName(operatorPodName)
-	if err != nil {
-		log.Fatalf(`Failed to get Operator Deployment name from "OPERATOR_POD_NAME" environment variable: %s`, err.Error())
-	}
-	return client.ObjectKey{Namespace: operatorNamespace, Name: deploymentName}
+
+	return client.ObjectKey{Namespace: operatorNamespace, Name: secretName}
 }

--- a/pkg/controller/atlas/connection.go
+++ b/pkg/controller/atlas/connection.go
@@ -7,8 +7,6 @@ import (
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/util/kube"
 )
 
 const (
@@ -26,14 +24,13 @@ type Connection struct {
 
 // ReadConnection reads Atlas API connection parameters from AtlasProject Secret or from the default Operator one if the
 // former is not specified
-func ReadConnection(log *zap.SugaredLogger, kubeClient client.Client, operatorDeployment client.ObjectKey, projectOverrideSecretRef *client.ObjectKey) (Connection, error) {
+func ReadConnection(log *zap.SugaredLogger, kubeClient client.Client, operatorAPISecret client.ObjectKey, projectOverrideSecretRef *client.ObjectKey) (Connection, error) {
 	if projectOverrideSecretRef != nil {
 		// TODO is it possible that part of connection (like orgID is still in the Operator level secret and needs to get merged?)
 		log.Infof("Reading Atlas API credentials from the AtlasProject Secret %s", projectOverrideSecretRef)
 		return readAtlasConnectionFromSecret(kubeClient, *projectOverrideSecretRef)
 	}
 
-	operatorAPISecret := kube.ObjectKey(operatorDeployment.Namespace, operatorDeployment.Name+"-api-key")
 	log.Debugf("AtlasProject connection Secret is not specified - using the Operator one: %v", operatorAPISecret)
 	return readAtlasConnectionFromSecret(kubeClient, operatorAPISecret)
 }

--- a/pkg/controller/atlascluster/atlascluster_controller.go
+++ b/pkg/controller/atlascluster/atlascluster_controller.go
@@ -44,11 +44,11 @@ import (
 
 // AtlasClusterReconciler reconciles an AtlasCluster object
 type AtlasClusterReconciler struct {
-	Client                 client.Client
-	Log                    *zap.SugaredLogger
-	Scheme                 *runtime.Scheme
-	AtlasDomain            string
-	OperatorDeploymentName client.ObjectKey
+	Client          client.Client
+	Log             *zap.SugaredLogger
+	Scheme          *runtime.Scheme
+	AtlasDomain     string
+	GlobalAPISecret client.ObjectKey
 }
 
 // +kubebuilder:rbac:groups=atlas.mongodb.com,resources=atlasclusters,verbs=get;list;watch;create;update;patch;delete
@@ -76,7 +76,7 @@ func (r *AtlasClusterReconciler) Reconcile(context context.Context, req ctrl.Req
 		return result.ReconcileResult(), nil
 	}
 
-	connection, err := atlas.ReadConnection(log, r.Client, r.OperatorDeploymentName, project.ConnectionSecretObjectKey())
+	connection, err := atlas.ReadConnection(log, r.Client, r.GlobalAPISecret, project.ConnectionSecretObjectKey())
 	if err != nil {
 		result := workflow.Terminate(workflow.AtlasCredentialsNotProvided, err.Error())
 		ctx.SetConditionFromResult(status.ClusterReadyType, result)
@@ -180,7 +180,7 @@ func (r *AtlasClusterReconciler) Delete(e event.DeleteEvent) error {
 }
 
 func (r *AtlasClusterReconciler) deleteClusterFromAtlas(cluster *mdbv1.AtlasCluster, project *mdbv1.AtlasProject, log *zap.SugaredLogger) error {
-	connection, err := atlas.ReadConnection(log, r.Client, r.OperatorDeploymentName, project.ConnectionSecretObjectKey())
+	connection, err := atlas.ReadConnection(log, r.Client, r.GlobalAPISecret, project.ConnectionSecretObjectKey())
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/atlasdatabaseuser/atlasdatabaseuser_controller.go
+++ b/pkg/controller/atlasdatabaseuser/atlasdatabaseuser_controller.go
@@ -45,11 +45,11 @@ import (
 // AtlasDatabaseUserReconciler reconciles an AtlasDatabaseUser object
 type AtlasDatabaseUserReconciler struct {
 	watch.ResourceWatcher
-	Client      client.Client
-	Log         *zap.SugaredLogger
-	Scheme      *runtime.Scheme
-	AtlasDomain string
-	OperatorPod client.ObjectKey
+	Client          client.Client
+	Log             *zap.SugaredLogger
+	Scheme          *runtime.Scheme
+	AtlasDomain     string
+	GlobalAPISecret client.ObjectKey
 }
 
 // +kubebuilder:rbac:groups=atlas.mongodb.com,resources=atlasdatabaseusers,verbs=get;list;watch;create;update;patch;delete
@@ -83,7 +83,7 @@ func (r *AtlasDatabaseUserReconciler) Reconcile(context context.Context, req ctr
 		return result.ReconcileResult(), nil
 	}
 
-	connection, err := atlas.ReadConnection(log, r.Client, r.OperatorPod, project.ConnectionSecretObjectKey())
+	connection, err := atlas.ReadConnection(log, r.Client, r.GlobalAPISecret, project.ConnectionSecretObjectKey())
 	if err != nil {
 		result := workflow.Terminate(workflow.AtlasCredentialsNotProvided, err.Error())
 		ctx.SetConditionFromResult(status.DatabaseUserReadyType, result)
@@ -167,7 +167,7 @@ func (r AtlasDatabaseUserReconciler) Delete(e event.DeleteEvent) error {
 }
 
 func (r AtlasDatabaseUserReconciler) deleteUserFromAtlas(dbUser *mdbv1.AtlasDatabaseUser, project *mdbv1.AtlasProject, log *zap.SugaredLogger) error {
-	connection, err := atlas.ReadConnection(log, r.Client, r.OperatorPod, project.ConnectionSecretObjectKey())
+	connection, err := atlas.ReadConnection(log, r.Client, r.GlobalAPISecret, project.ConnectionSecretObjectKey())
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/atlasproject/atlasproject_controller.go
+++ b/pkg/controller/atlasproject/atlasproject_controller.go
@@ -46,10 +46,10 @@ import (
 type AtlasProjectReconciler struct {
 	Client client.Client
 	watch.ResourceWatcher
-	Log         *zap.SugaredLogger
-	Scheme      *runtime.Scheme
-	AtlasDomain string
-	OperatorPod client.ObjectKey
+	Log             *zap.SugaredLogger
+	Scheme          *runtime.Scheme
+	AtlasDomain     string
+	GlobalAPISecret client.ObjectKey
 }
 
 // Dev note: duplicate the permissions in both sections below to generate both Role and ClusterRoles
@@ -83,7 +83,7 @@ func (r *AtlasProjectReconciler) Reconcile(context context.Context, req ctrl.Req
 	// This update will make sure the status is always updated in case of any errors or successful result
 	defer statushandler.Update(ctx, r.Client, project)
 
-	connection, err := atlas.ReadConnection(log, r.Client, r.OperatorPod, project.ConnectionSecretObjectKey())
+	connection, err := atlas.ReadConnection(log, r.Client, r.GlobalAPISecret, project.ConnectionSecretObjectKey())
 	if err != nil {
 		result := workflow.Terminate(workflow.AtlasCredentialsNotProvided, err.Error())
 		ctx.SetConditionFromResult(status.ProjectReadyType, result)
@@ -131,7 +131,7 @@ func (r *AtlasProjectReconciler) Delete(e event.DeleteEvent) error {
 		return nil
 	}
 
-	connection, err := atlas.ReadConnection(log, r.Client, r.OperatorPod, project.ConnectionSecretObjectKey())
+	connection, err := atlas.ReadConnection(log, r.Client, r.GlobalAPISecret, project.ConnectionSecretObjectKey())
 	if err != nil {
 		return err
 	}

--- a/test/int/integration_suite_test.go
+++ b/test/int/integration_suite_test.go
@@ -189,7 +189,7 @@ func prepareControllers() {
 		Log:             logger.Named("controllers").Named("AtlasProject").Sugar(),
 		AtlasDomain:     "https://cloud-qa.mongodb.com",
 		ResourceWatcher: watch.NewResourceWatcher(),
-		GlobalAPISecret: kube.ObjectKey(namespace.Name, "atlas-operator"),
+		GlobalAPISecret: kube.ObjectKey(namespace.Name, "atlas-operator-api-key"),
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
@@ -197,7 +197,7 @@ func prepareControllers() {
 		Client:          k8sManager.GetClient(),
 		Log:             logger.Named("controllers").Named("AtlasCluster").Sugar(),
 		AtlasDomain:     "https://cloud-qa.mongodb.com",
-		GlobalAPISecret: kube.ObjectKey(namespace.Name, "atlas-operator"),
+		GlobalAPISecret: kube.ObjectKey(namespace.Name, "atlas-operator-api-key"),
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
@@ -206,7 +206,7 @@ func prepareControllers() {
 		Log:             logger.Named("controllers").Named("AtlasDatabaseUser").Sugar(),
 		AtlasDomain:     "https://cloud-qa.mongodb.com",
 		ResourceWatcher: watch.NewResourceWatcher(),
-		GlobalAPISecret: kube.ObjectKey(namespace.Name, "atlas-operator"),
+		GlobalAPISecret: kube.ObjectKey(namespace.Name, "atlas-operator-api-key"),
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 

--- a/test/int/integration_suite_test.go
+++ b/test/int/integration_suite_test.go
@@ -189,15 +189,15 @@ func prepareControllers() {
 		Log:             logger.Named("controllers").Named("AtlasProject").Sugar(),
 		AtlasDomain:     "https://cloud-qa.mongodb.com",
 		ResourceWatcher: watch.NewResourceWatcher(),
-		OperatorPod:     kube.ObjectKey(namespace.Name, "atlas-operator"),
+		GlobalAPISecret: kube.ObjectKey(namespace.Name, "atlas-operator"),
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
 	err = (&atlascluster.AtlasClusterReconciler{
-		Client:                 k8sManager.GetClient(),
-		Log:                    logger.Named("controllers").Named("AtlasCluster").Sugar(),
-		AtlasDomain:            "https://cloud-qa.mongodb.com",
-		OperatorDeploymentName: kube.ObjectKey(namespace.Name, "atlas-operator"),
+		Client:          k8sManager.GetClient(),
+		Log:             logger.Named("controllers").Named("AtlasCluster").Sugar(),
+		AtlasDomain:     "https://cloud-qa.mongodb.com",
+		GlobalAPISecret: kube.ObjectKey(namespace.Name, "atlas-operator"),
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
@@ -206,7 +206,7 @@ func prepareControllers() {
 		Log:             logger.Named("controllers").Named("AtlasDatabaseUser").Sugar(),
 		AtlasDomain:     "https://cloud-qa.mongodb.com",
 		ResourceWatcher: watch.NewResourceWatcher(),
-		OperatorPod:     kube.ObjectKey(namespace.Name, "atlas-operator"),
+		GlobalAPISecret: kube.ObjectKey(namespace.Name, "atlas-operator"),
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 

--- a/test/int/project_test.go
+++ b/test/int/project_test.go
@@ -82,7 +82,7 @@ var _ = Describe("AtlasProject", func() {
 		Expect(createdProject.Status.ObservedGeneration).To(Equal(createdProject.Generation))
 	}
 
-	Describe("Creating the project", func() {
+	FDescribe("Creating the project", func() {
 		It("Should Succeed", func() {
 			expectedProject := mdbv1.DefaultProject(namespace.Name, connectionSecret.Name)
 			createdProject.ObjectMeta = expectedProject.ObjectMeta

--- a/test/int/project_test.go
+++ b/test/int/project_test.go
@@ -82,7 +82,7 @@ var _ = Describe("AtlasProject", func() {
 		Expect(createdProject.Status.ObservedGeneration).To(Equal(createdProject.Generation))
 	}
 
-	FDescribe("Creating the project", func() {
+	Describe("Creating the project", func() {
 		It("Should Succeed", func() {
 			expectedProject := mdbv1.DefaultProject(namespace.Name, connectionSecret.Name)
 			createdProject.ObjectMeta = expectedProject.ObjectMeta


### PR DESCRIPTION
This PR allows the user to override the global API key Secret by passing the `global-api-secret-name` argument to the container. If the flag not provided - the name defaults to the `<deployment_name>-api-key`

As this cannot be tested by integration tests I've tested this manually: changed the deployment spec to the following:

```
- args:
          - --atlas-domain=https://cloud-qa.mongodb.com
          - --health-probe-bind-address=:8081
          - --metrics-bind-address=127.0.0.1:8080
          - --leader-elect
          - --global-api-secret-name=the-global-key
          command:
          - /manager
 ```

and ensured, that the new Secret was used by the Operator instead of the default one