### PR TITLE
Refactor to use Builder package and filter namespaces with Predicates

### DIFF
--- a/main.go
+++ b/main.go
@@ -96,7 +96,7 @@ func main() {
 	}
 
 	if err = builder.ControllerManagedBy(mgr).
-		For(&mdbv1.AtlasCluster{}, builder.WithPredicates(config.WatchedNamespaces)).
+		For(&mdbv1.AtlasCluster{}, builder.WithPredicates(watch.CommonPredicates(), config.WatchedNamespaces)).
 		Complete(&atlascluster.AtlasClusterReconciler{
 			Client:          mgr.GetClient(),
 			Log:             logger.Named("controllers").Named("AtlasCluster").Sugar(),
@@ -110,7 +110,7 @@ func main() {
 	}
 
 	if err = builder.ControllerManagedBy(mgr).
-		For(&mdbv1.AtlasProject{}, builder.WithPredicates(config.WatchedNamespaces)).
+		For(&mdbv1.AtlasProject{}, builder.WithPredicates(watch.CommonPredicates(), config.WatchedNamespaces)).
 		Complete(&atlasproject.AtlasProjectReconciler{
 			Client:          mgr.GetClient(),
 			Log:             logger.Named("controllers").Named("AtlasProject").Sugar(),
@@ -125,7 +125,7 @@ func main() {
 	}
 
 	if err = builder.ControllerManagedBy(mgr).
-		For(&mdbv1.AtlasDatabaseUser{}, builder.WithPredicates(config.WatchedNamespaces)).
+		For(&mdbv1.AtlasDatabaseUser{}, builder.WithPredicates(watch.CommonPredicates(), config.WatchedNamespaces)).
 		Complete(&atlasdatabaseuser.AtlasDatabaseUserReconciler{
 			Client:          mgr.GetClient(),
 			Log:             logger.Named("controllers").Named("AtlasDatabaseUser").Sugar(),


### PR DESCRIPTION
I was going to use a [`MultiNamespaceCache`] to enable cross namespace watching, but after looking into it more there are some performance warnings when using a large number of namespaces and a preference for using [`Predicates`] for including/excluding namespaces.

Swapping to the builder pattern aligns with the expected use of `controller-runtime` from what I can tell and makes it very easy to leverage [`Predicates`], model `parent-child` references, and other commons tasks besides.

Since this may be a somewhat significant change I did a review of features that may be better implemented using the common flow of [`Predicates`]:

1. https://github.com/mongodb/mongodb-atlas-kubernetes/pull/272 could be done by adding a predicate to disable listening.
2. https://github.com/mongodb/mongodb-atlas-kubernetes/pull/213/files added +200 lines to the code base, but may have been implemented with a [`Predicate`] based on `Delete` requests that ignores the request if the label exists.
3. https://github.com/mongodb/mongodb-atlas-kubernetes/issues/270 works fine if you watch all namespaces, but if you want to restrict namespaces it doesn't because you can't find the Global API Key. This PR fixes that issue using predicates.

Using the controller [`Builder`] package also connects you to other facets of `controller-runtime` that you may be interested in pursuing. For instance you can define `Owns` relationships between `AtlasClusters` and `ConnectionSecrets` so that the controller knows to garbage collect `ConnectionSecrets` if the owner disappears. ([Docs](https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.9.2/pkg/builder#Builder.Owns)) Or just separating the control logic for `ConnectionSecrets` into their own controller.

I hope this is helpful! Thank you for letting me review your project and let me know if there was a reason for the previous code and I can close this PR. If you can't tell we're very excited about your work :)


[`Predicate`]: https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.9.2/pkg/predicate
[`Predicates`]: https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.9.2/pkg/predicate
[`MultiNamespaceCache`]: https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.9.2/pkg/cache#MultiNamespacedCacheBuilder
[`Builder`]: https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/builder