### PR TITLE
Specify registry for the operator image, and bypass kind cluster creation.

### DIFF
--- a/scripts/create_kind_cluster.sh
+++ b/scripts/create_kind_cluster.sh
@@ -2,6 +2,11 @@
 # sample from https://kind.sigs.k8s.io/docs/user/local-registry/
 set -o errexit
 
+if [[ "${USE_KIND:-}" = "false" ]]; then
+  echo "skipping creation of kind cluster"
+  exit 0
+fi
+
 if [[ "$(kind get clusters | grep -x kind)" = "kind" ]]; then
   echo "kind cluster already exists"
   exit 0

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -4,7 +4,11 @@ set -eou pipefail
 
 kubectl version
 
-image="localhost:5000/mongodb-atlas-kubernetes-operator"
+if [[ -z "${REGISTRY:-}" ]]; then
+  REGISTRY="localhost:5000"
+fi
+
+image="${REGISTRY}/mongodb-atlas-kubernetes-operator"
 docker build -t "${image}" .
 docker push "${image}"
 


### PR DESCRIPTION

### All Submissions:

This is a small patch to enable us to use clusters other than kind when deploying the operator.

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?

