### PR TITLE
CLOUDP-113285: Remove finalizer from the atlas project if connection secret is gone

### DIFF
--- a/.github/actions/set-tag/entrypoint.sh
+++ b/.github/actions/set-tag/entrypoint.sh
@@ -8,6 +8,6 @@ branch_name=${GITHUB_HEAD_REF-}
 if [ -z "${branch_name}" ]; then
     branch_name=$(echo "$GITHUB_REF" | awk -F'/' '{print $3}')
 fi
-branch_name=$(echo "${branch_name}" | sed  's/\//-/g')
+branch_name=$(echo "${branch_name}" | awk '{print substr($0, 1, 15)}' | sed 's/\//-/g')
 tag="${branch_name}-${commit_id}"
 echo "::set-output name=tag::$tag"

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -26,7 +26,7 @@ jobs:
           # Optional: working directory, useful for monorepos
           # working-directory:
 
-          args: --timeout 10m
+          args: --timeout 10m --exclude=dupl
           # Optional: show only new issues if it's a pull request. The default value is `false`.
           # only-new-issues: true
 

--- a/pkg/controller/atlasproject/atlasproject_controller.go
+++ b/pkg/controller/atlasproject/atlasproject_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
 	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/controller/validate"
 
 	"go.mongodb.org/atlas/mongodbatlas"

--- a/pkg/controller/atlasproject/atlasproject_controller.go
+++ b/pkg/controller/atlasproject/atlasproject_controller.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-
 	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/controller/validate"
 
 	"go.mongodb.org/atlas/mongodbatlas"
@@ -107,6 +106,10 @@ func (r *AtlasProjectReconciler) Reconcile(context context.Context, req ctrl.Req
 
 	connection, err := atlas.ReadConnection(log, r.Client, r.GlobalAPISecret, project.ConnectionSecretObjectKey())
 	if err != nil {
+		if errRm := r.removeDeletionFinalizer(context, project); errRm != nil {
+			result = workflow.Terminate(workflow.Internal, errRm.Error())
+			ctx.SetConditionFromResult(status.ClusterReadyType, result)
+		}
 		result = workflow.Terminate(workflow.AtlasCredentialsNotProvided, err.Error())
 		ctx.SetConditionFromResult(status.ProjectReadyType, result)
 		return result.ReconcileResult(), nil

--- a/test/int/cluster_test.go
+++ b/test/int/cluster_test.go
@@ -29,7 +29,7 @@ import (
 const (
 	// Set this to true if you are debugging cluster creation.
 	// This may not help much if there was the update though...
-	ClusterDevMode       = true
+	ClusterDevMode       = false
 	ClusterUpdateTimeout = 40 * time.Minute
 )
 
@@ -662,7 +662,7 @@ var _ = Describe("AtlasCluster", Label("int", "AtlasCluster"), func() {
 	})
 
 	Describe("Setting the cluster skip annotation should skip reconciliations.", func() {
-		FIt("Should Succeed", func() {
+		It("Should Succeed", func() {
 
 			By(`Creating the cluster with reconciliation policy "skip" first`, func() {
 				createdCluster = mdbv1.DefaultAWSCluster(namespace.Name, createdProject.Name).Lightweight()

--- a/test/int/cluster_test.go
+++ b/test/int/cluster_test.go
@@ -29,7 +29,7 @@ import (
 const (
 	// Set this to true if you are debugging cluster creation.
 	// This may not help much if there was the update though...
-	ClusterDevMode       = false
+	ClusterDevMode       = true
 	ClusterUpdateTimeout = 40 * time.Minute
 )
 
@@ -638,8 +638,11 @@ var _ = Describe("AtlasCluster", Label("int", "AtlasCluster"), func() {
 				createdCluster.ObjectMeta.Annotations = map[string]string{customresource.ResourcePolicyAnnotation: customresource.ResourcePolicyKeep}
 				Expect(k8sClient.Create(context.Background(), createdCluster)).ToNot(HaveOccurred())
 
-				Eventually(testutil.WaitFor(k8sClient, createdCluster, status.TrueCondition(status.ReadyType), validateClusterCreatingFunc()),
-					30*time.Minute, interval).Should(BeTrue())
+				Eventually(
+					func(g Gomega) {
+						success := testutil.WaitFor(k8sClient, createdCluster, status.TrueCondition(status.ReadyType), validateClusterCreatingFuncGContext(g))()
+						g.Expect(success).To(BeTrue())
+					}).WithTimeout(30 * time.Minute).WithPolling(interval).Should(Succeed())
 			})
 			By("Deleting the cluster - stays in Atlas", func() {
 				Expect(k8sClient.Delete(context.Background(), createdCluster)).To(Succeed())
@@ -659,13 +662,17 @@ var _ = Describe("AtlasCluster", Label("int", "AtlasCluster"), func() {
 	})
 
 	Describe("Setting the cluster skip annotation should skip reconciliations.", func() {
-		It("Should Succeed", func() {
+		FIt("Should Succeed", func() {
 
 			By(`Creating the cluster with reconciliation policy "skip" first`, func() {
 				createdCluster = mdbv1.DefaultAWSCluster(namespace.Name, createdProject.Name).Lightweight()
 				Expect(k8sClient.Create(context.Background(), createdCluster)).ToNot(HaveOccurred())
-				Eventually(testutil.WaitFor(k8sClient, createdCluster, status.TrueCondition(status.ReadyType), validateClusterCreatingFunc()),
-					30*time.Minute, interval).Should(BeTrue())
+
+				Eventually(
+					func(g Gomega) {
+						success := testutil.WaitFor(k8sClient, createdCluster, status.TrueCondition(status.ReadyType), validateClusterCreatingFuncGContext(g))()
+						g.Expect(success).To(BeTrue())
+					}).WithTimeout(30 * time.Minute).WithPolling(interval).Should(Succeed())
 
 				createdCluster.ObjectMeta.Annotations = map[string]string{customresource.ReconciliationPolicyAnnotation: customresource.ReconciliationPolicySkip}
 				createdCluster.Spec.ClusterSpec.Labels = append(createdCluster.Spec.ClusterSpec.Labels, mdbv1.LabelSpec{
@@ -698,8 +705,11 @@ var _ = Describe("AtlasCluster", Label("int", "AtlasCluster"), func() {
 			By(fmt.Sprintf("Creating the Advanced Cluster %s", kube.ObjectKeyFromObject(createdCluster)), func() {
 				Expect(k8sClient.Create(context.Background(), createdCluster)).ToNot(HaveOccurred())
 
-				Eventually(testutil.WaitFor(k8sClient, createdCluster, status.TrueCondition(status.ReadyType), validateClusterCreatingFunc()),
-					30*time.Minute, interval).Should(BeTrue())
+				Eventually(
+					func(g Gomega) {
+						success := testutil.WaitFor(k8sClient, createdCluster, status.TrueCondition(status.ReadyType), validateClusterCreatingFuncGContext(g))()
+						g.Expect(success).To(BeTrue())
+					}).WithTimeout(30 * time.Minute).WithPolling(interval).Should(Succeed())
 
 				doAdvancedClusterStatusChecks()
 				checkAdvancedAtlasState()
@@ -717,7 +727,7 @@ func validateClusterCreatingFunc() func(a mdbv1.AtlasCustomResource) {
 		}
 		// When the create request has been made to Atlas - we expect the following status
 		if startedCreation {
-			Expect(c.Status.StateName).To(Equal("CREATING"), fmt.Sprintf("Current conditions: %+v", c.Status.Conditions))
+			Expect(c.Status.StateName).To(Or(Equal("CREATING"), Equal("IDLE")), fmt.Sprintf("Current conditions: %+v", c.Status.Conditions))
 			expectedConditionsMatchers := testutil.MatchConditions(
 				status.FalseCondition(status.ClusterReadyType).WithReason(string(workflow.ClusterCreating)).WithMessageRegexp("cluster is provisioning"),
 				status.FalseCondition(status.ReadyType),
@@ -728,6 +738,30 @@ func validateClusterCreatingFunc() func(a mdbv1.AtlasCustomResource) {
 			// Otherwise there could have been some exception in Atlas on creation - let's check the conditions
 			condition, ok := testutil.FindConditionByType(c.Status.Conditions, status.ClusterReadyType)
 			Expect(ok).To(BeFalse(), fmt.Sprintf("Unexpected condition: %v", condition))
+		}
+	}
+}
+
+func validateClusterCreatingFuncGContext(g Gomega) func(a mdbv1.AtlasCustomResource) {
+	startedCreation := false
+	return func(a mdbv1.AtlasCustomResource) {
+		c := a.(*mdbv1.AtlasCluster)
+		if c.Status.StateName != "" {
+			startedCreation = true
+		}
+		// When the create request has been made to Atlas - we expect the following status
+		if startedCreation {
+			g.Expect(c.Status.StateName).To(Or(Equal("CREATING"), Equal("IDLE")), fmt.Sprintf("Current conditions: %+v", c.Status.Conditions))
+			expectedConditionsMatchers := testutil.MatchConditions(
+				status.FalseCondition(status.ClusterReadyType).WithReason(string(workflow.ClusterCreating)).WithMessageRegexp("cluster is provisioning"),
+				status.FalseCondition(status.ReadyType),
+				status.TrueCondition(status.ValidationSucceeded),
+			)
+			g.Expect(c.Status.Conditions).To(ConsistOf(expectedConditionsMatchers))
+		} else {
+			// Otherwise there could have been some exception in Atlas on creation - let's check the conditions
+			condition, ok := testutil.FindConditionByType(c.Status.Conditions, status.ClusterReadyType)
+			g.Expect(ok).To(BeFalse(), fmt.Sprintf("Unexpected condition: %v", condition))
 		}
 	}
 }

--- a/test/int/dbuser_test.go
+++ b/test/int/dbuser_test.go
@@ -161,13 +161,13 @@ var _ = Describe("AtlasDatabaseUser", Label("int", "AtlasDatabaseUser"), func() 
 					func(g Gomega) {
 						success := testutil.WaitFor(k8sClient, createdClusterAWS, status.TrueCondition(status.ReadyType), validateClusterCreatingFuncGContext(g))()
 						g.Expect(success).To(BeTrue())
-					}).WithTimeout(30 * time.Minute).WithPolling(interval).Should(Succeed())
+					}).WithTimeout(ClusterUpdateTimeout).WithPolling(interval).Should(Succeed())
 
 				Eventually(
 					func(g Gomega) {
 						success := testutil.WaitFor(k8sClient, createdClusterAzure, status.TrueCondition(status.ReadyType), validateClusterCreatingFuncGContext(g))()
 						g.Expect(success).To(BeTrue())
-					}).WithTimeout(30 * time.Minute).WithPolling(interval).Should(Succeed())
+					}).WithTimeout(ClusterUpdateTimeout).WithPolling(interval).Should(Succeed())
 			})
 			createdDBUser = mdbv1.DefaultDBUser(namespace.Name, "test-db-user", createdProject.Name).WithPasswordSecret(UserPasswordSecret)
 
@@ -319,7 +319,7 @@ var _ = Describe("AtlasDatabaseUser", Label("int", "AtlasDatabaseUser"), func() 
 					func(g Gomega) {
 						success := testutil.WaitFor(k8sClient, createdClusterAWS, status.TrueCondition(status.ReadyType), validateClusterCreatingFuncGContext(g))()
 						g.Expect(success).To(BeTrue())
-					}).WithTimeout(30 * time.Minute).WithPolling(interval).Should(Succeed())
+					}).WithTimeout(ClusterUpdateTimeout).WithPolling(intervalShort).Should(Succeed())
 			})
 			By("Updating the database user while the cluster is being created", func() {
 				createdDBUser = createdDBUser.WithRole("read", "test", "somecollection")
@@ -355,7 +355,7 @@ var _ = Describe("AtlasDatabaseUser", Label("int", "AtlasDatabaseUser"), func() 
 					func(g Gomega) {
 						success := testutil.WaitFor(k8sClient, createdClusterAWS, status.TrueCondition(status.ReadyType), validateClusterCreatingFuncGContext(g))()
 						g.Expect(success).To(BeTrue())
-					}).WithTimeout(30 * time.Minute).WithPolling(interval).Should(Succeed())
+					}).WithTimeout(ClusterUpdateTimeout).WithPolling(intervalShort).Should(Succeed())
 			})
 			createdDBUser = mdbv1.DefaultDBUser(namespace.Name, "test-db-user", createdProject.Name).WithPasswordSecret(UserPasswordSecret)
 			var connSecretInitial corev1.Secret
@@ -417,13 +417,13 @@ var _ = Describe("AtlasDatabaseUser", Label("int", "AtlasDatabaseUser"), func() 
 					func(g Gomega) {
 						success := testutil.WaitFor(k8sClient, createdClusterAWS, status.TrueCondition(status.ReadyType), validateClusterCreatingFuncGContext(g))()
 						g.Expect(success).To(BeTrue())
-					}).WithTimeout(30 * time.Minute).WithPolling(interval).Should(Succeed())
+					}).WithTimeout(ClusterUpdateTimeout).WithPolling(intervalShort).Should(Succeed())
 
 				Eventually(
 					func(g Gomega) {
 						success := testutil.WaitFor(k8sClient, createdClusterAzure, status.TrueCondition(status.ReadyType), validateClusterCreatingFuncGContext(g))()
 						g.Expect(success).To(BeTrue())
-					}).WithTimeout(30 * time.Minute).WithPolling(interval).Should(Succeed())
+					}).WithTimeout(ClusterUpdateTimeout).WithPolling(intervalShort).Should(Succeed())
 			})
 			createdDBUser = mdbv1.DefaultDBUser(namespace.Name, "test-db-user", createdProject.Name).WithPasswordSecret(UserPasswordSecret)
 
@@ -488,7 +488,7 @@ var _ = Describe("AtlasDatabaseUser", Label("int", "AtlasDatabaseUser"), func() 
 					func(g Gomega) {
 						success := testutil.WaitFor(k8sClient, createdClusterAWS, status.TrueCondition(status.ReadyType), validateClusterCreatingFuncGContext(g))()
 						g.Expect(success).To(BeTrue())
-					}).WithTimeout(30 * time.Minute).WithPolling(interval).Should(Succeed())
+					}).WithTimeout(ClusterUpdateTimeout).WithPolling(intervalShort).Should(Succeed())
 			})
 
 			By("Creating the expired Database User - no user created in Atlas", func() {

--- a/test/int/dbuser_test.go
+++ b/test/int/dbuser_test.go
@@ -157,11 +157,17 @@ var _ = Describe("AtlasDatabaseUser", Label("int", "AtlasDatabaseUser"), func() 
 				createdClusterAzure = mdbv1.DefaultAzureCluster(namespace.Name, createdProject.Name).Lightweight()
 				Expect(k8sClient.Create(context.Background(), createdClusterAzure)).ToNot(HaveOccurred())
 
-				Eventually(testutil.WaitFor(k8sClient, createdClusterAWS, status.TrueCondition(status.ReadyType), validateClusterCreatingFunc()),
-					ClusterUpdateTimeout, interval).Should(BeTrue())
+				Eventually(
+					func(g Gomega) {
+						success := testutil.WaitFor(k8sClient, createdClusterAWS, status.TrueCondition(status.ReadyType), validateClusterCreatingFuncGContext(g))()
+						g.Expect(success).To(BeTrue())
+					}).WithTimeout(30 * time.Minute).WithPolling(interval).Should(Succeed())
 
-				Eventually(testutil.WaitFor(k8sClient, createdClusterAzure, status.TrueCondition(status.ReadyType), validateClusterCreatingFunc()),
-					500, interval).Should(BeTrue())
+				Eventually(
+					func(g Gomega) {
+						success := testutil.WaitFor(k8sClient, createdClusterAzure, status.TrueCondition(status.ReadyType), validateClusterCreatingFuncGContext(g))()
+						g.Expect(success).To(BeTrue())
+					}).WithTimeout(30 * time.Minute).WithPolling(interval).Should(Succeed())
 			})
 			createdDBUser = mdbv1.DefaultDBUser(namespace.Name, "test-db-user", createdProject.Name).WithPasswordSecret(UserPasswordSecret)
 
@@ -309,8 +315,11 @@ var _ = Describe("AtlasDatabaseUser", Label("int", "AtlasDatabaseUser"), func() 
 				Expect(k8sClient.Create(context.Background(), createdClusterAWS)).ToNot(HaveOccurred())
 
 				// We don't wait for the full cluster creation - only when it has started the process
-				Eventually(testutil.WaitFor(k8sClient, createdClusterAWS, status.FalseCondition(status.ClusterReadyType).WithReason(string(workflow.ClusterCreating))),
-					20, intervalShort).Should(BeTrue())
+				Eventually(
+					func(g Gomega) {
+						success := testutil.WaitFor(k8sClient, createdClusterAWS, status.TrueCondition(status.ReadyType), validateClusterCreatingFuncGContext(g))()
+						g.Expect(success).To(BeTrue())
+					}).WithTimeout(30 * time.Minute).WithPolling(interval).Should(Succeed())
 			})
 			By("Updating the database user while the cluster is being created", func() {
 				createdDBUser = createdDBUser.WithRole("read", "test", "somecollection")
@@ -342,8 +351,11 @@ var _ = Describe("AtlasDatabaseUser", Label("int", "AtlasDatabaseUser"), func() 
 				createdClusterAWS = mdbv1.DefaultAWSCluster(namespace.Name, createdProject.Name).Lightweight()
 				Expect(k8sClient.Create(context.Background(), createdClusterAWS)).ToNot(HaveOccurred())
 
-				Eventually(testutil.WaitFor(k8sClient, createdClusterAWS, status.TrueCondition(status.ReadyType), validateClusterCreatingFunc()),
-					ClusterUpdateTimeout, interval).Should(BeTrue())
+				Eventually(
+					func(g Gomega) {
+						success := testutil.WaitFor(k8sClient, createdClusterAWS, status.TrueCondition(status.ReadyType), validateClusterCreatingFuncGContext(g))()
+						g.Expect(success).To(BeTrue())
+					}).WithTimeout(30 * time.Minute).WithPolling(interval).Should(Succeed())
 			})
 			createdDBUser = mdbv1.DefaultDBUser(namespace.Name, "test-db-user", createdProject.Name).WithPasswordSecret(UserPasswordSecret)
 			var connSecretInitial corev1.Secret
@@ -401,11 +413,17 @@ var _ = Describe("AtlasDatabaseUser", Label("int", "AtlasDatabaseUser"), func() 
 				createdClusterAzure = mdbv1.DefaultAzureCluster(namespace.Name, createdProject.Name).Lightweight()
 				Expect(k8sClient.Create(context.Background(), createdClusterAzure)).ToNot(HaveOccurred())
 
-				Eventually(testutil.WaitFor(k8sClient, createdClusterAWS, status.TrueCondition(status.ReadyType), validateClusterCreatingFunc()),
-					ClusterUpdateTimeout, interval).Should(BeTrue())
+				Eventually(
+					func(g Gomega) {
+						success := testutil.WaitFor(k8sClient, createdClusterAWS, status.TrueCondition(status.ReadyType), validateClusterCreatingFuncGContext(g))()
+						g.Expect(success).To(BeTrue())
+					}).WithTimeout(30 * time.Minute).WithPolling(interval).Should(Succeed())
 
-				Eventually(testutil.WaitFor(k8sClient, createdClusterAzure, status.TrueCondition(status.ReadyType), validateClusterCreatingFunc()),
-					ClusterUpdateTimeout, interval).Should(BeTrue())
+				Eventually(
+					func(g Gomega) {
+						success := testutil.WaitFor(k8sClient, createdClusterAzure, status.TrueCondition(status.ReadyType), validateClusterCreatingFuncGContext(g))()
+						g.Expect(success).To(BeTrue())
+					}).WithTimeout(30 * time.Minute).WithPolling(interval).Should(Succeed())
 			})
 			createdDBUser = mdbv1.DefaultDBUser(namespace.Name, "test-db-user", createdProject.Name).WithPasswordSecret(UserPasswordSecret)
 
@@ -466,8 +484,11 @@ var _ = Describe("AtlasDatabaseUser", Label("int", "AtlasDatabaseUser"), func() 
 				createdClusterAWS = mdbv1.DefaultAWSCluster(namespace.Name, createdProject.Name).Lightweight()
 				Expect(k8sClient.Create(context.Background(), createdClusterAWS)).To(Succeed())
 
-				Eventually(testutil.WaitFor(k8sClient, createdClusterAWS, status.TrueCondition(status.ReadyType), validateClusterCreatingFunc()),
-					ClusterUpdateTimeout, interval).Should(BeTrue())
+				Eventually(
+					func(g Gomega) {
+						success := testutil.WaitFor(k8sClient, createdClusterAWS, status.TrueCondition(status.ReadyType), validateClusterCreatingFuncGContext(g))()
+						g.Expect(success).To(BeTrue())
+					}).WithTimeout(30 * time.Minute).WithPolling(interval).Should(Succeed())
 			})
 
 			By("Creating the expired Database User - no user created in Atlas", func() {
@@ -533,8 +554,11 @@ var _ = Describe("AtlasDatabaseUser", Label("int", "AtlasDatabaseUser"), func() 
 					createdClusterAWS = mdbv1.DefaultAWSCluster(namespace.Name, createdProject.Name).Lightweight()
 					Expect(k8sClient.Create(context.Background(), createdClusterAWS)).ToNot(HaveOccurred())
 
-					Eventually(testutil.WaitFor(k8sClient, createdClusterAWS, status.TrueCondition(status.ReadyType), validateClusterCreatingFunc()),
-						30*time.Minute, interval).Should(BeTrue())
+					Eventually(
+						func(g Gomega) {
+							success := testutil.WaitFor(k8sClient, createdClusterAWS, status.TrueCondition(status.ReadyType), validateClusterCreatingFuncGContext(g))()
+							g.Expect(success).To(BeTrue())
+						}).WithTimeout(30 * time.Minute).WithPolling(interval).Should(Succeed())
 
 					createdDBUser = mdbv1.DefaultDBUser(namespace.Name, "test-db-user", createdProject.Name).WithPasswordSecret(UserPasswordSecret)
 					createdDBUser.ObjectMeta.Annotations = map[string]string{customresource.ResourcePolicyAnnotation: customresource.ResourcePolicyKeep}
@@ -559,8 +583,11 @@ var _ = Describe("AtlasDatabaseUser", Label("int", "AtlasDatabaseUser"), func() 
 				By(`Creating the user with reconciliation policy "skip" first`, func() {
 					createdClusterAWS = mdbv1.DefaultAWSCluster(namespace.Name, createdProject.Name).Lightweight()
 					Expect(k8sClient.Create(context.Background(), createdClusterAWS)).ToNot(HaveOccurred())
-					Eventually(testutil.WaitFor(k8sClient, createdClusterAWS, status.TrueCondition(status.ReadyType), validateClusterCreatingFunc()),
-						30*time.Minute, interval).Should(BeTrue())
+					Eventually(
+						func(g Gomega) {
+							success := testutil.WaitFor(k8sClient, createdClusterAWS, status.TrueCondition(status.ReadyType), validateClusterCreatingFuncGContext(g))()
+							g.Expect(success).To(BeTrue())
+						}).WithTimeout(30 * time.Minute).WithPolling(interval).Should(Succeed())
 
 					createdDBUser = mdbv1.DefaultDBUser(namespace.Name, "test-db-user", createdProject.Name).WithPasswordSecret(UserPasswordSecret)
 


### PR DESCRIPTION
### All Submissions:

Remove finalizer from the atlas project if connection secret is gone. Resolves: https://github.com/mongodb/mongodb-atlas-kubernetes/issues/425

* [x] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
