### PR TITLE
add label selector to secret watches/cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ kubectl create secret generic mongodb-atlas-operator-api-key \
          --from-literal="publicApiKey=<the_atlas_api_public_key>" \
          --from-literal="privateApiKey=<the_atlas_api_private_key>" \
          -n mongodb-atlas-system
+
+kubectl label secret mongodb-atlas-operator-api-key atlas.mongodb.com/type=credentials -n mongodb-atlas-system
 ```
 
 **2.** Create an `AtlasProject` Custom Resource
@@ -71,6 +73,8 @@ EOF
 **4.** Create a database user password Kubernetes Secret
 ```
 kubectl create secret generic the-user-password --from-literal="password=P@@sword%"
+
+kubectl label secret the-user-password atlas.mongodb.com/type=credentials
 ```
 
 **5.** Create an `AtlasDatabaseUser` Custom Resource

--- a/main.go
+++ b/main.go
@@ -25,11 +25,14 @@ import (
 
 	"github.com/go-logr/zapr"
 	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	ctrzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -40,6 +43,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/controller/atlascluster"
 	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/controller/atlasdatabaseuser"
 	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/controller/atlasproject"
+	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/controller/connectionsecret"
 	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/controller/watch"
 	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/util/kube"
 	// +kubebuilder:scaffold:imports
@@ -85,6 +89,15 @@ func main() {
 		LeaderElection:         config.EnableLeaderElection,
 		LeaderElectionID:       "06d035fb.mongodb.com",
 		SyncPeriod:             &syncPeriod,
+		NewCache: cache.BuilderWithOptions(cache.Options{
+			SelectorsByObject: cache.SelectorsByObject{
+				&corev1.Secret{}: {
+					Label: labels.SelectorFromSet(labels.Set{
+						connectionsecret.CredLabelKey: connectionsecret.CredLabelVal,
+					}),
+				},
+			},
+		}),
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")

--- a/pkg/controller/atlasdatabaseuser/databaseuser_test.go
+++ b/pkg/controller/atlasdatabaseuser/databaseuser_test.go
@@ -90,7 +90,7 @@ func TestCheckUserExpired(t *testing.T) {
 		// Create a connection secret
 		_, err := connectionsecret.Ensure(fakeClient, "testNs", "project1", "603e7bf38a94956835659ae5", "cluster1", data)
 		assert.NoError(t, err)
-		after := time.Now().Add(time.Minute * 1).Format("2006-01-02T15:04:05")
+		after := time.Now().UTC().Add(time.Minute * 1).Format("2006-01-02T15:04:05")
 		result := checkUserExpired(zap.S(), fakeClient, "603e7bf38a94956835659ae5", *mdbv1.DefaultDBUser("testNs", data.DBUserName, "").WithDeleteAfterDate(after))
 		assert.True(t, result.IsOk())
 

--- a/pkg/controller/atlasproject/ipaccess_list_test.go
+++ b/pkg/controller/atlasproject/ipaccess_list_test.go
@@ -54,12 +54,12 @@ func TestFilterActiveIPAccessLists(t *testing.T) {
 		assert.Equal(t, []project.IPAccessList{ipAccessExpired}, expired)
 	})
 	t.Run("Two active", func(t *testing.T) {
-		dateAfter1 := time.Now().Add(time.Minute * 1).Format("2006-01-02T15:04:05")
-		dateAfter2 := time.Now().Add(time.Hour * 5).Format("2006-01-02T15:04:05")
+		dateAfter1 := time.Now().UTC().Add(time.Minute * 1).Format("2006-01-02T15:04:05")
+		dateAfter2 := time.Now().UTC().Add(time.Hour * 5).Format("2006-01-02T15:04:05")
 		ipAccessActive1 := project.IPAccessList{DeleteAfterDate: dateAfter1}
 		ipAccessActive2 := project.IPAccessList{DeleteAfterDate: dateAfter2}
 		active, expired := filterActiveIPAccessLists([]project.IPAccessList{ipAccessActive2, ipAccessActive1})
-		assert.Equal(t, active, []project.IPAccessList{ipAccessActive2, ipAccessActive1})
+		assert.Equal(t, []project.IPAccessList{ipAccessActive2, ipAccessActive1}, active)
 		assert.Empty(t, expired)
 	})
 }

--- a/pkg/controller/connectionsecret/ensuresecret.go
+++ b/pkg/controller/connectionsecret/ensuresecret.go
@@ -16,6 +16,8 @@ import (
 const (
 	ProjectLabelKey string = "atlas.mongodb.com/project-id"
 	ClusterLabelKey string = "atlas.mongodb.com/cluster-name"
+	CredLabelKey           = "atlas.mongodb.com/type"
+	CredLabelVal           = "credentials"
 
 	connectionSecretStdKey    string = "connectionStringStandard"
 	connectionSecretStdSrvKey string = "connectionStringStandardSrv"
@@ -71,7 +73,11 @@ func fillSecret(secret *corev1.Secret, projectID string, clusterName string, dat
 		}
 	}
 
-	secret.Labels = map[string]string{ProjectLabelKey: projectID, ClusterLabelKey: kube.NormalizeLabelValue(clusterName)}
+	secret.Labels = map[string]string{
+		CredLabelKey:    CredLabelVal,
+		ProjectLabelKey: projectID,
+		ClusterLabelKey: kube.NormalizeLabelValue(clusterName),
+	}
 
 	secret.Data = map[string][]byte{
 		connectionSecretStdKey:    []byte(connURL),

--- a/pkg/controller/connectionsecret/ensuresecret_test.go
+++ b/pkg/controller/connectionsecret/ensuresecret_test.go
@@ -94,6 +94,7 @@ func validateSecret(t *testing.T, fakeClient client.Client, namespace, projectNa
 	expectedLabels := map[string]string{
 		"atlas.mongodb.com/project-id":   projectID,
 		"atlas.mongodb.com/cluster-name": clusterName,
+		"atlas.mongodb.com/type":         "credentials",
 	}
 	assert.Equal(t, expectedData, secret.Data)
 	assert.Equal(t, expectedLabels, secret.Labels)

--- a/pkg/controller/connectionsecret/listsecrets.go
+++ b/pkg/controller/connectionsecret/listsecrets.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/util/kube"
@@ -23,7 +24,12 @@ func ListByUserName(k8sClient client.Client, namespace, projectID, userName stri
 func list(k8sClient client.Client, namespace, projectID, clusterName, dbUserName string) ([]corev1.Secret, error) {
 	secrets := corev1.SecretList{}
 	var result []corev1.Secret
-	if err := k8sClient.List(context.Background(), &secrets, client.InNamespace(namespace)); err != nil {
+	opts := &client.ListOptions{
+		LabelSelector: labels.SelectorFromSet(map[string]string{
+			CredLabelKey: CredLabelVal,
+		}),
+	}
+	if err := k8sClient.List(context.Background(), &secrets, client.InNamespace(namespace), opts); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
With this change, we limit the controller to only cache secrets with a specific label. This also means the controller only sees secrets with the proper label.

closes https://github.com/mongodb/mongodb-atlas-kubernetes/issues/360

Signed-off-by: Tommy Hughes <tohughes@redhat.com>

### All Submissions:

* [x] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [x] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if there is one).
