### PR TITLE
Added validation for cluster resource

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/fatih/structtag v1.2.0
 	github.com/go-logr/zapr v1.2.3
 	github.com/google/go-cmp v0.5.7
+	github.com/hashicorp/go-multierror v1.1.1
 	github.com/mongodb-forks/digest v1.0.3
 	github.com/mxschmitt/playwright-go v0.1400.0
 	github.com/onsi/ginkgo/v2 v2.1.3
@@ -56,6 +57,7 @@ require (
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/googleapis/gnostic v0.5.5 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
+	github.com/hashicorp/errwrap v1.0.0 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect

--- a/go.sum
+++ b/go.sum
@@ -331,11 +331,14 @@ github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFb
 github.com/h2non/filetype v1.1.1/go.mod h1:319b3zT68BvV+WRj7cwy856M2ehB3HqNOt6sy1HndBY=
 github.com/hashicorp/consul/api v1.1.0/go.mod h1:VmuI/Lkw1nC05EYQWNKwWGbkg+FbDBtguAZLlVdkD9Q=
 github.com/hashicorp/consul/sdk v0.1.1/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=
+github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-msgpack v0.5.3/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
+github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
+github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/go-rootcerts v1.0.0/go.mod h1:K6zTfqpRlCUIjkwsN4Z+hiSfzSTQa6eBIzfwKfwNnHU=
 github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerXegt+ozgdvDeDU=
 github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdvsLplgctolz4=

--- a/pkg/api/v1/status/condition.go
+++ b/pkg/api/v1/status/condition.go
@@ -28,7 +28,8 @@ conditions:
 type ConditionType string
 
 const (
-	ReadyType ConditionType = "Ready"
+	ReadyType           ConditionType = "Ready"
+	ValidationSucceeded ConditionType = "ValidationSucceeded"
 )
 
 // AtlasProject condition types

--- a/pkg/controller/validate/validate.go
+++ b/pkg/controller/validate/validate.go
@@ -1,0 +1,29 @@
+package validate
+
+import (
+	"errors"
+
+	"github.com/hashicorp/go-multierror"
+
+	mdbv1 "github.com/mongodb/mongodb-atlas-kubernetes/pkg/api/v1"
+)
+
+func ClusterSpec(clusterSpec mdbv1.AtlasClusterSpec) error {
+	var err error
+	if clusterSpec.AdvancedClusterSpec == nil && clusterSpec.ClusterSpec == nil {
+		err = multierror.Append(err, errors.New("expected exactly one of spec.clusterSpec or spec.advancedClusterSpec, neither were present"))
+	}
+
+	if clusterSpec.AdvancedClusterSpec != nil && clusterSpec.ClusterSpec != nil {
+		err = multierror.Append(err, errors.New("expected exactly one of spec.clusterSpec or spec.advancedClusterSpec, both were present"))
+	}
+	return err
+}
+
+func Project(_ *mdbv1.AtlasProject) error {
+	return nil
+}
+
+func DatabaseUser(_ *mdbv1.AtlasDatabaseUser) error {
+	return nil
+}

--- a/pkg/controller/validate/validate_test.go
+++ b/pkg/controller/validate/validate_test.go
@@ -1,0 +1,34 @@
+package validate
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	mdbv1 "github.com/mongodb/mongodb-atlas-kubernetes/pkg/api/v1"
+)
+
+func TestClusterValidation(t *testing.T) {
+	t.Run("Invalid cluster specs", func(t *testing.T) {
+		t.Run("Multiple specs specified", func(t *testing.T) {
+			spec := mdbv1.AtlasClusterSpec{AdvancedClusterSpec: &mdbv1.AdvancedClusterSpec{}, ClusterSpec: &mdbv1.ClusterSpec{}}
+			assert.Error(t, ClusterSpec(spec))
+		})
+		t.Run("No specs specified", func(t *testing.T) {
+			spec := mdbv1.AtlasClusterSpec{AdvancedClusterSpec: nil, ClusterSpec: nil}
+			assert.Error(t, ClusterSpec(spec))
+		})
+	})
+	t.Run("Valid cluster specs", func(t *testing.T) {
+		t.Run("Advanced cluster spec specified", func(t *testing.T) {
+			spec := mdbv1.AtlasClusterSpec{AdvancedClusterSpec: &mdbv1.AdvancedClusterSpec{}, ClusterSpec: nil}
+			assert.NoError(t, ClusterSpec(spec))
+			assert.Nil(t, ClusterSpec(spec))
+		})
+		t.Run("Regular cluster specs specified", func(t *testing.T) {
+			spec := mdbv1.AtlasClusterSpec{AdvancedClusterSpec: nil, ClusterSpec: &mdbv1.ClusterSpec{}}
+			assert.NoError(t, ClusterSpec(spec))
+			assert.Nil(t, ClusterSpec(spec))
+		})
+	})
+}

--- a/test/int/cluster_test.go
+++ b/test/int/cluster_test.go
@@ -111,6 +111,7 @@ var _ = Describe("AtlasCluster", Label("int", "AtlasCluster"), func() {
 			Expect(createdCluster.Status.Conditions).To(ConsistOf(testutil.MatchConditions(
 				status.TrueCondition(status.ClusterReadyType),
 				status.TrueCondition(status.ReadyType),
+				status.TrueCondition(status.ValidationSucceeded),
 			)))
 			Expect(createdCluster.Status.ObservedGeneration).To(Equal(createdCluster.Generation))
 			Expect(createdCluster.Status.ObservedGeneration).To(Equal(lastGeneration + 1))
@@ -131,6 +132,7 @@ var _ = Describe("AtlasCluster", Label("int", "AtlasCluster"), func() {
 			Expect(createdCluster.Status.Conditions).To(ConsistOf(testutil.MatchConditions(
 				status.TrueCondition(status.ClusterReadyType),
 				status.TrueCondition(status.ReadyType),
+				status.TrueCondition(status.ValidationSucceeded),
 			)))
 			Expect(createdCluster.Status.ObservedGeneration).To(Equal(createdCluster.Generation))
 			Expect(createdCluster.Status.ObservedGeneration).To(Equal(lastGeneration + 1))
@@ -719,6 +721,7 @@ func validateClusterCreatingFunc() func(a mdbv1.AtlasCustomResource) {
 			expectedConditionsMatchers := testutil.MatchConditions(
 				status.FalseCondition(status.ClusterReadyType).WithReason(string(workflow.ClusterCreating)).WithMessageRegexp("cluster is provisioning"),
 				status.FalseCondition(status.ReadyType),
+				status.TrueCondition(status.ValidationSucceeded),
 			)
 			Expect(c.Status.Conditions).To(ConsistOf(expectedConditionsMatchers))
 		} else {
@@ -743,6 +746,7 @@ func validateClusterUpdatingFunc() func(a mdbv1.AtlasCustomResource) {
 			expectedConditionsMatchers := testutil.MatchConditions(
 				status.FalseCondition(status.ClusterReadyType).WithReason(string(workflow.ClusterUpdating)).WithMessageRegexp("cluster is updating"),
 				status.FalseCondition(status.ReadyType),
+				status.TrueCondition(status.ValidationSucceeded),
 			)
 			Expect(c.Status.Conditions).To(ConsistOf(expectedConditionsMatchers))
 		}

--- a/test/int/cluster_test.go
+++ b/test/int/cluster_test.go
@@ -107,7 +107,7 @@ var _ = Describe("AtlasCluster", Label("int", "AtlasCluster"), func() {
 			Expect(createdCluster.Status.MongoDBVersion).To(Equal(atlasCluster.MongoDBVersion))
 			Expect(createdCluster.Status.MongoURIUpdated).To(Equal(atlasCluster.MongoURIUpdated))
 			Expect(createdCluster.Status.StateName).To(Equal("IDLE"))
-			Expect(createdCluster.Status.Conditions).To(HaveLen(2))
+			Expect(createdCluster.Status.Conditions).To(HaveLen(3))
 			Expect(createdCluster.Status.Conditions).To(ConsistOf(testutil.MatchConditions(
 				status.TrueCondition(status.ClusterReadyType),
 				status.TrueCondition(status.ReadyType),
@@ -128,7 +128,7 @@ var _ = Describe("AtlasCluster", Label("int", "AtlasCluster"), func() {
 			Expect(createdCluster.Status.ConnectionStrings.StandardSrv).To(Equal(atlasCluster.ConnectionStrings.StandardSrv))
 			Expect(createdCluster.Status.MongoDBVersion).To(Equal(atlasCluster.MongoDBVersion))
 			Expect(createdCluster.Status.StateName).To(Equal("IDLE"))
-			Expect(createdCluster.Status.Conditions).To(HaveLen(2))
+			Expect(createdCluster.Status.Conditions).To(HaveLen(3))
 			Expect(createdCluster.Status.Conditions).To(ConsistOf(testutil.MatchConditions(
 				status.TrueCondition(status.ClusterReadyType),
 				status.TrueCondition(status.ReadyType),

--- a/test/int/clusterwide/dbuser_test.go
+++ b/test/int/clusterwide/dbuser_test.go
@@ -199,6 +199,7 @@ func validateClusterCreatingFunc() func(a mdbv1.AtlasCustomResource) {
 			expectedConditionsMatchers := testutil.MatchConditions(
 				status.FalseCondition(status.ClusterReadyType).WithReason(string(workflow.ClusterCreating)).WithMessageRegexp("cluster is provisioning"),
 				status.FalseCondition(status.ReadyType),
+				status.TrueCondition(status.ValidationSucceeded),
 			)
 			Expect(c.Status.Conditions).To(ConsistOf(expectedConditionsMatchers))
 		} else {
@@ -215,6 +216,7 @@ func validateDatabaseUserUpdatingFunc() func(a mdbv1.AtlasCustomResource) {
 		expectedConditionsMatchers := testutil.MatchConditions(
 			status.FalseCondition(status.DatabaseUserReadyType).WithReason(string(workflow.DatabaseUserClustersAppliedChanges)),
 			status.FalseCondition(status.ReadyType),
+			status.TrueCondition(status.ValidationSucceeded),
 		)
 		Expect(d.Status.Conditions).To(ConsistOf(expectedConditionsMatchers))
 	}

--- a/test/int/dbuser_test.go
+++ b/test/int/dbuser_test.go
@@ -323,6 +323,7 @@ var _ = Describe("AtlasDatabaseUser", Label("int", "AtlasDatabaseUser"), func() 
 				expectedConditionsMatchers := testutil.MatchConditions(
 					status.TrueCondition(status.DatabaseUserReadyType),
 					status.TrueCondition(status.ReadyType),
+					status.TrueCondition(status.ValidationSucceeded),
 				)
 				Expect(createdDBUser.Status.Conditions).To(ConsistOf(expectedConditionsMatchers))
 
@@ -519,6 +520,7 @@ var _ = Describe("AtlasDatabaseUser", Label("int", "AtlasDatabaseUser"), func() 
 				expectedConditionsMatchers := testutil.MatchConditions(
 					status.FalseCondition(status.DatabaseUserReadyType),
 					status.FalseCondition(status.ReadyType),
+					status.TrueCondition(status.ValidationSucceeded),
 				)
 				Expect(createdDBUser.Status.Conditions).To(ConsistOf(expectedConditionsMatchers))
 
@@ -801,6 +803,7 @@ func validateDatabaseUserUpdatingFunc() func(a mdbv1.AtlasCustomResource) {
 		expectedConditionsMatchers := testutil.MatchConditions(
 			status.FalseCondition(status.DatabaseUserReadyType).WithReason(string(workflow.DatabaseUserClustersAppliedChanges)),
 			status.FalseCondition(status.ReadyType),
+			status.TrueCondition(status.ValidationSucceeded),
 		)
 		Expect(d.Status.Conditions).To(ConsistOf(expectedConditionsMatchers))
 	}
@@ -814,6 +817,7 @@ func validateDatabaseUserWaitingForCluster() func(a mdbv1.AtlasCustomResource) {
 		userChangesApplied := testutil.MatchConditions(
 			status.FalseCondition(status.DatabaseUserReadyType).WithReason(string(workflow.DatabaseUserClustersAppliedChanges)),
 			status.FalseCondition(status.ReadyType),
+			status.TrueCondition(status.ValidationSucceeded),
 		)
 		// this is the status the db user gets to when tries to create connection secrets and sees that the cluster
 		// is not ready

--- a/test/int/project_test.go
+++ b/test/int/project_test.go
@@ -79,6 +79,7 @@ var _ = Describe("AtlasProject", Label("int", "AtlasProject"), func() {
 			status.TrueCondition(status.ProjectReadyType),
 			status.TrueCondition(status.IPAccessListReadyType),
 			status.TrueCondition(status.ReadyType),
+			status.TrueCondition(status.ValidationSucceeded),
 		)
 		Expect(createdProject.Status.ID).NotTo(BeNil())
 		Expect(createdProject.Status.Conditions).To(ConsistOf(projectReadyConditions))
@@ -116,6 +117,7 @@ var _ = Describe("AtlasProject", Label("int", "AtlasProject"), func() {
 			expectedConditionsMatchers := testutil.MatchConditions(
 				status.FalseCondition(status.ProjectReadyType),
 				status.FalseCondition(status.ReadyType),
+				status.TrueCondition(status.ValidationSucceeded),
 			)
 			Expect(createdProject.Status.Conditions).To(ConsistOf(expectedConditionsMatchers))
 			Expect(createdProject.ID()).To(BeEmpty())
@@ -446,6 +448,7 @@ var _ = Describe("AtlasProject", Label("int", "AtlasProject"), func() {
 				status.TrueCondition(status.ProjectReadyType),
 				status.TrueCondition(status.IPAccessListReadyType),
 				status.TrueCondition(status.ReadyType),
+				status.TrueCondition(status.ValidationSucceeded),
 			)
 			Expect(createdProject.Status.Conditions).To(ConsistOf(expectedConditionsMatchers))
 			Expect(createdProject.Status.ObservedGeneration).To(Equal(createdProject.Generation))
@@ -462,6 +465,7 @@ var _ = Describe("AtlasProject", Label("int", "AtlasProject"), func() {
 				expectedConditionsMatchers := testutil.MatchConditions(
 					status.FalseCondition(status.ProjectReadyType).WithReason(string(workflow.AtlasCredentialsNotProvided)),
 					status.FalseCondition(status.ReadyType),
+					status.TrueCondition(status.ValidationSucceeded),
 				)
 				Expect(createdProject.Status.Conditions).To(ConsistOf(expectedConditionsMatchers))
 				Expect(createdProject.ID()).To(BeEmpty())

--- a/test/int/project_test.go
+++ b/test/int/project_test.go
@@ -366,6 +366,7 @@ var _ = Describe("AtlasProject", Label("int", "AtlasProject"), func() {
 
 			expectedConditionsMatchers := testutil.MatchConditions(
 				status.TrueCondition(status.ProjectReadyType),
+				status.TrueCondition(status.ValidationSucceeded),
 				ipAccessFailedCondition,
 				status.FalseCondition(status.ReadyType),
 			)


### PR DESCRIPTION
### All Submissions:

This PR validates the new advancedCluster/regularCluster spec changes.

The validation functions for the other types isn't strictly required, but I think it's a good idea to have all resources showing the same conditions.

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
