### PR TITLE
CLOUDP-126252: Maintenance Windows support

### DIFF
--- a/config/crd/bases/atlas.mongodb.com_atlasdeployments.yaml
+++ b/config/crd/bases/atlas.mongodb.com_atlasdeployments.yaml
@@ -19,7 +19,7 @@ spec:
   - name: v1
     schema:
       openAPIV3Schema:
-        description: AtlasDeployment is the Schema for the atlasclusters API
+        description: AtlasDeployment is the Schema for the atlasdeployments API
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation

--- a/config/crd/bases/atlas.mongodb.com_atlasprojects.yaml
+++ b/config/crd/bases/atlas.mongodb.com_atlasprojects.yaml
@@ -320,10 +320,6 @@ spec:
                     description: Flag indicating whether any scheduled project maintenance
                       should be deferred automatically for one week.
                     type: boolean
-                  autoDeferOnceEnabled:
-                    description: Flag that indicates whether you want to defer all
-                      maintenance windows one week they would be triggered.
-                    type: boolean
                   dayOfWeek:
                     description: Day of the week when you would like the maintenance
                       window to start as a 1-based integer. Sunday 1, Monday 2, Tuesday

--- a/config/crd/bases/atlas.mongodb.com_atlasprojects.yaml
+++ b/config/crd/bases/atlas.mongodb.com_atlasprojects.yaml
@@ -324,6 +324,8 @@ spec:
                     description: Day of the week when you would like the maintenance
                       window to start as a 1-based integer. Sunday 1, Monday 2, Tuesday
                       3, Wednesday 4, Thursday 5, Friday 6, Saturday 7
+                    maximum: 7
+                    minimum: 1
                     type: integer
                   defer:
                     description: Flag indicating whether the next scheduled project
@@ -333,6 +335,8 @@ spec:
                     description: Hour of the day when you would like the maintenance
                       window to start. This parameter uses the 24-hour clock, where
                       midnight is 0, noon is 12.
+                    maximum: 23
+                    minimum: 0
                     type: integer
                   startASAP:
                     description: Flag indicating whether project maintenance has been

--- a/config/crd/bases/atlas.mongodb.com_atlasprojects.yaml
+++ b/config/crd/bases/atlas.mongodb.com_atlasprojects.yaml
@@ -227,6 +227,40 @@ spec:
                       type: object
                   type: object
                 type: array
+              maintenanceWindow:
+                description: MaintenanceWindow allows to specify a preferred time
+                  in the week to run maintenance operations. See more information
+                  at https://www.mongodb.com/docs/atlas/reference/api/maintenance-windows/
+                properties:
+                  autoDefer:
+                    description: Flag indicating whether any scheduled project maintenance
+                      should be deferred automatically for one week.
+                    type: boolean
+                  dayOfWeek:
+                    description: Day of the week when you would like the maintenance
+                      window to start as a 1-based integer. Sunday 1, Monday 2, Tuesday
+                      3, Wednesday 4, Thursday 5, Friday 6, Saturday 7
+                    maximum: 7
+                    minimum: 1
+                    type: integer
+                  defer:
+                    description: Flag indicating whether the next scheduled project
+                      maintenance should be deferred for one week. Cannot be specified
+                      if startASAP is true
+                    type: boolean
+                  hourOfDay:
+                    description: Hour of the day when you would like the maintenance
+                      window to start. This parameter uses the 24-hour clock, where
+                      midnight is 0, noon is 12.
+                    maximum: 23
+                    minimum: 0
+                    type: integer
+                  startASAP:
+                    description: Flag indicating whether project maintenance has been
+                      directed to start immediately. Cannot be specified if defer
+                      is true
+                    type: boolean
+                type: object
               name:
                 description: Name is the name of the Project that is created in Atlas
                   by the Operator if it doesn't exist yet.
@@ -311,38 +345,6 @@ spec:
                       type: string
                   type: object
                 type: array
-              projectMaintenanceWindow:
-                description: ProjectMaintenanceWindow allow to specify a preferred
-                  time in the week to run maintenance operations. See more information
-                  at https://www.mongodb.com/docs/atlas/reference/api/maintenance-windows/
-                properties:
-                  autoDefer:
-                    description: Flag indicating whether any scheduled project maintenance
-                      should be deferred automatically for one week.
-                    type: boolean
-                  dayOfWeek:
-                    description: Day of the week when you would like the maintenance
-                      window to start as a 1-based integer. Sunday 1, Monday 2, Tuesday
-                      3, Wednesday 4, Thursday 5, Friday 6, Saturday 7
-                    maximum: 7
-                    minimum: 1
-                    type: integer
-                  defer:
-                    description: Flag indicating whether the next scheduled project
-                      maintenance should be deferred for one week.
-                    type: boolean
-                  hourOfDay:
-                    description: Hour of the day when you would like the maintenance
-                      window to start. This parameter uses the 24-hour clock, where
-                      midnight is 0, noon is 12.
-                    maximum: 23
-                    minimum: 0
-                    type: integer
-                  startASAP:
-                    description: Flag indicating whether project maintenance has been
-                      directed to start immediately.
-                    type: boolean
-                type: object
               withDefaultAlertsSettings:
                 default: true
                 description: Flag that indicates whether to create the new project

--- a/config/crd/bases/atlas.mongodb.com_atlasprojects.yaml
+++ b/config/crd/bases/atlas.mongodb.com_atlasprojects.yaml
@@ -311,6 +311,30 @@ spec:
                       type: string
                   type: object
                 type: array
+              projectMaintenanceWindow:
+                description: ProjectMaintenanceWindow allow to specify a preferred
+                  time in the week to run maintenance operations. See more information
+                  at https://www.mongodb.com/docs/atlas/reference/api/maintenance-windows/
+                properties:
+                  autoDeferOnceEnabled:
+                    description: Flag that indicates whether you want to defer all
+                      maintenance windows one week they would be triggered.
+                    type: boolean
+                  dayOfWeek:
+                    description: Day of the week when you would like the maintenance
+                      window to start as a 1-based integer. Sunday 1, Monday 2, Tuesday
+                      3, Wednesday 4, Thursday 5, Friday 6, Saturday 7
+                    type: integer
+                  hourOfDay:
+                    description: Hour of the day when you would like the maintenance
+                      window to start. This parameter uses the 24-hour clock, where
+                      midnight is 0, noon is 12.
+                    type: integer
+                  startASAP:
+                    description: Flag indicating whether project maintenance has been
+                      directed to start immediately.
+                    type: boolean
+                type: object
               withDefaultAlertsSettings:
                 default: true
                 description: Flag that indicates whether to create the new project

--- a/config/crd/bases/atlas.mongodb.com_atlasprojects.yaml
+++ b/config/crd/bases/atlas.mongodb.com_atlasprojects.yaml
@@ -316,6 +316,10 @@ spec:
                   time in the week to run maintenance operations. See more information
                   at https://www.mongodb.com/docs/atlas/reference/api/maintenance-windows/
                 properties:
+                  autoDefer:
+                    description: Flag indicating whether any scheduled project maintenance
+                      should be deferred automatically for one week.
+                    type: boolean
                   autoDeferOnceEnabled:
                     description: Flag that indicates whether you want to defer all
                       maintenance windows one week they would be triggered.
@@ -325,6 +329,10 @@ spec:
                       window to start as a 1-based integer. Sunday 1, Monday 2, Tuesday
                       3, Wednesday 4, Thursday 5, Friday 6, Saturday 7
                     type: integer
+                  defer:
+                    description: Flag indicating whether the next scheduled project
+                      maintenance should be deferred for one week.
+                    type: boolean
                   hourOfDay:
                     description: Hour of the day when you would like the maintenance
                       window to start. This parameter uses the 24-hour clock, where

--- a/config/samples/atlas_v1_atlasproject.yaml
+++ b/config/samples/atlas_v1_atlasproject.yaml
@@ -10,7 +10,6 @@ spec:
   projectMaintenanceWindow:
     dayOfWeek: 7
     hourOfDay: 18
-    autoDeferOnceEnabled: false
+    autoDefer: false
     #startASAP: true
     #defer: true
-    #autoDefer: true

--- a/config/samples/atlas_v1_atlasproject.yaml
+++ b/config/samples/atlas_v1_atlasproject.yaml
@@ -7,3 +7,7 @@ spec:
   projectIpAccessList:
     - ipAddress: "192.0.2.15"
       comment: "IP address for Application Server A"
+  projectMaintenanceWindow:
+    dayOfWeek: 7
+    hourOfDay: 18
+    autoDeferOnceEnabled: false

--- a/config/samples/atlas_v1_atlasproject.yaml
+++ b/config/samples/atlas_v1_atlasproject.yaml
@@ -11,3 +11,6 @@ spec:
     dayOfWeek: 7
     hourOfDay: 18
     autoDeferOnceEnabled: false
+    #startASAP: true
+    #defer: true
+    #autoDefer: true

--- a/config/samples/atlas_v1_atlasproject_with_maintenance_window.yaml
+++ b/config/samples/atlas_v1_atlasproject_with_maintenance_window.yaml
@@ -7,4 +7,9 @@ spec:
   projectIpAccessList:
     - ipAddress: "192.0.2.15"
       comment: "IP address for Application Server A"
-
+  maintenanceWindow:
+    dayOfWeek: 3
+    hourOfDay: 5
+    autoDefer: true
+    startASAP: false
+    defer: false

--- a/config/samples/atlas_v1_atlasproject_with_maintenance_window.yaml
+++ b/config/samples/atlas_v1_atlasproject_with_maintenance_window.yaml
@@ -11,5 +11,4 @@ spec:
     dayOfWeek: 3
     hourOfDay: 5
     autoDefer: true
-    startASAP: false
-    defer: false
+

--- a/pkg/api/v1/atlasproject_types.go
+++ b/pkg/api/v1/atlasproject_types.go
@@ -55,10 +55,10 @@ type AtlasProjectSpec struct {
 	// +optional
 	ProjectIPAccessList []project.IPAccessList `json:"projectIpAccessList,omitempty"`
 
-	// ProjectMaintenanceWindow allow to specify a preferred time in the week to run maintenance operations. See more
+	// MaintenanceWindow allows to specify a preferred time in the week to run maintenance operations. See more
 	// information at https://www.mongodb.com/docs/atlas/reference/api/maintenance-windows/
 	// +optional
-	ProjectMaintenanceWindow project.MaintenanceWindow `json:"projectMaintenanceWindow,omitempty"`
+	MaintenanceWindow project.MaintenanceWindow `json:"maintenanceWindow,omitempty"`
 
 	// PrivateEndpoints is a list of Private Endpoints configured for the current Project.
 	PrivateEndpoints []PrivateEndpoint `json:"privateEndpoints,omitempty"`
@@ -176,7 +176,7 @@ func (p *AtlasProject) WithIPAccessList(ipAccess project.IPAccessList) *AtlasPro
 }
 
 func (p *AtlasProject) WithMaintenanceWindow(window project.MaintenanceWindow) *AtlasProject {
-	p.Spec.ProjectMaintenanceWindow = window
+	p.Spec.MaintenanceWindow = window
 	return p
 }
 

--- a/pkg/api/v1/atlasproject_types.go
+++ b/pkg/api/v1/atlasproject_types.go
@@ -176,7 +176,6 @@ func (p *AtlasProject) WithIPAccessList(ipAccess project.IPAccessList) *AtlasPro
 }
 
 func (p *AtlasProject) WithMaintenanceWindow(window project.MaintenanceWindow) *AtlasProject {
-	// TODO should I check for validity of "window" here ?
 	p.Spec.ProjectMaintenanceWindow = window
 	return p
 }

--- a/pkg/api/v1/atlasproject_types.go
+++ b/pkg/api/v1/atlasproject_types.go
@@ -55,6 +55,11 @@ type AtlasProjectSpec struct {
 	// +optional
 	ProjectIPAccessList []project.IPAccessList `json:"projectIpAccessList,omitempty"`
 
+	// ProjectMaintenanceWindow allow to specify a preferred time in the week to run maintenance operations. See more
+	// information at https://www.mongodb.com/docs/atlas/reference/api/maintenance-windows/
+	// +optional
+	ProjectMaintenanceWindow project.MaintenanceWindow `json:"projectMaintenanceWindow,omitempty"`
+
 	// PrivateEndpoints is a list of Private Endpoints configured for the current Project.
 	PrivateEndpoints []PrivateEndpoint `json:"privateEndpoints,omitempty"`
 
@@ -167,6 +172,12 @@ func (p *AtlasProject) WithIPAccessList(ipAccess project.IPAccessList) *AtlasPro
 		p.Spec.ProjectIPAccessList = []project.IPAccessList{}
 	}
 	p.Spec.ProjectIPAccessList = append(p.Spec.ProjectIPAccessList, ipAccess)
+	return p
+}
+
+func (p *AtlasProject) WithMaintenanceWindow(window project.MaintenanceWindow) *AtlasProject {
+	// TODO should I check for validity of "window" here ?
+	p.Spec.ProjectMaintenanceWindow = window
 	return p
 }
 

--- a/pkg/api/v1/project/maintenancewindow.go
+++ b/pkg/api/v1/project/maintenancewindow.go
@@ -1,0 +1,62 @@
+package project
+
+import (
+	"go.mongodb.org/atlas/mongodbatlas"
+
+	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/util/compat"
+)
+
+type MaintenanceWindow struct {
+	// Day of the week when you would like the maintenance window to start as a 1-based integer.
+	// Sunday 1, Monday 2, Tuesday 3, Wednesday 4, Thursday 5, Friday 6, Saturday 7
+	// +optional
+	DayOfWeek int `json:"dayOfWeek,omitempty"`
+	// Hour of the day when you would like the maintenance window to start.
+	// This parameter uses the 24-hour clock, where midnight is 0, noon is 12.
+	// +optional
+	HourOfDay int `json:"hourOfDay,omitempty"`
+	// Flag that indicates whether you want to defer all maintenance windows one week they would be triggered.
+	// +optional
+	AutoDeferOnceEnabled bool `json:"autoDeferOnceEnabled,omitempty"`
+	// Flag indicating whether project maintenance has been directed to start immediately.
+	// +optional
+	StartASAP bool `json:"startASAP,omitempty"`
+}
+
+// ToAtlas converts the ProjectMaintenanceWindow to native Atlas client format.
+func (m MaintenanceWindow) ToAtlas() (*mongodbatlas.MaintenanceWindow, error) {
+	result := &mongodbatlas.MaintenanceWindow{}
+	err := compat.JSONCopy(result, m)
+	return result, err
+}
+
+func (m MaintenanceWindow) Identifier() interface{} {
+	return m.DayOfWeek // TODO complete, is it needed ?
+}
+
+// ************************************ Builder methods *************************************************
+// Note, that we don't use pointers here as the AtlasProject uses this without pointers
+
+func NewMaintenanceWindow() MaintenanceWindow {
+	return MaintenanceWindow{}
+}
+
+func (m MaintenanceWindow) WithDay(day int) MaintenanceWindow {
+	m.DayOfWeek = day
+	return m
+}
+
+func (m MaintenanceWindow) WithHour(hour int) MaintenanceWindow {
+	m.HourOfDay = hour
+	return m
+}
+
+func (m MaintenanceWindow) WithAutoDefer(autoDefer bool) MaintenanceWindow {
+	m.AutoDeferOnceEnabled = autoDefer
+	return m
+}
+
+func (m MaintenanceWindow) WithStartASAP(startASAP bool) MaintenanceWindow {
+	m.StartASAP = startASAP
+	return m
+}

--- a/pkg/api/v1/project/maintenancewindow.go
+++ b/pkg/api/v1/project/maintenancewindow.go
@@ -31,14 +31,14 @@ type MaintenanceWindow struct {
 }
 
 // ToAtlas converts the MaintenanceWindow to native Atlas client format.
-func (m MaintenanceWindow) ToAtlas() (*mongodbatlas.MaintenanceWindow, error) {
+func (m MaintenanceWindow) ToAtlas() *mongodbatlas.MaintenanceWindow {
 	return &mongodbatlas.MaintenanceWindow{
 		DayOfWeek:            m.DayOfWeek,
 		HourOfDay:            &m.HourOfDay,
 		StartASAP:            &m.StartASAP,
 		NumberOfDeferrals:    0,
 		AutoDeferOnceEnabled: &m.AutoDefer,
-	}, nil
+	}
 }
 
 // ************************************ Builder methods *************************************************

--- a/pkg/api/v1/project/maintenancewindow.go
+++ b/pkg/api/v1/project/maintenancewindow.go
@@ -21,6 +21,12 @@ type MaintenanceWindow struct {
 	// Flag indicating whether project maintenance has been directed to start immediately.
 	// +optional
 	StartASAP bool `json:"startASAP,omitempty"`
+	// Flag indicating whether the next scheduled project maintenance should be deferred for one week.
+	// +optional
+	Defer bool `json:"defer,omitempty"`
+	// Flag indicating whether any scheduled project maintenance should be deferred automatically for one week.
+	// +optional
+	AutoDefer bool `json:"autoDefer,omitempty"`
 }
 
 // ToAtlas converts the ProjectMaintenanceWindow to native Atlas client format.
@@ -47,12 +53,22 @@ func (m MaintenanceWindow) WithHour(hour int) MaintenanceWindow {
 	return m
 }
 
-func (m MaintenanceWindow) WithAutoDefer(autoDefer bool) MaintenanceWindow {
-	m.AutoDeferOnceEnabled = autoDefer
+func (m MaintenanceWindow) WithAutoDeferOnceEnabled(autoDeferOnceEnabled bool) MaintenanceWindow {
+	m.AutoDeferOnceEnabled = autoDeferOnceEnabled
 	return m
 }
 
 func (m MaintenanceWindow) WithStartASAP(startASAP bool) MaintenanceWindow {
 	m.StartASAP = startASAP
+	return m
+}
+
+func (m MaintenanceWindow) WithDefer(isDefer bool) MaintenanceWindow {
+	m.Defer = isDefer
+	return m
+}
+
+func (m MaintenanceWindow) WithAutoDefer(autoDefer bool) MaintenanceWindow {
+	m.AutoDefer = autoDefer
 	return m
 }

--- a/pkg/api/v1/project/maintenancewindow.go
+++ b/pkg/api/v1/project/maintenancewindow.go
@@ -10,10 +10,14 @@ type MaintenanceWindow struct {
 	// Day of the week when you would like the maintenance window to start as a 1-based integer.
 	// Sunday 1, Monday 2, Tuesday 3, Wednesday 4, Thursday 5, Friday 6, Saturday 7
 	// +optional
+	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Maximum=7
 	DayOfWeek int `json:"dayOfWeek,omitempty"`
 	// Hour of the day when you would like the maintenance window to start.
 	// This parameter uses the 24-hour clock, where midnight is 0, noon is 12.
 	// +optional
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Maximum=23
 	HourOfDay int `json:"hourOfDay,omitempty"`
 	// Flag indicating whether any scheduled project maintenance should be deferred automatically for one week.
 	// +optional

--- a/pkg/api/v1/project/maintenancewindow.go
+++ b/pkg/api/v1/project/maintenancewindow.go
@@ -15,18 +15,15 @@ type MaintenanceWindow struct {
 	// This parameter uses the 24-hour clock, where midnight is 0, noon is 12.
 	// +optional
 	HourOfDay int `json:"hourOfDay,omitempty"`
-	// Flag that indicates whether you want to defer all maintenance windows one week they would be triggered.
+	// Flag indicating whether any scheduled project maintenance should be deferred automatically for one week.
 	// +optional
-	AutoDeferOnceEnabled bool `json:"autoDeferOnceEnabled,omitempty"`
+	AutoDefer bool `json:"autoDefer,omitempty"`
 	// Flag indicating whether project maintenance has been directed to start immediately.
 	// +optional
 	StartASAP bool `json:"startASAP,omitempty"`
 	// Flag indicating whether the next scheduled project maintenance should be deferred for one week.
 	// +optional
 	Defer bool `json:"defer,omitempty"`
-	// Flag indicating whether any scheduled project maintenance should be deferred automatically for one week.
-	// +optional
-	AutoDefer bool `json:"autoDefer,omitempty"`
 }
 
 // ToAtlas converts the ProjectMaintenanceWindow to native Atlas client format.
@@ -53,8 +50,8 @@ func (m MaintenanceWindow) WithHour(hour int) MaintenanceWindow {
 	return m
 }
 
-func (m MaintenanceWindow) WithAutoDeferOnceEnabled(autoDeferOnceEnabled bool) MaintenanceWindow {
-	m.AutoDeferOnceEnabled = autoDeferOnceEnabled
+func (m MaintenanceWindow) WithAutoDefer(autoDefer bool) MaintenanceWindow {
+	m.AutoDefer = autoDefer
 	return m
 }
 
@@ -65,10 +62,5 @@ func (m MaintenanceWindow) WithStartASAP(startASAP bool) MaintenanceWindow {
 
 func (m MaintenanceWindow) WithDefer(isDefer bool) MaintenanceWindow {
 	m.Defer = isDefer
-	return m
-}
-
-func (m MaintenanceWindow) WithAutoDefer(autoDefer bool) MaintenanceWindow {
-	m.AutoDefer = autoDefer
 	return m
 }

--- a/pkg/api/v1/project/maintenancewindow.go
+++ b/pkg/api/v1/project/maintenancewindow.go
@@ -21,24 +21,23 @@ type MaintenanceWindow struct {
 	// +optional
 	AutoDefer bool `json:"autoDefer,omitempty"`
 	// Flag indicating whether project maintenance has been directed to start immediately.
+	// Cannot be specified if defer is true
 	// +optional
 	StartASAP bool `json:"startASAP,omitempty"`
 	// Flag indicating whether the next scheduled project maintenance should be deferred for one week.
+	// Cannot be specified if startASAP is true
 	// +optional
 	Defer bool `json:"defer,omitempty"`
 }
 
-// ToAtlas converts the ProjectMaintenanceWindow to native Atlas client format.
+// ToAtlas converts the MaintenanceWindow to native Atlas client format.
 func (m MaintenanceWindow) ToAtlas() (*mongodbatlas.MaintenanceWindow, error) {
-	hourOfDayValue := m.HourOfDay
-	startASAPValue := m.StartASAP
-	autoDeferValue := m.AutoDefer
 	return &mongodbatlas.MaintenanceWindow{
 		DayOfWeek:            m.DayOfWeek,
-		HourOfDay:            &hourOfDayValue,
-		StartASAP:            &startASAPValue,
+		HourOfDay:            &m.HourOfDay,
+		StartASAP:            &m.StartASAP,
 		NumberOfDeferrals:    0,
-		AutoDeferOnceEnabled: &autoDeferValue,
+		AutoDeferOnceEnabled: &m.AutoDefer,
 	}, nil
 }
 

--- a/pkg/api/v1/project/maintenancewindow.go
+++ b/pkg/api/v1/project/maintenancewindow.go
@@ -30,10 +30,6 @@ func (m MaintenanceWindow) ToAtlas() (*mongodbatlas.MaintenanceWindow, error) {
 	return result, err
 }
 
-func (m MaintenanceWindow) Identifier() interface{} {
-	return m.DayOfWeek // TODO complete, is it needed ?
-}
-
 // ************************************ Builder methods *************************************************
 // Note, that we don't use pointers here as the AtlasProject uses this without pointers
 

--- a/pkg/api/v1/project/maintenancewindow.go
+++ b/pkg/api/v1/project/maintenancewindow.go
@@ -30,12 +30,15 @@ type MaintenanceWindow struct {
 
 // ToAtlas converts the ProjectMaintenanceWindow to native Atlas client format.
 func (m MaintenanceWindow) ToAtlas() (*mongodbatlas.MaintenanceWindow, error) {
+	hourOfDayValue := m.HourOfDay
+	startASAPValue := m.StartASAP
+	autoDeferValue := m.AutoDefer
 	return &mongodbatlas.MaintenanceWindow{
 		DayOfWeek:            m.DayOfWeek,
-		HourOfDay:            &m.HourOfDay,
-		StartASAP:            &m.StartASAP,
+		HourOfDay:            &hourOfDayValue,
+		StartASAP:            &startASAPValue,
 		NumberOfDeferrals:    0,
-		AutoDeferOnceEnabled: &m.AutoDefer,
+		AutoDeferOnceEnabled: &autoDeferValue,
 	}, nil
 }
 

--- a/pkg/api/v1/project/maintenancewindow.go
+++ b/pkg/api/v1/project/maintenancewindow.go
@@ -2,8 +2,6 @@ package project
 
 import (
 	"go.mongodb.org/atlas/mongodbatlas"
-
-	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/util/compat"
 )
 
 type MaintenanceWindow struct {
@@ -32,9 +30,13 @@ type MaintenanceWindow struct {
 
 // ToAtlas converts the ProjectMaintenanceWindow to native Atlas client format.
 func (m MaintenanceWindow) ToAtlas() (*mongodbatlas.MaintenanceWindow, error) {
-	result := &mongodbatlas.MaintenanceWindow{}
-	err := compat.JSONCopy(result, m)
-	return result, err
+	return &mongodbatlas.MaintenanceWindow{
+		DayOfWeek:            m.DayOfWeek,
+		HourOfDay:            &m.HourOfDay,
+		StartASAP:            &m.StartASAP,
+		NumberOfDeferrals:    0,
+		AutoDeferOnceEnabled: &m.AutoDefer,
+	}, nil
 }
 
 // ************************************ Builder methods *************************************************

--- a/pkg/api/v1/status/condition.go
+++ b/pkg/api/v1/status/condition.go
@@ -36,6 +36,7 @@ const (
 const (
 	ProjectReadyType                ConditionType = "ProjectReady"
 	IPAccessListReadyType           ConditionType = "IPAccessListReady"
+	MaintenanceWindowReadyType      ConditionType = "MaintenanceWindowReady"
 	PrivateEndpointServiceReadyType ConditionType = "PrivateEndpointServiceReady"
 	PrivateEndpointReadyType        ConditionType = "PrivateEndpointReady"
 	IntegrationReadyType            ConditionType = "ThirdPartyIntegrationReady"

--- a/pkg/api/v1/zz_generated.deepcopy.go
+++ b/pkg/api/v1/zz_generated.deepcopy.go
@@ -624,7 +624,7 @@ func (in *AtlasProjectSpec) DeepCopyInto(out *AtlasProjectSpec) {
 		*out = make([]project.IPAccessList, len(*in))
 		copy(*out, *in)
 	}
-	out.ProjectMaintenanceWindow = in.ProjectMaintenanceWindow
+	out.MaintenanceWindow = in.MaintenanceWindow
 	if in.PrivateEndpoints != nil {
 		in, out := &in.PrivateEndpoints, &out.PrivateEndpoints
 		*out = make([]PrivateEndpoint, len(*in))

--- a/pkg/api/v1/zz_generated.deepcopy.go
+++ b/pkg/api/v1/zz_generated.deepcopy.go
@@ -624,6 +624,7 @@ func (in *AtlasProjectSpec) DeepCopyInto(out *AtlasProjectSpec) {
 		*out = make([]project.IPAccessList, len(*in))
 		copy(*out, *in)
 	}
+	out.ProjectMaintenanceWindow = in.ProjectMaintenanceWindow
 	if in.PrivateEndpoints != nil {
 		in, out := &in.PrivateEndpoints, &out.PrivateEndpoints
 		*out = make([]PrivateEndpoint, len(*in))

--- a/pkg/controller/atlasproject/atlasproject_controller.go
+++ b/pkg/controller/atlasproject/atlasproject_controller.go
@@ -202,10 +202,12 @@ func (r *AtlasProjectReconciler) Reconcile(context context.Context, req ctrl.Req
 	}
 
 	if result = ensureMaintenanceWindow(ctx, projectID, project); !result.IsOk() {
-		ctx.SetConditionTrue(status.MaintenanceWindowReadyType)
-		r.EventRecorder.Event(project, "Normal", string(status.MaintenanceWindowReadyType), "")
+		setCondition(ctx, status.MaintenanceWindowReadyType, result)
+		r.Log.Warnf("%s%s", "Maintenance window reconciliation failed with error ", result.GetMessage())
 		return result.ReconcileResult(), nil
 	}
+	r.EventRecorder.Event(project, "Normal", string(status.MaintenanceWindowReadyType), "")
+	ctx.SetConditionTrue(status.MaintenanceWindowReadyType)
 
 	if result = r.ensurePrivateEndpoint(ctx, projectID, project); !result.IsOk() {
 		return result.ReconcileResult(), nil

--- a/pkg/controller/atlasproject/atlasproject_controller.go
+++ b/pkg/controller/atlasproject/atlasproject_controller.go
@@ -202,7 +202,8 @@ func (r *AtlasProjectReconciler) Reconcile(context context.Context, req ctrl.Req
 	}
 
 	if result = ensureMaintenanceWindow(ctx, projectID, project); !result.IsOk() {
-		// TODO setcondition ?
+		ctx.SetConditionTrue(status.MaintenanceWindowReadyType)
+		r.EventRecorder.Event(project, "Normal", string(status.MaintenanceWindowReadyType), "")
 		return result.ReconcileResult(), nil
 	}
 

--- a/pkg/controller/atlasproject/atlasproject_controller.go
+++ b/pkg/controller/atlasproject/atlasproject_controller.go
@@ -203,7 +203,7 @@ func (r *AtlasProjectReconciler) Reconcile(context context.Context, req ctrl.Req
 
 	if result = ensureMaintenanceWindow(ctx, projectID, project); !result.IsOk() {
 		setCondition(ctx, status.MaintenanceWindowReadyType, result)
-		r.Log.Warnf("%s%s", "Maintenance window reconciliation failed with error ", result.GetMessage())
+		r.Log.Warnf("Maintenance window reconciliation failed with error : %s", result.GetMessage())
 		return result.ReconcileResult(), nil
 	}
 	r.EventRecorder.Event(project, "Normal", string(status.MaintenanceWindowReadyType), "")

--- a/pkg/controller/atlasproject/atlasproject_controller.go
+++ b/pkg/controller/atlasproject/atlasproject_controller.go
@@ -201,6 +201,11 @@ func (r *AtlasProjectReconciler) Reconcile(context context.Context, req ctrl.Req
 		return reconcile.Result{Requeue: true}, nil
 	}
 
+	if result = ensureMaintenanceWindow(ctx, projectID, project); !result.IsOk() {
+		// TODO setcondition ?
+		return result.ReconcileResult(), nil
+	}
+
 	if result = r.ensurePrivateEndpoint(ctx, projectID, project); !result.IsOk() {
 		return result.ReconcileResult(), nil
 	}

--- a/pkg/controller/atlasproject/maintenancewindow.go
+++ b/pkg/controller/atlasproject/maintenancewindow.go
@@ -110,7 +110,7 @@ func validateMaintenanceWindow(window project.MaintenanceWindow) error {
 				2) startASAP is true, deferral fields are empty, autoDeferOnceEnabled is false or empty
 				3) defer is true, all other fields are empty
 				4) autoDefer is true, all other fields are empty
-				5) all fields are empty
+				5) all fields are empty (will delete the window if it exists)
 		`)
 	}
 }

--- a/pkg/controller/atlasproject/maintenancewindow.go
+++ b/pkg/controller/atlasproject/maintenancewindow.go
@@ -1,0 +1,66 @@
+package atlasproject
+
+import (
+	"context"
+	"errors"
+
+	"go.mongodb.org/atlas/mongodbatlas"
+
+	mdbv1 "github.com/mongodb/mongodb-atlas-kubernetes/pkg/api/v1"
+	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/api/v1/project"
+	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/controller/workflow"
+)
+
+func ensureMaintenanceWindow(ctx *workflow.Context, projectID string, project *mdbv1.AtlasProject) workflow.Result {
+	if err := validateMaintenanceWindow(project.Spec.ProjectMaintenanceWindow); err != nil {
+		return workflow.Terminate(workflow.ProjectWindowInvalid, err.Error())
+	}
+
+	if result := createOrUpdateInAtlas(ctx.Client, projectID, project.Spec.ProjectMaintenanceWindow); !result.IsOk() {
+		return result
+	}
+	return workflow.OK()
+}
+
+func validateMaintenanceWindow(window project.MaintenanceWindow) error {
+	// TODO verify we make correct checks here
+	if window.StartASAP {
+		if noneSpecified := isEmpty(window.DayOfWeek) && isEmpty(window.HourOfDay) && !window.AutoDeferOnceEnabled; !noneSpecified {
+			return errors.New("none of 'dayOfWeek', 'hourOfDay' and 'autoDeferOnceEnabled' should be specified if" +
+				" 'startASAP is true")
+		}
+	}
+
+	if isEmpty(window.DayOfWeek) || isEmpty(window.HourOfDay) {
+		return errors.New("both 'dayOfWeek' and 'hourOfDay' must be specified")
+	}
+
+	// Atlas will check if dayOfWeek and hourOfDay are in the bounds
+	return nil
+}
+
+// operatorToAtlasMaintenanceWindow converts the maintenanceWindow specified in the project CR to the format
+// expected by the Atlas API.
+func operatorToAtlasMaintenanceWindow(maintenanceWindow project.MaintenanceWindow) (*mongodbatlas.MaintenanceWindow, workflow.Result) {
+	operatorWindow, err := maintenanceWindow.ToAtlas()
+	if err != nil {
+		return nil, workflow.Terminate(workflow.Internal, err.Error())
+	}
+	return operatorWindow, workflow.OK()
+}
+
+func createOrUpdateInAtlas(client mongodbatlas.Client, projectID string, maintenanceWindow project.MaintenanceWindow) workflow.Result {
+	operatorWindow, status := operatorToAtlasMaintenanceWindow(maintenanceWindow)
+	if !status.IsOk() {
+		return status
+	}
+
+	if _, err := client.MaintenanceWindows.Update(context.Background(), projectID, operatorWindow); err != nil {
+		return workflow.Terminate(workflow.ProjectWindowNotCreatedInAtlas, err.Error())
+	}
+	return workflow.OK()
+}
+
+func isEmpty(i int) bool {
+	return i == 0
+}

--- a/pkg/controller/atlasproject/maintenancewindow.go
+++ b/pkg/controller/atlasproject/maintenancewindow.go
@@ -97,20 +97,16 @@ func validateMaintenanceWindow(window project.MaintenanceWindow) error {
 	if isEmptyWindow(window) || (windowSpecified(window) && maxOneFlag(window)) {
 		return nil
 	}
-	return errors.New(`
-		projectMaintenanceWindow must respect the following constraints, or be empty :
-			1) dayOfWeek must be specified, hourOfDay is 0 by default, autoDeferral is false by default
-			2) only one of (startASAP, defer) is true
-	`)
+	errorString := "projectMaintenanceWindow must respect the following constraints, or be empty : " +
+		"1) dayOfWeek must be specified (hourOfDay is 0 by default, autoDeferral is false by default) " +
+		"2) only one of (startASAP, defer) is true"
+	return errors.New(errorString)
 }
 
 // operatorToAtlasMaintenanceWindow converts the maintenanceWindow specified in the project CR to the format
 // expected by the Atlas API.
 func operatorToAtlasMaintenanceWindow(maintenanceWindow project.MaintenanceWindow) (*mongodbatlas.MaintenanceWindow, workflow.Result) {
-	operatorWindow, err := maintenanceWindow.ToAtlas()
-	if err != nil {
-		return nil, workflow.Terminate(workflow.Internal, err.Error())
-	}
+	operatorWindow := maintenanceWindow.ToAtlas()
 	return operatorWindow, workflow.OK()
 }
 

--- a/pkg/controller/atlasproject/maintenancewindow.go
+++ b/pkg/controller/atlasproject/maintenancewindow.go
@@ -106,11 +106,11 @@ func validateMaintenanceWindow(window project.MaintenanceWindow) error {
 		return errors.New(`
 			projectMaintenanceWindow must respect one of the following constraints :
 				1) both hourOfDay and dayOfWeek are specified (!= 0), deferral fields are empty,
-				   only one or none of startASAP and autoDeferOnceEnabled are true
+				   only one or none of startASAP and autoDeferOnceEnabled is true
 				2) startASAP is true, deferral fields are empty, autoDeferOnceEnabled is false or empty
 				3) defer is true, all other fields are empty
 				4) autoDefer is true, all other fields are empty
-				5) projectMaintenanceWindow isn't specified, or all fields are empty
+				5) all fields are empty
 		`)
 	}
 }

--- a/pkg/controller/atlasproject/maintenancewindow.go
+++ b/pkg/controller/atlasproject/maintenancewindow.go
@@ -15,7 +15,7 @@ import (
 // state of the Maintenance Window specified in the project CR. If a Maintenance Window exists
 // in Atlas but is not specified in the CR, it is deleted.
 func ensureMaintenanceWindow(ctx *workflow.Context, projectID string, atlasProject *mdbv1.AtlasProject) workflow.Result {
-	windowSpec := atlasProject.Spec.ProjectMaintenanceWindow
+	windowSpec := atlasProject.Spec.MaintenanceWindow
 	if err := validateMaintenanceWindow(windowSpec); err != nil {
 		return workflow.Terminate(workflow.ProjectWindowInvalid, err.Error())
 	}
@@ -88,14 +88,7 @@ func windowSpecified(window project.MaintenanceWindow) bool {
 }
 
 func maxOneFlag(window project.MaintenanceWindow) bool {
-	sum := 0
-	if window.StartASAP {
-		sum++
-	}
-	if window.Defer {
-		sum++
-	}
-	return sum <= 1
+	return !(window.StartASAP && window.Defer)
 }
 
 // validateMaintenanceWindow performs validation of the Maintenance Window. Note, that we intentionally don't validate

--- a/pkg/controller/atlasproject/maintenancewindow_test.go
+++ b/pkg/controller/atlasproject/maintenancewindow_test.go
@@ -1,0 +1,183 @@
+package atlasproject
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/api/v1/project"
+)
+
+func TestValidateMaintenanceWindow(t *testing.T) {
+	testCases := []struct {
+		in    project.MaintenanceWindow
+		valid bool
+	}{
+		// All fields empty, valid
+		{
+			in: project.MaintenanceWindow{
+				DayOfWeek:            0,
+				HourOfDay:            0,
+				AutoDeferOnceEnabled: false,
+				StartASAP:            false,
+				Defer:                false,
+				AutoDefer:            false,
+			},
+			valid: true,
+		},
+
+		// Modify just the window (hour and day), valid
+		{
+			in: project.MaintenanceWindow{
+				DayOfWeek:            1, // Sunday
+				HourOfDay:            2, // 2am
+				AutoDeferOnceEnabled: false,
+				StartASAP:            false,
+				Defer:                false,
+				AutoDefer:            false,
+			},
+			valid: true,
+		},
+
+		// Modify window and autoDefer, valid
+		{
+			in: project.MaintenanceWindow{
+				DayOfWeek:            3,  // Tuesday
+				HourOfDay:            14, // 2pm
+				AutoDeferOnceEnabled: true,
+				StartASAP:            false,
+				Defer:                false,
+				AutoDefer:            false,
+			},
+			valid: true,
+		},
+
+		// Modify window and startASAP, valid
+		{
+			in: project.MaintenanceWindow{
+				DayOfWeek:            3,  // Tuesday
+				HourOfDay:            14, // 2pm
+				AutoDeferOnceEnabled: false,
+				StartASAP:            true,
+				Defer:                false,
+				AutoDefer:            false,
+			},
+			valid: true,
+		},
+
+		// startASAP only, valid
+		{
+			in: project.MaintenanceWindow{
+				DayOfWeek:            0,
+				HourOfDay:            0,
+				AutoDeferOnceEnabled: false,
+				StartASAP:            true,
+				Defer:                false,
+				AutoDefer:            false,
+			},
+			valid: true,
+		},
+
+		// Defer only, valid
+		{
+			in: project.MaintenanceWindow{
+				DayOfWeek:            0,
+				HourOfDay:            0,
+				AutoDeferOnceEnabled: false,
+				StartASAP:            false,
+				Defer:                true,
+				AutoDefer:            false,
+			},
+			valid: true,
+		},
+
+		// Auto-defer only, valid
+		{
+			in: project.MaintenanceWindow{
+				DayOfWeek:            0,
+				HourOfDay:            0,
+				AutoDeferOnceEnabled: false,
+				StartASAP:            false,
+				Defer:                false,
+				AutoDefer:            true,
+			},
+			valid: true,
+		},
+
+		// Modify window, both startASAP and autoDeferOnceEnabled activated, invalid
+		{
+			in: project.MaintenanceWindow{
+				DayOfWeek:            1, // Sunday
+				HourOfDay:            2, // 2am
+				AutoDeferOnceEnabled: true,
+				StartASAP:            true,
+				Defer:                false,
+				AutoDefer:            false,
+			},
+			valid: false,
+		},
+
+		// Defer and other fields enabled, invalid
+		{
+			in: project.MaintenanceWindow{
+				DayOfWeek:            1,
+				HourOfDay:            0,
+				AutoDeferOnceEnabled: false,
+				StartASAP:            true,
+				Defer:                true,
+				AutoDefer:            false,
+			},
+			valid: false,
+		},
+
+		// Auto-defer and another field enabled, invalid
+		{
+			in: project.MaintenanceWindow{
+				DayOfWeek:            0,
+				HourOfDay:            0,
+				AutoDeferOnceEnabled: true,
+				StartASAP:            false,
+				Defer:                false,
+				AutoDefer:            true,
+			},
+			valid: false,
+		},
+
+		// AutoDeferOnceEnabled only, invalid
+		{
+			in: project.MaintenanceWindow{
+				DayOfWeek:            0,
+				HourOfDay:            0,
+				AutoDeferOnceEnabled: true,
+				StartASAP:            false,
+				Defer:                false,
+				AutoDefer:            false,
+			},
+			valid: false,
+		},
+
+		// One out of two fields of the window specified, invalid
+		{
+			in: project.MaintenanceWindow{
+				DayOfWeek:            2, // Monday
+				HourOfDay:            0, // Empty
+				AutoDeferOnceEnabled: true,
+				StartASAP:            false,
+				Defer:                false,
+				AutoDefer:            false,
+			},
+			valid: false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run("", func(t *testing.T) {
+			err := validateMaintenanceWindow(testCase.in)
+			if !testCase.valid {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/controller/atlasproject/maintenancewindow_test.go
+++ b/pkg/controller/atlasproject/maintenancewindow_test.go
@@ -16,155 +16,95 @@ func TestValidateMaintenanceWindow(t *testing.T) {
 		// All fields empty, valid
 		{
 			in: project.MaintenanceWindow{
-				DayOfWeek:            0,
-				HourOfDay:            0,
-				AutoDeferOnceEnabled: false,
-				StartASAP:            false,
-				Defer:                false,
-				AutoDefer:            false,
+				DayOfWeek: 0,
+				HourOfDay: 0,
+				StartASAP: false,
+				Defer:     false,
+				AutoDefer: false,
 			},
 			valid: true,
 		},
 
-		// Modify just the window (hour and day), valid
+		// Only dayOfWeek specified, valid
 		{
 			in: project.MaintenanceWindow{
-				DayOfWeek:            1, // Sunday
-				HourOfDay:            2, // 2am
-				AutoDeferOnceEnabled: false,
-				StartASAP:            false,
-				Defer:                false,
-				AutoDefer:            false,
+				DayOfWeek: 1, // Sunday
+				HourOfDay: 0, // Will default to midnight
+				StartASAP: false,
+				Defer:     false,
+				AutoDefer: false,
 			},
 			valid: true,
 		},
 
-		// Modify window and autoDefer, valid
+		// Specify window and autoDefer, valid
 		{
 			in: project.MaintenanceWindow{
-				DayOfWeek:            3,  // Tuesday
-				HourOfDay:            14, // 2pm
-				AutoDeferOnceEnabled: true,
-				StartASAP:            false,
-				Defer:                false,
-				AutoDefer:            false,
+				DayOfWeek: 3,  // Tuesday
+				HourOfDay: 14, // 2pm
+				StartASAP: false,
+				Defer:     false,
+				AutoDefer: true,
 			},
 			valid: true,
 		},
 
-		// Modify window and startASAP, valid
+		// Specify window, autoDefer, and startASAP, valid
 		{
 			in: project.MaintenanceWindow{
-				DayOfWeek:            3,  // Tuesday
-				HourOfDay:            14, // 2pm
-				AutoDeferOnceEnabled: false,
-				StartASAP:            true,
-				Defer:                false,
-				AutoDefer:            false,
+				DayOfWeek: 3,  // Tuesday
+				HourOfDay: 14, // 2pm
+				StartASAP: true,
+				Defer:     false,
+				AutoDefer: true,
 			},
 			valid: true,
 		},
 
-		// startASAP only, valid
+		// Specify window, autoDefer, and defer, valid
 		{
 			in: project.MaintenanceWindow{
-				DayOfWeek:            0,
-				HourOfDay:            0,
-				AutoDeferOnceEnabled: false,
-				StartASAP:            true,
-				Defer:                false,
-				AutoDefer:            false,
+				DayOfWeek: 3,  // Tuesday
+				HourOfDay: 14, // 2pm
+				StartASAP: false,
+				Defer:     true,
+				AutoDefer: true,
 			},
 			valid: true,
 		},
 
-		// Defer only, valid
+		// StartASAP only, invalid
 		{
 			in: project.MaintenanceWindow{
-				DayOfWeek:            0,
-				HourOfDay:            0,
-				AutoDeferOnceEnabled: false,
-				StartASAP:            false,
-				Defer:                true,
-				AutoDefer:            false,
-			},
-			valid: true,
-		},
-
-		// Auto-defer only, valid
-		{
-			in: project.MaintenanceWindow{
-				DayOfWeek:            0,
-				HourOfDay:            0,
-				AutoDeferOnceEnabled: false,
-				StartASAP:            false,
-				Defer:                false,
-				AutoDefer:            true,
-			},
-			valid: true,
-		},
-
-		// Modify window, both startASAP and autoDeferOnceEnabled activated, invalid
-		{
-			in: project.MaintenanceWindow{
-				DayOfWeek:            1, // Sunday
-				HourOfDay:            2, // 2am
-				AutoDeferOnceEnabled: true,
-				StartASAP:            true,
-				Defer:                false,
-				AutoDefer:            false,
+				DayOfWeek: 0,
+				HourOfDay: 0,
+				StartASAP: true,
+				Defer:     false,
+				AutoDefer: false,
 			},
 			valid: false,
 		},
 
-		// Defer and other fields enabled, invalid
+		// AutoDefer only, invalid
 		{
 			in: project.MaintenanceWindow{
-				DayOfWeek:            1,
-				HourOfDay:            0,
-				AutoDeferOnceEnabled: false,
-				StartASAP:            true,
-				Defer:                true,
-				AutoDefer:            false,
+				DayOfWeek: 0,
+				HourOfDay: 0,
+				StartASAP: false,
+				Defer:     false,
+				AutoDefer: true,
 			},
 			valid: false,
 		},
 
-		// Auto-defer and another field enabled, invalid
+		// Both startASAP and Defer specified, invalid
 		{
 			in: project.MaintenanceWindow{
-				DayOfWeek:            0,
-				HourOfDay:            0,
-				AutoDeferOnceEnabled: true,
-				StartASAP:            false,
-				Defer:                false,
-				AutoDefer:            true,
-			},
-			valid: false,
-		},
-
-		// AutoDeferOnceEnabled only, invalid
-		{
-			in: project.MaintenanceWindow{
-				DayOfWeek:            0,
-				HourOfDay:            0,
-				AutoDeferOnceEnabled: true,
-				StartASAP:            false,
-				Defer:                false,
-				AutoDefer:            false,
-			},
-			valid: false,
-		},
-
-		// One out of two fields of the window specified, invalid
-		{
-			in: project.MaintenanceWindow{
-				DayOfWeek:            2, // Monday
-				HourOfDay:            0, // Empty
-				AutoDeferOnceEnabled: true,
-				StartASAP:            false,
-				Defer:                false,
-				AutoDefer:            false,
+				DayOfWeek: 3,  // Tuesday
+				HourOfDay: 14, // 2pm
+				StartASAP: true,
+				Defer:     true,
+				AutoDefer: true,
 			},
 			valid: false,
 		},

--- a/pkg/controller/workflow/reason.go
+++ b/pkg/controller/workflow/reason.go
@@ -15,6 +15,8 @@ const (
 	ProjectNotCreatedInAtlas                ConditionReason = "ProjectNotCreatedInAtlas"
 	ProjectIPAccessInvalid                  ConditionReason = "ProjectIPAccessListInvalid"
 	ProjectIPNotCreatedInAtlas              ConditionReason = "ProjectIPAccessListNotCreatedInAtlas"
+	ProjectWindowInvalid                    ConditionReason = "ProjectWindowInvalid"
+	ProjectWindowNotCreatedInAtlas          ConditionReason = "ProjectWindowNotCreatedInAtlas"
 	ProjectPEServiceIsNotReadyInAtlas       ConditionReason = "ProjectPrivateEndpointServiceIsNotReadyInAtlas"
 	ProjectPrivateEndpointIsNotReadyInAtlas ConditionReason = "ProjectPrivateEndpointIsNotReadyInAtlas"
 	ProjectIPAccessListNotActive            ConditionReason = "ProjectIPAccessListNotActive"

--- a/pkg/controller/workflow/reason.go
+++ b/pkg/controller/workflow/reason.go
@@ -17,6 +17,7 @@ const (
 	ProjectIPNotCreatedInAtlas              ConditionReason = "ProjectIPAccessListNotCreatedInAtlas"
 	ProjectWindowInvalid                    ConditionReason = "ProjectWindowInvalid"
 	ProjectWindowNotCreatedInAtlas          ConditionReason = "ProjectWindowNotCreatedInAtlas"
+	ProjectWindowNotDeletedInAtlas          ConditionReason = "projectWindowNotDeletedInAtlas"
 	ProjectPEServiceIsNotReadyInAtlas       ConditionReason = "ProjectPrivateEndpointServiceIsNotReadyInAtlas"
 	ProjectPrivateEndpointIsNotReadyInAtlas ConditionReason = "ProjectPrivateEndpointIsNotReadyInAtlas"
 	ProjectIPAccessListNotActive            ConditionReason = "ProjectIPAccessListNotActive"

--- a/pkg/controller/workflow/reason.go
+++ b/pkg/controller/workflow/reason.go
@@ -18,6 +18,8 @@ const (
 	ProjectWindowInvalid                    ConditionReason = "ProjectWindowInvalid"
 	ProjectWindowNotCreatedInAtlas          ConditionReason = "ProjectWindowNotCreatedInAtlas"
 	ProjectWindowNotDeletedInAtlas          ConditionReason = "projectWindowNotDeletedInAtlas"
+	ProjectWindowNotDeferredInAtlas         ConditionReason = "ProjectWindowNotDeferredInAtlas"
+	ProjectWindowNotAutoDeferredInAtlas     ConditionReason = "ProjectWindowNotAutoDeferredInAtlas"
 	ProjectPEServiceIsNotReadyInAtlas       ConditionReason = "ProjectPrivateEndpointServiceIsNotReadyInAtlas"
 	ProjectPrivateEndpointIsNotReadyInAtlas ConditionReason = "ProjectPrivateEndpointIsNotReadyInAtlas"
 	ProjectIPAccessListNotActive            ConditionReason = "ProjectIPAccessListNotActive"

--- a/pkg/controller/workflow/reason.go
+++ b/pkg/controller/workflow/reason.go
@@ -16,6 +16,7 @@ const (
 	ProjectIPAccessInvalid                  ConditionReason = "ProjectIPAccessListInvalid"
 	ProjectIPNotCreatedInAtlas              ConditionReason = "ProjectIPAccessListNotCreatedInAtlas"
 	ProjectWindowInvalid                    ConditionReason = "ProjectWindowInvalid"
+	ProjectWindowNotObtainedFromAtlas       ConditionReason = "ProjectWindowNotObtainedFromAtlas"
 	ProjectWindowNotCreatedInAtlas          ConditionReason = "ProjectWindowNotCreatedInAtlas"
 	ProjectWindowNotDeletedInAtlas          ConditionReason = "projectWindowNotDeletedInAtlas"
 	ProjectWindowNotDeferredInAtlas         ConditionReason = "ProjectWindowNotDeferredInAtlas"

--- a/pkg/util/testutil/maintenancewindow_matcher.go
+++ b/pkg/util/testutil/maintenancewindow_matcher.go
@@ -1,6 +1,8 @@
 package testutil
 
 import (
+	"reflect"
+
 	"github.com/onsi/gomega/format"
 	"github.com/onsi/gomega/types"
 	"go.mongodb.org/atlas/mongodbatlas"
@@ -21,10 +23,11 @@ type maintenanceWindowMatcher struct {
 }
 
 func (m *maintenanceWindowMatcher) Match(actual interface{}) (success bool, err error) {
-	var c mongodbatlas.MaintenanceWindow
+	var c *mongodbatlas.MaintenanceWindow
 	var ok bool
-	if c, ok = actual.(mongodbatlas.MaintenanceWindow); !ok {
-		panic("Expected mongodbatlas.ProjectMaintenanceWindow")
+	if c, ok = actual.(*mongodbatlas.MaintenanceWindow); !ok {
+		actualType := reflect.TypeOf(actual)
+		panic("Expected *mongodbatlas.MaintenanceWindow but received type " + actualType.String())
 	}
 	if c.DayOfWeek != m.ExpectedMaintenanceWindow.DayOfWeek {
 		return false, nil

--- a/pkg/util/testutil/maintenancewindow_matcher.go
+++ b/pkg/util/testutil/maintenancewindow_matcher.go
@@ -1,0 +1,48 @@
+package testutil
+
+import (
+	"github.com/onsi/gomega/format"
+	"github.com/onsi/gomega/types"
+	"go.mongodb.org/atlas/mongodbatlas"
+
+	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/api/v1/project"
+)
+
+// MatchMaintenanceWindow returns the GomegaMatcher that checks if the 'actual' mongodbatlas.MaintenanceWindow matches
+// the 'expected' mdbv1.MaintenanceWindow  one.
+// Note, that we cannot compare them by all the fields as Atlas tends to set default fields after MaintenanceWindow
+// requests execution so we need to compare only the fields that remain in the same state
+func MatchMaintenanceWindow(expected project.MaintenanceWindow) types.GomegaMatcher {
+	return &maintenanceWindowMatcher{ExpectedMaintenanceWindow: expected}
+}
+
+type maintenanceWindowMatcher struct {
+	ExpectedMaintenanceWindow project.MaintenanceWindow
+}
+
+func (m *maintenanceWindowMatcher) Match(actual interface{}) (success bool, err error) {
+	var c mongodbatlas.MaintenanceWindow
+	var ok bool
+	if c, ok = actual.(mongodbatlas.MaintenanceWindow); !ok {
+		panic("Expected mongodbatlas.ProjectIPAccessList")
+	}
+	if m.ExpectedMaintenanceWindow.DayOfWeek != 0 && c.DayOfWeek != m.ExpectedMaintenanceWindow.DayOfWeek {
+		return false, nil
+	}
+	if *c.HourOfDay != m.ExpectedMaintenanceWindow.HourOfDay {
+		return false, nil
+	}
+	// TODO : check assumption : an autoDefer POST request enable the field AutoDeferOnceEnabled of the maintenance object
+	if *c.AutoDeferOnceEnabled != m.ExpectedMaintenanceWindow.AutoDefer {
+		return false, nil
+	}
+	return true, nil
+}
+
+func (m *maintenanceWindowMatcher) FailureMessage(actual interface{}) (message string) {
+	return format.Message(actual, "to match", m.ExpectedMaintenanceWindow)
+}
+
+func (m *maintenanceWindowMatcher) NegatedFailureMessage(actual interface{}) (message string) {
+	return format.Message(actual, "not to match", m.ExpectedMaintenanceWindow)
+}

--- a/pkg/util/testutil/maintenancewindow_matcher.go
+++ b/pkg/util/testutil/maintenancewindow_matcher.go
@@ -24,7 +24,7 @@ func (m *maintenanceWindowMatcher) Match(actual interface{}) (success bool, err 
 	var c mongodbatlas.MaintenanceWindow
 	var ok bool
 	if c, ok = actual.(mongodbatlas.MaintenanceWindow); !ok {
-		panic("Expected mongodbatlas.ProjectIPAccessList")
+		panic("Expected mongodbatlas.ProjectMaintenanceWindow")
 	}
 	if c.DayOfWeek != m.ExpectedMaintenanceWindow.DayOfWeek {
 		return false, nil

--- a/pkg/util/testutil/maintenancewindow_matcher.go
+++ b/pkg/util/testutil/maintenancewindow_matcher.go
@@ -9,7 +9,7 @@ import (
 )
 
 // MatchMaintenanceWindow returns the GomegaMatcher that checks if the 'actual' mongodbatlas.MaintenanceWindow matches
-// the 'expected' mdbv1.MaintenanceWindow  one.
+// the 'expected' mdbv1.MaintenanceWindow one.
 // Note, that we cannot compare them by all the fields as Atlas tends to set default fields after MaintenanceWindow
 // requests execution so we need to compare only the fields that remain in the same state
 func MatchMaintenanceWindow(expected project.MaintenanceWindow) types.GomegaMatcher {
@@ -26,13 +26,12 @@ func (m *maintenanceWindowMatcher) Match(actual interface{}) (success bool, err 
 	if c, ok = actual.(mongodbatlas.MaintenanceWindow); !ok {
 		panic("Expected mongodbatlas.ProjectIPAccessList")
 	}
-	if m.ExpectedMaintenanceWindow.DayOfWeek != 0 && c.DayOfWeek != m.ExpectedMaintenanceWindow.DayOfWeek {
+	if c.DayOfWeek != m.ExpectedMaintenanceWindow.DayOfWeek {
 		return false, nil
 	}
 	if *c.HourOfDay != m.ExpectedMaintenanceWindow.HourOfDay {
 		return false, nil
 	}
-	// TODO : check assumption : an autoDefer POST request enable the field AutoDeferOnceEnabled of the maintenance object
 	if *c.AutoDeferOnceEnabled != m.ExpectedMaintenanceWindow.AutoDefer {
 		return false, nil
 	}

--- a/pkg/util/testutil/maintenancewindow_matcher.go
+++ b/pkg/util/testutil/maintenancewindow_matcher.go
@@ -1,6 +1,7 @@
 package testutil
 
 import (
+	"errors"
 	"reflect"
 
 	"github.com/onsi/gomega/format"
@@ -27,7 +28,7 @@ func (m *maintenanceWindowMatcher) Match(actual interface{}) (success bool, err 
 	var ok bool
 	if c, ok = actual.(*mongodbatlas.MaintenanceWindow); !ok {
 		actualType := reflect.TypeOf(actual)
-		panic("Expected *mongodbatlas.MaintenanceWindow but received type " + actualType.String())
+		return false, errors.New("Expected *mongodbatlas.MaintenanceWindow but received type " + actualType.String())
 	}
 	if c.DayOfWeek != m.ExpectedMaintenanceWindow.DayOfWeek {
 		return false, nil

--- a/test/int/project_test.go
+++ b/test/int/project_test.go
@@ -77,7 +77,7 @@ var _ = Describe("AtlasProject", Label("int", "AtlasProject"), func() {
 	checkMaintenanceWindowInAtlas := func() {
 		window, _, err := atlasClient.MaintenanceWindows.Get(context.Background(), createdProject.ID())
 		Expect(err).NotTo(HaveOccurred())
-		Expect(window).To(testutil.MatchMaintenanceWindow(createdProject.Spec.ProjectMaintenanceWindow))
+		Expect(window).To(testutil.MatchMaintenanceWindow(createdProject.Spec.MaintenanceWindow))
 	}
 
 	checkAtlasProjectIsReady := func() {
@@ -245,7 +245,7 @@ var _ = Describe("AtlasProject", Label("int", "AtlasProject"), func() {
 			By("Updating the project")
 
 			createdProject.Spec.ProjectIPAccessList = []project.IPAccessList{{CIDRBlock: "0.0.0.0/0"}}
-			createdProject.Spec.ProjectMaintenanceWindow = project.MaintenanceWindow{
+			createdProject.Spec.MaintenanceWindow = project.MaintenanceWindow{
 				DayOfWeek: 4,
 				HourOfDay: 11,
 				AutoDefer: true,
@@ -459,8 +459,8 @@ var _ = Describe("AtlasProject", Label("int", "AtlasProject"), func() {
 					ProjectCreationTimeout, interval).Should(BeTrue())
 			})
 			By("Updating the project maintenance window hour and enabling auto-defer", func() {
-				createdProject.Spec.ProjectMaintenanceWindow.HourOfDay = 3
-				createdProject.Spec.ProjectMaintenanceWindow.AutoDefer = true
+				createdProject.Spec.MaintenanceWindow.HourOfDay = 3
+				createdProject.Spec.MaintenanceWindow.AutoDefer = true
 				Expect(k8sClient.Update(context.Background(), createdProject)).To(Succeed())
 
 				Eventually(testutil.WaitFor(k8sClient, createdProject, status.TrueCondition(status.ReadyType), validateNoErrorsMaintenanceWindowDuringUpdate),
@@ -470,7 +470,7 @@ var _ = Describe("AtlasProject", Label("int", "AtlasProject"), func() {
 				checkMaintenanceWindowInAtlas()
 			})
 			By("Toggling auto-defer to false", func() {
-				createdProject.Spec.ProjectMaintenanceWindow.AutoDefer = false
+				createdProject.Spec.MaintenanceWindow.AutoDefer = false
 				Expect(k8sClient.Update(context.Background(), createdProject)).To(Succeed())
 
 				Eventually(testutil.WaitFor(k8sClient, createdProject, status.TrueCondition(status.ReadyType), validateNoErrorsMaintenanceWindowDuringUpdate),

--- a/test/int/project_test.go
+++ b/test/int/project_test.go
@@ -482,8 +482,6 @@ var _ = Describe("AtlasProject", Label("int", "AtlasProject"), func() {
 		})
 	})
 
-	// TODO : more integration tests ? e.g trying invalid spec (multiple flags activated), but this is also tested by unit tests
-
 	Describe("Using the global Connection Secret", func() {
 		It("Should Succeed", func() {
 			globalConnectionSecret := buildConnectionSecret("atlas-operator-api-key")

--- a/test/int/project_test.go
+++ b/test/int/project_test.go
@@ -498,6 +498,7 @@ var _ = Describe("AtlasProject", Label("int", "AtlasProject"), func() {
 			expectedConditionsMatchers := testutil.MatchConditions(
 				status.TrueCondition(status.ProjectReadyType),
 				status.TrueCondition(status.IPAccessListReadyType),
+				status.TrueCondition(status.MaintenanceWindowReadyType),
 				status.TrueCondition(status.ReadyType),
 				status.TrueCondition(status.ValidationSucceeded),
 			)


### PR DESCRIPTION
### All Submissions:

* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [x] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if there is one).
* [ ] Update docs/release-notes/release-notes.md if your changes should be included in the release notes for the next release.

# Maintenance window feature guide 

## Example of definition of a maintenance window for an atlas project :

```
projectMaintenanceWindow:
  dayOfWeek: 5
  hourOfDay: 1
  autoDefer: false
  startASAP: false
  defer: false
```
If no field specified, maintenance window is deleted (if it exists)
User must always specify at least `dayOfWeek`. `hourOfDay` is defaulted to 0 (midnight), `autoDefer` is defaulted to false
Only one of (`startASAP`, `defer`) can be true

`dayOfWeek`, `hourOfDay` and `autoDefer` represent the actual state of the window in Atlas 
`defer` and `startASAP` are used to send one request only (and then the user should reset them to `false`)

## How the operator works :

1. Check if window needs to be deleted
2. Check if window needs to be updated (`hourOfDay`, `dayOfWeek`)
    1. If yes, update (`hourOfDay`, `dayOfWeek`, `autoDefer`) according to YAML spec
    2. If no, check if `autoDefer` must be toggled (there is a specific request in Atlas API for this field)
3. Check if a `startASAP` request needs to be sent, if yes send and return
4. Check if a `defer` request needs to be sent, if yes send and return


Although it doesn’t make much sense, it is possible both to toggle auto-deferral and to ask the maintenance to start immediately through the API, so the operator reflects this possibility as well 
Note : `defer` works only if a maintenance is scheduled (a notification has been sent to the user 72h prior to the beginning), the operator doesn’t check for that and simply send the deferral request  which might fail if no maintenance is scheduled