### PR TITLE
Add coreutils install

### DIFF
--- a/docs/dev/start-guide.md
+++ b/docs/dev/start-guide.md
@@ -9,6 +9,7 @@ brew install kustomize # or https://kubectl.docs.kubernetes.io/installation/kust
 brew install act # or https://github.com/nektos/act#installation
 brew install yq # or https://pypi.org/project/yq/
 brew install shellcheck # or https://github.com/koalaman/shellcheck#installing
+brew install coreutils # or https://www.gnu.org/software/coreutils/
 brew install pre-commit # or https://pre-commit.com/index.html#install
 pre-commit install # from the root of the project
 ```


### PR DESCRIPTION
### All Submissions:

* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if there is one).
* [ ] Update docs/release-notes/release-notes.md if your changes should be included in the release notes for the next release.

`deploy.sh` uses the `timeout` command (on line 41) which is not natively present on MacOS and should be installed via `brew install coreutils`
This PR adds `coreutils` installation in the startup guide as a dependency