### PR TITLE
Remove safe-to-test label when commits are pushed to forks

### DIFF
--- a/.github/workflows/remove-label.yml
+++ b/.github/workflows/remove-label.yml
@@ -1,7 +1,6 @@
 name: Remove Labels
 
-on:
-  pull_request:
+on: [ pull_request, pull_request_target ]
 
 jobs:
   remove-safe-to-test-label:


### PR DESCRIPTION
### All Submissions:

This PR adds makes it so that labels are removed when new changes are pushed to forks so you don't need to manually remove/re-add the label to run tests.


* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if there is one).
