### PR TITLE
CLOUDP-115287: Allow users not to specify TENANT when creating AtlasCluster resources

### DIFF
--- a/pkg/controller/atlascluster/atlascluster_controller.go
+++ b/pkg/controller/atlascluster/atlascluster_controller.go
@@ -173,8 +173,6 @@ func (r *AtlasClusterReconciler) verifyNonTenantCase(cluster *mdbv1.AtlasCluster
 		pSettings.BackingProviderName = string(pSettings.ProviderName)
 		pSettings.ProviderName = "TENANT"
 	}
-
-	return
 }
 
 func (r *AtlasClusterReconciler) selectClusterHandler(cluster *mdbv1.AtlasCluster) clusterHandlerFunc {

--- a/pkg/controller/atlascluster/atlascluster_controller.go
+++ b/pkg/controller/atlascluster/atlascluster_controller.go
@@ -20,9 +20,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/api/v1/provider"
 	"strings"
 	"time"
+
+	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/api/v1/provider"
 
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 

--- a/pkg/controller/atlascluster/atlascluster_controller.go
+++ b/pkg/controller/atlascluster/atlascluster_controller.go
@@ -176,8 +176,15 @@ func modifyProviderSettings(pSettings *mdbv1.ProviderSettingsSpec, clusterType s
 	if pSettings == nil || string(pSettings.ProviderName) == clusterType {
 		return
 	}
-	switch pSettings.InstanceSizeName {
-	case "M0", "M2", "M5":
+
+	switch strings.ToUpper(clusterType) {
+	case "TENANT":
+		switch pSettings.InstanceSizeName {
+		case "M0", "M2", "M5":
+			pSettings.BackingProviderName = string(pSettings.ProviderName)
+			pSettings.ProviderName = provider.ProviderName(clusterType)
+		}
+	case "SERVERLESS":
 		pSettings.BackingProviderName = string(pSettings.ProviderName)
 		pSettings.ProviderName = provider.ProviderName(clusterType)
 	}


### PR DESCRIPTION
### All Submissions:

closes [CLOUDP-115287](https://jira.mongodb.org/browse/CLOUDP-115287)

* [x] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [x] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if there is one).
