### PR TITLE
Fixed URL for the atlas operator client

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -174,7 +174,7 @@ jobs:
 
       - name: Change path for the test
         run: |
-          sed -i -e 's/cloud.mongodb.com/cloud-qa.mongodb.com\//' bundle/manifests/mongodb-atlas-kubernetes.clusterserviceversion.yaml
+          awk '{gsub(/cloud.mongodb.com/, "cloud-qa.mongodb.com", $0); print}' bundle/manifests/mongodb-atlas-kubernetes.clusterserviceversion.yaml > tmp && mv tmp bundle/manifests/mongodb-atlas-kubernetes.clusterserviceversion.yaml
 
       - name: Push bundle-image for the test
         if: ${{ matrix.test == 'openshift' || matrix.test == 'bundle-test' && !env.ACT }}

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -184,7 +184,7 @@ type Config struct {
 func parseConfiguration(log *zap.SugaredLogger) Config {
 	var globalAPISecretName string
 	config := Config{}
-	flag.StringVar(&config.AtlasDomain, "atlas-domain", "https://cloud.mongodb.com", "the Atlas URL domain name (no slash in the end).")
+	flag.StringVar(&config.AtlasDomain, "atlas-domain", "https://cloud.mongodb.com/", "the Atlas URL domain name (no slash in the end).")
 	flag.StringVar(&config.MetricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&config.ProbeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.StringVar(&globalAPISecretName, "global-api-secret-name", "", "The name of the Secret that contains Atlas API keys. "+

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -184,7 +184,7 @@ type Config struct {
 func parseConfiguration(log *zap.SugaredLogger) Config {
 	var globalAPISecretName string
 	config := Config{}
-	flag.StringVar(&config.AtlasDomain, "atlas-domain", "https://cloud.mongodb.com/", "the Atlas URL domain name (no slash in the end).")
+	flag.StringVar(&config.AtlasDomain, "atlas-domain", "https://cloud.mongodb.com/", "the Atlas URL domain name (with slash in the end).")
 	flag.StringVar(&config.MetricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&config.ProbeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.StringVar(&globalAPISecretName, "global-api-secret-name", "", "The name of the Secret that contains Atlas API keys. "+

--- a/config/release/prod/prod_patch.json
+++ b/config/release/prod/prod_patch.json
@@ -1,6 +1,6 @@
 [
   {"op": "add",
     "path": "/spec/template/spec/containers/0/args/0",
-    "value": "--atlas-domain=https://cloud.mongodb.com"
+    "value": "--atlas-domain=https://cloud.mongodb.com/"
   }
 ]


### PR DESCRIPTION
### All Submissions:

With the latest upgrade of the atlas api library, it is now necessary to provide URL with trailing slash

* [x] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
