### PR TITLE
CLOUDP-86954: remove kube-proxy

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -24,7 +24,9 @@ spec:
       - command:
         - /manager
         args:
-        - --leader-elect
+        - "--leader-elect"
+        - "--health-probe-bind-address=:8081"
+        - "--metrics-bind-address=127.0.0.1:8080"
         image: controller:latest
         name: manager
         securityContext:

--- a/config/release/base/allinone/kustomization.yaml
+++ b/config/release/base/allinone/kustomization.yaml
@@ -9,6 +9,6 @@ commonLabels:
   app.kubernetes.io/instance: mongodb-atlas-kubernetes-operator
 
 resources:
-- ../../../managerwithproxy
+- ../../../manager
 - ../../../crd
 - ../../../rbac/clusterwide

--- a/config/release/base/clusterwide/kustomization.yaml
+++ b/config/release/base/clusterwide/kustomization.yaml
@@ -9,5 +9,5 @@ commonLabels:
   app.kubernetes.io/instance: mongodb-atlas-kubernetes-operator
 
 resources:
-- ../../../managerwithproxy
+- ../../../manager
 - ../../../rbac/clusterwide

--- a/config/release/base/namespaced/kustomization.yaml
+++ b/config/release/base/namespaced/kustomization.yaml
@@ -9,7 +9,7 @@ commonLabels:
   app.kubernetes.io/instance: mongodb-atlas-kubernetes-operator
 
 resources:
-- ../../../managerwithproxy
+- ../../../manager
 - ../../../rbac/namespaced
 
 patches:

--- a/config/release/base/namespaced/manager_watched_namespace_patch.json
+++ b/config/release/base/namespaced/manager_watched_namespace_patch.json
@@ -1,6 +1,6 @@
 [
   {"op": "add",
-    "path": "/spec/template/spec/containers/1/env/0",
+    "path": "/spec/template/spec/containers/0/env/0",
     "value": {
       "name": "WATCH_NAMESPACE",
       "valueFrom": {

--- a/config/release/dev/dev_patch.json
+++ b/config/release/dev/dev_patch.json
@@ -1,6 +1,6 @@
 [
   {"op": "add",
-    "path": "/spec/template/spec/containers/1/args/0",
+    "path": "/spec/template/spec/containers/0/args/0",
     "value": "--atlas-domain=https://cloud-qa.mongodb.com"
   }
 ]

--- a/config/release/prod/prod_patch.json
+++ b/config/release/prod/prod_patch.json
@@ -1,6 +1,6 @@
 [
   {"op": "add",
-    "path": "/spec/template/spec/containers/1/args/0",
+    "path": "/spec/template/spec/containers/0/args/0",
     "value": "--atlas-domain=https://cloud.mongodb.com"
   }
 ]

--- a/deploy/all-in-one.yaml
+++ b/deploy/all-in-one.yaml
@@ -1114,16 +1114,6 @@ spec:
     spec:
       containers:
       - args:
-        - --secure-listen-address=0.0.0.0:8443
-        - --upstream=http://127.0.0.1:8080/
-        - --logtostderr=true
-        - --v=10
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
-        name: kube-rbac-proxy
-        ports:
-        - containerPort: 8443
-          name: https
-      - args:
         - --atlas-domain=https://cloud.mongodb.com
         - --health-probe-bind-address=:8081
         - --metrics-bind-address=127.0.0.1:8080

--- a/deploy/clusterwide/clusterwide-config.yaml
+++ b/deploy/clusterwide/clusterwide-config.yaml
@@ -250,16 +250,6 @@ spec:
     spec:
       containers:
       - args:
-        - --secure-listen-address=0.0.0.0:8443
-        - --upstream=http://127.0.0.1:8080/
-        - --logtostderr=true
-        - --v=10
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
-        name: kube-rbac-proxy
-        ports:
-        - containerPort: 8443
-          name: https
-      - args:
         - --atlas-domain=https://cloud.mongodb.com
         - --health-probe-bind-address=:8081
         - --metrics-bind-address=127.0.0.1:8080

--- a/deploy/namespaced/namespaced-config.yaml
+++ b/deploy/namespaced/namespaced-config.yaml
@@ -254,16 +254,6 @@ spec:
     spec:
       containers:
       - args:
-        - --secure-listen-address=0.0.0.0:8443
-        - --upstream=http://127.0.0.1:8080/
-        - --logtostderr=true
-        - --v=10
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
-        name: kube-rbac-proxy
-        ports:
-        - containerPort: 8443
-          name: https
-      - args:
         - --atlas-domain=https://cloud.mongodb.com
         - --health-probe-bind-address=:8081
         - --metrics-bind-address=127.0.0.1:8080


### PR DESCRIPTION
Removing the container for kube-proxy
Note, that we usually don't change the configs in `deploy` directory manually - this is done during the release.
But now I've decided to do it as this will fix the critical error for the users. Also the previous release 0.5.0 will still have kube-proxy - so we are changing the "dev" version only