### PR TITLE
CLOUDP-88737: Do not try to delete non-existing Atlas projects

### DIFF
--- a/pkg/controller/atlasproject/atlasproject_controller.go
+++ b/pkg/controller/atlasproject/atlasproject_controller.go
@@ -134,7 +134,7 @@ func (r *AtlasProjectReconciler) Delete(e event.DeleteEvent) error {
 	log.Infow("-> Starting AtlasProject deletion", "spec", project.Spec)
 
 	if project.Status.ID == "" {
-		log.Infof("Project does not exist, nothing to remove")
+		log.Infof("Project does not exist in Atlas, nothing to remove")
 		return nil
 	}
 

--- a/pkg/controller/atlasproject/atlasproject_controller.go
+++ b/pkg/controller/atlasproject/atlasproject_controller.go
@@ -133,6 +133,11 @@ func (r *AtlasProjectReconciler) Delete(e event.DeleteEvent) error {
 	log := r.Log.With("atlasproject", kube.ObjectKeyFromObject(project))
 	log.Infow("-> Starting AtlasProject deletion", "spec", project.Spec)
 
+	if project.Status.ID == "" {
+		log.Infof("Project does not exist, nothing to remove")
+		return nil
+	}
+
 	if customresource.ResourceShouldBeLeftInAtlas(project) {
 		log.Infof("Not removing the Atlas Project from Atlas as the '%s' annotation is set", customresource.ResourcePolicyAnnotation)
 		return nil
@@ -155,7 +160,7 @@ func (r *AtlasProjectReconciler) Delete(e event.DeleteEvent) error {
 			_, err = atlasClient.Projects.Delete(context.Background(), project.Status.ID)
 			var apiError *mongodbatlas.ErrorResponse
 			if errors.As(err, &apiError) && apiError.ErrorCode == atlas.NotInGroup {
-				log.Infow("Project doesn't exist or is already deleted", "projectID", project.Status.ID)
+				log.Infow("Project is already deleted", "projectID", project.Status.ID)
 				return
 			}
 


### PR DESCRIPTION
I've added an extra check in the Delete method for Projects.

- I thought it makes sense to have this new check right after the first function comment
(so it is clear that that's a part of delete process)
- No error is thrown