### PR TITLE
Fix backup export and policies

### DIFF
--- a/config/crd/bases/atlas.mongodb.com_atlasbackuppolicies.yaml
+++ b/config/crd/bases/atlas.mongodb.com_atlasbackuppolicies.yaml
@@ -46,13 +46,6 @@ spec:
                         instance of the corresponding FrequencyType. The only accepted
                         value you can set for frequency interval with NVMe clusters
                         is 12.
-                      enum:
-                      - 1
-                      - 2
-                      - 4
-                      - 6
-                      - 8
-                      - 12
                       type: integer
                     frequencyType:
                       description: 'Frequency associated with the backup policy item.

--- a/pkg/api/v1/atlasbackuppolicy_types.go
+++ b/pkg/api/v1/atlasbackuppolicy_types.go
@@ -25,7 +25,6 @@ type AtlasBackupPolicyItem struct {
 
 	// Desired frequency of the new backup policy item specified by FrequencyType. A value of 1 specifies the first instance of the corresponding FrequencyType.
 	// The only accepted value you can set for frequency interval with NVMe clusters is 12.
-	// +kubebuilder:validation:Enum:=1;2;4;6;8;12
 	FrequencyInterval int `json:"frequencyInterval"`
 
 	// Scope of the backup policy item: days, weeks, or months

--- a/pkg/api/v1/atlasbackupschedule_types.go
+++ b/pkg/api/v1/atlasbackupschedule_types.go
@@ -23,7 +23,7 @@ type AtlasBackupScheduleSpec struct {
 
 	// Export policy for automatically exporting cloud backup snapshots to AWS bucket.
 	// +optional
-	Export AtlasBackupExportSpec `json:"export,omitempty"`
+	Export *AtlasBackupExportSpec `json:"export,omitempty"`
 
 	// A reference (name & namespace) for backup policy in the desired updated backup policy.
 	PolicyRef common.ResourceRefNamespaced `json:"policy"`

--- a/test/int/deployment_test.go
+++ b/test/int/deployment_test.go
@@ -816,7 +816,7 @@ var _ = Describe("AtlasDeployment", Label("int", "AtlasDeployment"), func() {
 					ReferenceMinuteOfHour: 10,
 					RestoreWindowDays:     5,
 					UpdateSnapshots:       false,
-					Export:                mdbv1.AtlasBackupExportSpec{FrequencyType: "MONTHLY"},
+					Export:                &mdbv1.AtlasBackupExportSpec{FrequencyType: "MONTHLY"},
 				},
 			}
 


### PR DESCRIPTION
### All Submissions:

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [X] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if there is one).
* [X] Update docs/release-notes/release-notes.md if your changes should be included in the release notes for the next release.

The export field should be a pointer, to avoid instantiating the underlying struct when not specified in Atlas.
The enum validation was wrong, the specified set of value works only for hourly backup, but not for the other frequencies.