### PR TITLE
Using helm charts as submodules

### DIFF
--- a/.github/actions/int-test/Dockerfile
+++ b/.github/actions/int-test/Dockerfile
@@ -1,5 +1,6 @@
 FROM golang:1.15
 
+ENV GO111MODULE=on
 
 # Download binaries for envtets (api-server, etcd)
 RUN curl -Lo setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.8.0/hack/setup-envtest.sh && \
@@ -7,7 +8,7 @@ RUN curl -Lo setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/
     /bin/bash -c "source setup-envtest.sh && fetch_envtest_tools /usr/local/kubebuilder"
 
 RUN go get github.com/onsi/ginkgo/ginkgo && \
-   go get github.com/onsi/gomega/...
+    go get github.com/onsi/gomega/...
 
 COPY entrypoint.sh /home/entrypoint.sh
 RUN chmod +x /home/entrypoint.sh

--- a/.github/workflows/test-forked.yml
+++ b/.github/workflows/test-forked.yml
@@ -4,7 +4,7 @@ on:
   pull_request_target:
     types: [labeled]
     paths-ignore:
-      - 'docs/**'
+      - "docs/**"
 
 jobs:
   allowed:
@@ -127,7 +127,14 @@ jobs:
         # k8s: ["1.17-kind", "1.19-kind", "1.17-opeshift"] # <supported platform version>-<platform>
         k8s: ["v1.18.15-kind"] # <K8sGitVersion>-<Platform>
         test:
-          ["cluster-ns", "cluster-wide", "bundle-test", "helm-ns", "helm-wide", "helm-update"]
+          [
+            "cluster-ns",
+            "cluster-wide",
+            "bundle-test",
+            "helm-ns",
+            "helm-wide",
+            "helm-update",
+          ]
         include:
           - k8s: "latest-openshift"
             test: "openshift"
@@ -214,9 +221,7 @@ jobs:
       - name: Checkout helm charts repo
         uses: actions/checkout@v2
         with:
-          repository: mongodb/helm-charts
-          path: my-charts
-          ref: dev
+          submodules: recursive
 
       - name: Run e2e test
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,14 +3,14 @@ name: Test
 on:
   push:
     branches:
-      - 'main'
+      - "main"
     paths-ignore:
-      - 'docs/**'
+      - "docs/**"
   pull_request:
     branches:
-      - '**'
+      - "**"
     paths-ignore:
-      - 'docs/**'
+      - "docs/**"
   workflow_dispatch:
 
 jobs:
@@ -137,7 +137,14 @@ jobs:
         # k8s: ["1.17-kind", "1.19-kind", "1.17-opeshift"] # <supported platform version>-<platform>
         k8s: ["v1.18.15-kind"] # <K8sGitVersion>-<Platform>
         test:
-          ["cluster-ns", "cluster-wide", "bundle-test", "helm-ns", "helm-wide", "helm-update"]
+          [
+            "cluster-ns",
+            "cluster-wide",
+            "bundle-test",
+            "helm-ns",
+            "helm-wide",
+            "helm-update",
+          ]
         include:
           - k8s: "latest-openshift"
             test: "openshift"
@@ -224,9 +231,7 @@ jobs:
       - name: Checkout helm charts repo
         uses: actions/checkout@v2
         with:
-          repository: mongodb/helm-charts
-          path: my-charts
-          ref: dev
+          submodules: recursive
 
       - name: Run e2e test
         env:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "helm-charts"]
+	path = helm-charts
+	url = git@github.com:mongodb/helm-charts.git

--- a/test/e2e/config/config.go
+++ b/test/e2e/config/config.go
@@ -2,6 +2,7 @@ package config
 
 const (
 	ConfigAll = "../../deploy/" // Released generated files
+
 	// ClusterSample      = "data/atlascluster_basic.yaml"
 	DataFolder               = "data"
 	DefaultOperatorNS        = "mongodb-atlas-system"
@@ -11,9 +12,10 @@ const (
 	AtlasAPIURL              = AtlasHost + "/api/atlas/v1.0/"
 	TestAppLabelPrefix       = "app=test-app-"
 	ActrcPath                = "../../.actrc"
+
 	// HELM related path
 	HelmTestAppPath             = "../app/helm/"
-	HelmOperatorChartPath       = "../../my-charts/charts/atlas-operator"
-	HelmCRDChartPath            = "../../my-charts/charts/atlas-operator-crds"
-	HelmAtlasResourcesChartPath = "../../my-charts/charts/atlas-cluster"
+	HelmOperatorChartPath       = "../../helm-charts/charts/atlas-operator"
+	HelmCRDChartPath            = "../../helm-charts/charts/atlas-operator-crds"
+	HelmAtlasResourcesChartPath = "../../helm-charts/charts/atlas-cluster"
 )


### PR DESCRIPTION
This is a copy of the previous test which was running the forked tests, but they seem to be fetching `main` for testing purposes and not the SHA of the latest commit.