### PR TITLE
Added target for unit-tests. Unified build for Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,14 +13,15 @@ RUN go mod download
 COPY main.go main.go
 COPY .git/ .git/
 COPY pkg/ pkg/
+COPY Makefile Makefile
+COPY config/ config/
+COPY hack/ hack/
+
 
 ARG VERSION
 ENV PRODUCT_VERSION=${VERSION}
 
-# Build
-RUN if [ -z $PRODUCT_VERSION ]; then PRODUCT_VERSION=$(git describe --tags); fi; \
-    CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on \
-    go build -a -ldflags="-X main.version=$PRODUCT_VERSION" -o manager main.go
+RUN make manager
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4-205.1626828526
 
@@ -41,7 +42,7 @@ LABEL name="MongoDB Atlas Operator" \
       description="MongoDB Atlas Operator is a Kubernetes Operator allowing to manage MongoDB Atlas resources not leaving Kubernetes cluster"
 
 WORKDIR /
-COPY --from=builder /workspace/manager .
+COPY --from=builder /workspace/bin/manager .
 COPY hack/licenses licenses
 
 USER 1001:0

--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,10 @@ help: ## Show this help screen
 .PHONY: all
 all: manager ## Build all binaries
 
+.PHONY: unit-test
+unit-test:
+	go test -race -cover ./pkg/...
+
 .PHONY: int-test
 int-test: ENVTEST_ASSETS_DIR = $(shell pwd)/testbin
 int-test: export ATLAS_ORG_ID=$(shell grep "ATLAS_ORG_ID" .actrc | cut -d "=" -f 2)

--- a/config/rbac/clusterwide/role.yaml
+++ b/config/rbac/clusterwide/role.yaml
@@ -84,4 +84,3 @@ rules:
   - get
   - patch
   - update
-


### PR DESCRIPTION
### All Submissions:
* Added target for unit-tests
* Dockerfile now uses the same Makefile to build the manager

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
