### PR TITLE
soft delete projects

### DIFF
--- a/pkg/controller/atlasproject/atlasproject_controller.go
+++ b/pkg/controller/atlasproject/atlasproject_controller.go
@@ -119,16 +119,11 @@ func (r *AtlasProjectReconciler) Reconcile(context context.Context, req ctrl.Req
 				return result.ReconcileResult(), nil
 			}
 		}
-	}
-
-	if !project.GetDeletionTimestamp().IsZero() {
+	} else {
 		if isDeletionFinalizerPresent(project) {
 			if customresource.ResourceShouldBeLeftInAtlas(project) {
-				log.Infof("Not removing the Atlas Project from Atlas as the '%s' annotation is set", customresource.ResourcePolicyAnnotation)
-				return result.ReconcileResult(), nil
-			}
-
-			if err = r.deleteAtlasProject(context, atlasClient, project); err != nil {
+				log.Infof("Deleting only AtlasProject Kubernetes Resource as '%s' annotation is set", customresource.ResourcePolicyAnnotation)
+			} else if err = r.deleteAtlasProject(context, atlasClient, project); err != nil {
 				result = workflow.Terminate(workflow.Internal, err.Error())
 				ctx.SetConditionFromResult(status.ClusterReadyType, result)
 				return result.ReconcileResult(), nil


### PR DESCRIPTION
### All Submissions:

* [x] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if there is one).

When adding the `mongodb.com/atlas-resource-policy: keep` annotation the resource actually needs to be deleted from K8S even if we keep it in Atlas. Otherwise the controller will continuously try to delete the K8S CR.

If something tries to delete an object and the infinite delete loop occurs I don't think it's possible to update or change the object being deleted in any way. At least helm will refuse to do it.
