### PR TITLE
CLOUDP-111985: Made E2E cross-platform

### DIFF
--- a/.github/actions/gen-install-scripts/entrypoint.sh
+++ b/.github/actions/gen-install-scripts/entrypoint.sh
@@ -60,12 +60,12 @@ else
   cd config/manager && kustomize edit set image controller="${INPUT_IMAGE_URL_REDHAT}" && cd -
   kustomize build --load-restrictor LoadRestrictionsNone config/manifests | operator-sdk generate bundle -q --overwrite --version "${INPUT_VERSION}" --default-channel="${channel}" --channels="${channel}"
   # add replaces
-  sed -i  '/replaces:*+/d' "bundle/manifests/mongodb-atlas-kubernetes.clusterserviceversion.yaml"
+  awk '!/replaces:/' bundle/manifests/mongodb-atlas-kubernetes.clusterserviceversion.yaml > tmp && mv tmp bundle/manifests/mongodb-atlas-kubernetes.clusterserviceversion.yaml
   echo "  replaces: $current_version" >> bundle/manifests/mongodb-atlas-kubernetes.clusterserviceversion.yaml
 fi
 
 # add additional LABELs to bundle.Docker file
 label="LABEL com.redhat.openshift.versions=\"v4.5-v4.7\"\nLABEL com.redhat.delivery.backport=true\nLABEL com.redhat.delivery.operator.bundle=true"
-sed -i "/FROM scratch/a $label" bundle.Dockerfile
+awk -v rep="FROM scratch\n\n$label" '{sub(/FROM scratch/, rep); print}' bundle.Dockerfile > tmp && mv tmp bundle.Dockerfile
 
 operator-sdk bundle validate ./bundle


### PR DESCRIPTION
### All Submissions:

This PR closes CLOUDP-111985. `sed` replaced with `awk` to allow script to run on both MacOS and Linux without any modifications.

* [x] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?

