### PR TITLE
CLOUDP-133702: Prevent changing instanceSize and diskGB if autoscaling is enabled

### DIFF
--- a/.github/workflows/openshift-upgrade-test.yaml
+++ b/.github/workflows/openshift-upgrade-test.yaml
@@ -34,6 +34,11 @@ jobs:
         id: prepare
         uses: ./.github/actions/set-tag
 
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: "1.18"
+
       - name: Download tools for openshift test
         run: |
           wget https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/latest-4.9/opm-linux.tar.gz -O opm.tar.gz -q

--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ int-test: export GINKGO_EDITOR_INTEGRATION="true"
 int-test: generate manifests ## Run integration tests. Sample with labels: `make int-test label=AtlasProject` or `make int-test label='AtlasDeployment && !slow'`
 	mkdir -p $(ENVTEST_ASSETS_DIR)
 	test -f $(ENVTEST_ASSETS_DIR)/setup-envtest.sh || curl -sSLo $(ENVTEST_ASSETS_DIR)/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.8.0/hack/setup-envtest.sh
-	source $(ENVTEST_ASSETS_DIR)/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); ginkgo --label-filter='$(label)' --timeout 80m -v -nodes=8 ./test/int -coverprofile cover.out
+	source $(ENVTEST_ASSETS_DIR)/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); ./scripts/int_local.sh $(label)
 
 .PHONY: e2e
 e2e: run-kind ## Run e2e test. Command `make e2e label=cluster-ns` run cluster-ns test

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mongodb/mongodb-atlas-kubernetes
 
-go 1.17
+go 1.18
 
 require (
 	github.com/Azure/azure-sdk-for-go v66.0.0+incompatible

--- a/pkg/api/v1/atlasdeployment_types_test.go
+++ b/pkg/api/v1/atlasdeployment_types_test.go
@@ -146,17 +146,17 @@ func parseJSONName(t reflect.StructTag) string {
 
 func TestIsEqual(t *testing.T) {
 	operatorArgs := ProcessArgs{
-		JavascriptEnabled: toptr.Boolptr(true),
+		JavascriptEnabled: toptr.MakePtr(true),
 	}
 
 	atlasArgs := mongodbatlas.ProcessArgs{
-		JavascriptEnabled: toptr.Boolptr(false),
+		JavascriptEnabled: toptr.MakePtr(false),
 	}
 
 	areTheyEqual := operatorArgs.IsEqual(atlasArgs)
 	assert.False(t, areTheyEqual, "should NOT be equal if pointer values are different")
 
-	atlasArgs.JavascriptEnabled = toptr.Boolptr(true)
+	atlasArgs.JavascriptEnabled = toptr.MakePtr(true)
 
 	areTheyEqual = operatorArgs.IsEqual(atlasArgs)
 	assert.True(t, areTheyEqual, "should be equal if all pointer values are the same")
@@ -174,7 +174,7 @@ func TestIsEqual(t *testing.T) {
 	areTheyEqual = operatorArgs.IsEqual(atlasArgs)
 	assert.True(t, areTheyEqual, "should work for non-pointer values")
 
-	operatorArgs.OplogSizeMB = toptr.Int64ptr(8)
+	operatorArgs.OplogSizeMB = toptr.MakePtr[int64](8)
 
 	areTheyEqual = operatorArgs.IsEqual(atlasArgs)
 	assert.False(t, areTheyEqual, "should NOT be equal if Operator has more args")

--- a/pkg/controller/atlasdeployment/advanced_deployment.go
+++ b/pkg/controller/atlasdeployment/advanced_deployment.go
@@ -120,13 +120,13 @@ func handleAutoscaling(kubeDeployment *mdbv1.AdvancedDeploymentSpec) {
 			if regConfig.AutoScaling != nil {
 				if regConfig.AutoScaling.DiskGB != nil &&
 					regConfig.AutoScaling.DiskGB.Enabled != nil &&
-					*regConfig.AutoScaling.DiskGB.Enabled == true {
+					*regConfig.AutoScaling.DiskGB.Enabled {
 					isDiskAutoScaled = true
 				}
 
 				if regConfig.AutoScaling.Compute != nil &&
 					regConfig.AutoScaling.Compute.Enabled != nil &&
-					*regConfig.AutoScaling.Compute.Enabled == true {
+					*regConfig.AutoScaling.Compute.Enabled {
 					cleanupInstanceSize(regConfig.ElectableSpecs)
 					cleanupInstanceSize(regConfig.AnalyticsSpecs)
 					cleanupInstanceSize(regConfig.ReadOnlySpecs)

--- a/pkg/controller/atlasdeployment/advanced_deployment.go
+++ b/pkg/controller/atlasdeployment/advanced_deployment.go
@@ -59,6 +59,8 @@ func (r *AtlasDeploymentReconciler) ensureAdvancedDeploymentState(ctx *workflow.
 }
 
 func advancedDeploymentIdle(ctx *workflow.Context, project *mdbv1.AtlasProject, deployment *mdbv1.AtlasDeployment, atlasDeploymentAsAtlas *mongodbatlas.AdvancedCluster) (*mongodbatlas.AdvancedCluster, workflow.Result) {
+	handleAutoscaling(deployment.Spec.AdvancedDeploymentSpec)
+
 	specDeployment, atlasDeployment, err := MergedAdvancedDeployment(*atlasDeploymentAsAtlas, *deployment.Spec.AdvancedDeploymentSpec)
 	if err != nil {
 		return atlasDeploymentAsAtlas, workflow.Terminate(workflow.Internal, err.Error())
@@ -81,7 +83,11 @@ func advancedDeploymentIdle(ctx *workflow.Context, project *mdbv1.AtlasProject, 
 		}
 	}
 
-	deploymentAsAtlas, err := cleanupTheSpec(specDeployment).ToAtlas()
+	// Prevent changing of instanceSize and diskSizeGB if autoscaling is enabled
+
+	cleanupTheSpec(&specDeployment)
+
+	deploymentAsAtlas, err := specDeployment.ToAtlas()
 	if err != nil {
 		return atlasDeploymentAsAtlas, workflow.Terminate(workflow.Internal, err.Error())
 	}
@@ -94,9 +100,44 @@ func advancedDeploymentIdle(ctx *workflow.Context, project *mdbv1.AtlasProject, 
 	return nil, workflow.InProgress(workflow.DeploymentUpdating, "deployment is updating")
 }
 
-func cleanupTheSpec(deployment mdbv1.AdvancedDeploymentSpec) *mdbv1.AdvancedDeploymentSpec {
+func cleanupTheSpec(deployment *mdbv1.AdvancedDeploymentSpec) {
 	deployment.MongoDBVersion = ""
-	return &deployment
+}
+
+// This will prevent from setting diskSizeGB if at least one region config has enabled disk size autoscaling
+// It will also prevent from setting ANY of (electable | analytics | readonly) specs
+//
+//	if region config has enabled compute autoscaling
+func handleAutoscaling(kubeDeployment *mdbv1.AdvancedDeploymentSpec) {
+	isDiskAutoScaled := false
+	cleanupInstanceSize := func(s *mdbv1.Specs) {
+		if s != nil {
+			s.InstanceSize = ""
+		}
+	}
+	for _, repSpec := range kubeDeployment.ReplicationSpecs {
+		for _, regConfig := range repSpec.RegionConfigs {
+			if regConfig.AutoScaling != nil {
+				if regConfig.AutoScaling.DiskGB != nil &&
+					regConfig.AutoScaling.DiskGB.Enabled != nil &&
+					*regConfig.AutoScaling.DiskGB.Enabled == true {
+					isDiskAutoScaled = true
+				}
+
+				if regConfig.AutoScaling.Compute != nil &&
+					regConfig.AutoScaling.Compute.Enabled != nil &&
+					*regConfig.AutoScaling.Compute.Enabled == true {
+					cleanupInstanceSize(regConfig.ElectableSpecs)
+					cleanupInstanceSize(regConfig.AnalyticsSpecs)
+					cleanupInstanceSize(regConfig.ReadOnlySpecs)
+				}
+			}
+		}
+	}
+
+	if isDiskAutoScaled {
+		kubeDeployment.DiskSizeGB = nil
+	}
 }
 
 // MergedAdvancedDeployment will return the result of merging AtlasDeploymentSpec with Atlas Advanced Deployment

--- a/pkg/controller/atlasdeployment/advanced_deployment_test.go
+++ b/pkg/controller/atlasdeployment/advanced_deployment_test.go
@@ -1,6 +1,8 @@
 package atlasdeployment
 
 import (
+	"encoding/json"
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -60,4 +62,396 @@ func TestMergedAdvancedDeployment(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, "AWS", merged.ReplicationSpecs[0].RegionConfigs[0].BackingProviderName)
 	})
+}
+
+func MakePtr[T comparable](val T) *T {
+	return &val
+}
+
+func TestAdvancedDeployment_handleAutoscaling(t *testing.T) {
+	testCases := []struct {
+		input      *v1.AdvancedDeploymentSpec
+		expected   *v1.AdvancedDeploymentSpec
+		shouldFail bool
+		testName   string
+	}{
+		{
+			testName: "One region and autoscaling ENABLED for compute AND disk",
+			input: &v1.AdvancedDeploymentSpec{
+				DiskSizeGB: MakePtr(15),
+				ReplicationSpecs: []*v1.AdvancedReplicationSpec{
+					{
+						NumShards: 1,
+						ZoneName:  "us-east-1",
+						RegionConfigs: []*v1.AdvancedRegionConfig{
+							{
+								ElectableSpecs: &v1.Specs{
+									DiskIOPS:      nil,
+									EbsVolumeType: "",
+									InstanceSize:  "M30",
+									NodeCount:     MakePtr(1),
+								},
+								AutoScaling: &v1.AdvancedAutoScalingSpec{
+									DiskGB: &v1.DiskGB{
+										Enabled: MakePtr(true),
+									},
+									Compute: &v1.ComputeSpec{
+										Enabled:          MakePtr(true),
+										ScaleDownEnabled: nil,
+										MinInstanceSize:  "M10",
+										MaxInstanceSize:  "M40",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: &v1.AdvancedDeploymentSpec{
+				DiskSizeGB: nil,
+				ReplicationSpecs: []*v1.AdvancedReplicationSpec{
+					{
+						NumShards: 1,
+						ZoneName:  "us-east-1",
+						RegionConfigs: []*v1.AdvancedRegionConfig{
+							{
+								ElectableSpecs: &v1.Specs{
+									DiskIOPS:      nil,
+									EbsVolumeType: "",
+									InstanceSize:  "",
+									NodeCount:     MakePtr(1),
+								},
+								AutoScaling: &v1.AdvancedAutoScalingSpec{
+									DiskGB: &v1.DiskGB{
+										Enabled: MakePtr(true),
+									},
+									Compute: &v1.ComputeSpec{
+										Enabled:          MakePtr(true),
+										ScaleDownEnabled: nil,
+										MinInstanceSize:  "M10",
+										MaxInstanceSize:  "M40",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			shouldFail: false,
+		},
+		{
+			testName: "One region and autoscaling ENABLED for compute ONLY",
+			input: &v1.AdvancedDeploymentSpec{
+				DiskSizeGB: MakePtr(15),
+				ReplicationSpecs: []*v1.AdvancedReplicationSpec{
+					{
+						NumShards: 1,
+						ZoneName:  "us-east-1",
+						RegionConfigs: []*v1.AdvancedRegionConfig{
+							{
+								ElectableSpecs: &v1.Specs{
+									DiskIOPS:      nil,
+									EbsVolumeType: "",
+									InstanceSize:  "M40",
+									NodeCount:     MakePtr(1),
+								},
+								AutoScaling: &v1.AdvancedAutoScalingSpec{
+									DiskGB: &v1.DiskGB{
+										Enabled: MakePtr(false),
+									},
+									Compute: &v1.ComputeSpec{
+										Enabled:          MakePtr(true),
+										ScaleDownEnabled: nil,
+										MinInstanceSize:  "M10",
+										MaxInstanceSize:  "M40",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: &v1.AdvancedDeploymentSpec{
+				DiskSizeGB: MakePtr(15),
+				ReplicationSpecs: []*v1.AdvancedReplicationSpec{
+					{
+						NumShards: 1,
+						ZoneName:  "us-east-1",
+						RegionConfigs: []*v1.AdvancedRegionConfig{
+							{
+								ElectableSpecs: &v1.Specs{
+									DiskIOPS:      nil,
+									EbsVolumeType: "",
+									InstanceSize:  "",
+									NodeCount:     MakePtr(1),
+								},
+								AutoScaling: &v1.AdvancedAutoScalingSpec{
+									DiskGB: &v1.DiskGB{
+										Enabled: MakePtr(false),
+									},
+									Compute: &v1.ComputeSpec{
+										Enabled:          MakePtr(true),
+										ScaleDownEnabled: nil,
+										MinInstanceSize:  "M10",
+										MaxInstanceSize:  "M40",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			shouldFail: false,
+		},
+		{
+			testName: "One region and autoscaling ENABLED for diskGB ONLY",
+			input: &v1.AdvancedDeploymentSpec{
+				DiskSizeGB: MakePtr(15),
+				ReplicationSpecs: []*v1.AdvancedReplicationSpec{
+					{
+						NumShards: 1,
+						ZoneName:  "us-east-1",
+						RegionConfigs: []*v1.AdvancedRegionConfig{
+							{
+								ElectableSpecs: &v1.Specs{
+									DiskIOPS:      nil,
+									EbsVolumeType: "",
+									InstanceSize:  "M40",
+									NodeCount:     MakePtr(1),
+								},
+								AutoScaling: &v1.AdvancedAutoScalingSpec{
+									DiskGB: &v1.DiskGB{
+										Enabled: MakePtr(true),
+									},
+									Compute: &v1.ComputeSpec{
+										Enabled:          MakePtr(false),
+										ScaleDownEnabled: nil,
+										MinInstanceSize:  "M10",
+										MaxInstanceSize:  "M40",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: &v1.AdvancedDeploymentSpec{
+				DiskSizeGB: nil,
+				ReplicationSpecs: []*v1.AdvancedReplicationSpec{
+					{
+						NumShards: 1,
+						ZoneName:  "us-east-1",
+						RegionConfigs: []*v1.AdvancedRegionConfig{
+							{
+								ElectableSpecs: &v1.Specs{
+									DiskIOPS:      nil,
+									EbsVolumeType: "",
+									InstanceSize:  "M40",
+									NodeCount:     MakePtr(1),
+								},
+								AutoScaling: &v1.AdvancedAutoScalingSpec{
+									DiskGB: &v1.DiskGB{
+										Enabled: MakePtr(true),
+									},
+									Compute: &v1.ComputeSpec{
+										Enabled:          MakePtr(false),
+										ScaleDownEnabled: nil,
+										MinInstanceSize:  "M10",
+										MaxInstanceSize:  "M40",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			shouldFail: false,
+		},
+		{
+			testName: "Two regions and autoscaling ENABLED for compute AND disk in different regions",
+			input: &v1.AdvancedDeploymentSpec{
+				DiskSizeGB: MakePtr(15),
+				ReplicationSpecs: []*v1.AdvancedReplicationSpec{
+					{
+						NumShards: 1,
+						ZoneName:  "us-east-1",
+						RegionConfigs: []*v1.AdvancedRegionConfig{
+							{
+								RegionName: "WESTERN_EUROPE",
+								ElectableSpecs: &v1.Specs{
+									DiskIOPS:      nil,
+									EbsVolumeType: "",
+									InstanceSize:  "M30",
+									NodeCount:     MakePtr(1),
+								},
+								AutoScaling: &v1.AdvancedAutoScalingSpec{
+									DiskGB: &v1.DiskGB{
+										Enabled: MakePtr(true),
+									},
+									Compute: &v1.ComputeSpec{
+										Enabled:          MakePtr(false),
+										ScaleDownEnabled: nil,
+										MinInstanceSize:  "M10",
+										MaxInstanceSize:  "M40",
+									},
+								},
+							},
+							{
+								RegionName: "EASTERN_EUROPE",
+								ElectableSpecs: &v1.Specs{
+									DiskIOPS:      nil,
+									EbsVolumeType: "",
+									InstanceSize:  "M20",
+									NodeCount:     MakePtr(1),
+								},
+								AutoScaling: &v1.AdvancedAutoScalingSpec{
+									DiskGB: &v1.DiskGB{
+										Enabled: MakePtr(false),
+									},
+									Compute: &v1.ComputeSpec{
+										Enabled:          MakePtr(true),
+										ScaleDownEnabled: nil,
+										MinInstanceSize:  "M10",
+										MaxInstanceSize:  "M30",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: &v1.AdvancedDeploymentSpec{
+				DiskSizeGB: nil,
+				ReplicationSpecs: []*v1.AdvancedReplicationSpec{
+					{
+						NumShards: 1,
+						ZoneName:  "us-east-1",
+						RegionConfigs: []*v1.AdvancedRegionConfig{
+							{
+								RegionName: "WESTERN_EUROPE",
+								ElectableSpecs: &v1.Specs{
+									DiskIOPS:      nil,
+									EbsVolumeType: "",
+									InstanceSize:  "M30",
+									NodeCount:     MakePtr(1),
+								},
+								AutoScaling: &v1.AdvancedAutoScalingSpec{
+									DiskGB: &v1.DiskGB{
+										Enabled: MakePtr(true),
+									},
+									Compute: &v1.ComputeSpec{
+										Enabled:          MakePtr(false),
+										ScaleDownEnabled: nil,
+										MinInstanceSize:  "M10",
+										MaxInstanceSize:  "M40",
+									},
+								},
+							},
+							{
+								RegionName: "EASTERN_EUROPE",
+								ElectableSpecs: &v1.Specs{
+									DiskIOPS:      nil,
+									EbsVolumeType: "",
+									InstanceSize:  "",
+									NodeCount:     MakePtr(1),
+								},
+								AutoScaling: &v1.AdvancedAutoScalingSpec{
+									DiskGB: &v1.DiskGB{
+										Enabled: MakePtr(false),
+									},
+									Compute: &v1.ComputeSpec{
+										Enabled:          MakePtr(true),
+										ScaleDownEnabled: nil,
+										MinInstanceSize:  "M10",
+										MaxInstanceSize:  "M30",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			shouldFail: false,
+		},
+		{
+			testName: "One region and autoscaling DISABLED for diskGB AND compute",
+			input: &v1.AdvancedDeploymentSpec{
+				DiskSizeGB: MakePtr(15),
+				ReplicationSpecs: []*v1.AdvancedReplicationSpec{
+					{
+						NumShards: 1,
+						ZoneName:  "us-east-1",
+						RegionConfigs: []*v1.AdvancedRegionConfig{
+							{
+								ElectableSpecs: &v1.Specs{
+									DiskIOPS:      nil,
+									EbsVolumeType: "",
+									InstanceSize:  "M20",
+									NodeCount:     MakePtr(1),
+								},
+								AutoScaling: &v1.AdvancedAutoScalingSpec{
+									DiskGB: &v1.DiskGB{
+										Enabled: MakePtr(false),
+									},
+									Compute: &v1.ComputeSpec{
+										Enabled:          MakePtr(false),
+										ScaleDownEnabled: nil,
+										MinInstanceSize:  "M10",
+										MaxInstanceSize:  "M40",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: &v1.AdvancedDeploymentSpec{
+				DiskSizeGB: MakePtr(15),
+				ReplicationSpecs: []*v1.AdvancedReplicationSpec{
+					{
+						NumShards: 1,
+						ZoneName:  "us-east-1",
+						RegionConfigs: []*v1.AdvancedRegionConfig{
+							{
+								ElectableSpecs: &v1.Specs{
+									DiskIOPS:      nil,
+									EbsVolumeType: "",
+									InstanceSize:  "M20",
+									NodeCount:     MakePtr(1),
+								},
+								AutoScaling: &v1.AdvancedAutoScalingSpec{
+									DiskGB: &v1.DiskGB{
+										Enabled: MakePtr(false),
+									},
+									Compute: &v1.ComputeSpec{
+										Enabled:          MakePtr(false),
+										ScaleDownEnabled: nil,
+										MinInstanceSize:  "M10",
+										MaxInstanceSize:  "M40",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			shouldFail: false,
+		},
+	}
+	for _, tt := range testCases {
+		t.Run(tt.testName, func(t *testing.T) {
+			handleAutoscaling(tt.input)
+			if !reflect.DeepEqual(tt.input, tt.expected) && !tt.shouldFail {
+				expJson, err := json.MarshalIndent(tt.expected, "", " ")
+				if err != nil {
+					t.Fatalf("err: %v", err)
+				}
+				inpJson, err := json.MarshalIndent(tt.input, "", " ")
+				if err != nil {
+					t.Fatalf("err: %v", err)
+				}
+				t.Errorf("FAIL. Expected: %v, Got: %v", string(expJson), string(inpJson))
+			}
+		})
+	}
 }

--- a/pkg/controller/atlasdeployment/advanced_deployment_test.go
+++ b/pkg/controller/atlasdeployment/advanced_deployment_test.go
@@ -2,6 +2,7 @@ package atlasdeployment
 
 import (
 	"encoding/json"
+	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/util/toptr"
 	"reflect"
 	"testing"
 
@@ -64,10 +65,6 @@ func TestMergedAdvancedDeployment(t *testing.T) {
 	})
 }
 
-func MakePtr[T comparable](val T) *T {
-	return &val
-}
-
 func TestAdvancedDeployment_handleAutoscaling(t *testing.T) {
 	testCases := []struct {
 		input      *v1.AdvancedDeploymentSpec
@@ -78,7 +75,7 @@ func TestAdvancedDeployment_handleAutoscaling(t *testing.T) {
 		{
 			testName: "One region and autoscaling ENABLED for compute AND disk",
 			input: &v1.AdvancedDeploymentSpec{
-				DiskSizeGB: MakePtr(15),
+				DiskSizeGB: toptr.MakePtr(15),
 				ReplicationSpecs: []*v1.AdvancedReplicationSpec{
 					{
 						NumShards: 1,
@@ -89,14 +86,14 @@ func TestAdvancedDeployment_handleAutoscaling(t *testing.T) {
 									DiskIOPS:      nil,
 									EbsVolumeType: "",
 									InstanceSize:  "M30",
-									NodeCount:     MakePtr(1),
+									NodeCount:     toptr.MakePtr(1),
 								},
 								AutoScaling: &v1.AdvancedAutoScalingSpec{
 									DiskGB: &v1.DiskGB{
-										Enabled: MakePtr(true),
+										Enabled: toptr.MakePtr(true),
 									},
 									Compute: &v1.ComputeSpec{
-										Enabled:          MakePtr(true),
+										Enabled:          toptr.MakePtr(true),
 										ScaleDownEnabled: nil,
 										MinInstanceSize:  "M10",
 										MaxInstanceSize:  "M40",
@@ -119,14 +116,14 @@ func TestAdvancedDeployment_handleAutoscaling(t *testing.T) {
 									DiskIOPS:      nil,
 									EbsVolumeType: "",
 									InstanceSize:  "",
-									NodeCount:     MakePtr(1),
+									NodeCount:     toptr.MakePtr(1),
 								},
 								AutoScaling: &v1.AdvancedAutoScalingSpec{
 									DiskGB: &v1.DiskGB{
-										Enabled: MakePtr(true),
+										Enabled: toptr.MakePtr(true),
 									},
 									Compute: &v1.ComputeSpec{
-										Enabled:          MakePtr(true),
+										Enabled:          toptr.MakePtr(true),
 										ScaleDownEnabled: nil,
 										MinInstanceSize:  "M10",
 										MaxInstanceSize:  "M40",
@@ -142,7 +139,7 @@ func TestAdvancedDeployment_handleAutoscaling(t *testing.T) {
 		{
 			testName: "One region and autoscaling ENABLED for compute ONLY",
 			input: &v1.AdvancedDeploymentSpec{
-				DiskSizeGB: MakePtr(15),
+				DiskSizeGB: toptr.MakePtr(15),
 				ReplicationSpecs: []*v1.AdvancedReplicationSpec{
 					{
 						NumShards: 1,
@@ -153,14 +150,14 @@ func TestAdvancedDeployment_handleAutoscaling(t *testing.T) {
 									DiskIOPS:      nil,
 									EbsVolumeType: "",
 									InstanceSize:  "M40",
-									NodeCount:     MakePtr(1),
+									NodeCount:     toptr.MakePtr(1),
 								},
 								AutoScaling: &v1.AdvancedAutoScalingSpec{
 									DiskGB: &v1.DiskGB{
-										Enabled: MakePtr(false),
+										Enabled: toptr.MakePtr(false),
 									},
 									Compute: &v1.ComputeSpec{
-										Enabled:          MakePtr(true),
+										Enabled:          toptr.MakePtr(true),
 										ScaleDownEnabled: nil,
 										MinInstanceSize:  "M10",
 										MaxInstanceSize:  "M40",
@@ -172,7 +169,7 @@ func TestAdvancedDeployment_handleAutoscaling(t *testing.T) {
 				},
 			},
 			expected: &v1.AdvancedDeploymentSpec{
-				DiskSizeGB: MakePtr(15),
+				DiskSizeGB: toptr.MakePtr(15),
 				ReplicationSpecs: []*v1.AdvancedReplicationSpec{
 					{
 						NumShards: 1,
@@ -183,14 +180,14 @@ func TestAdvancedDeployment_handleAutoscaling(t *testing.T) {
 									DiskIOPS:      nil,
 									EbsVolumeType: "",
 									InstanceSize:  "",
-									NodeCount:     MakePtr(1),
+									NodeCount:     toptr.MakePtr(1),
 								},
 								AutoScaling: &v1.AdvancedAutoScalingSpec{
 									DiskGB: &v1.DiskGB{
-										Enabled: MakePtr(false),
+										Enabled: toptr.MakePtr(false),
 									},
 									Compute: &v1.ComputeSpec{
-										Enabled:          MakePtr(true),
+										Enabled:          toptr.MakePtr(true),
 										ScaleDownEnabled: nil,
 										MinInstanceSize:  "M10",
 										MaxInstanceSize:  "M40",
@@ -206,7 +203,7 @@ func TestAdvancedDeployment_handleAutoscaling(t *testing.T) {
 		{
 			testName: "One region and autoscaling ENABLED for diskGB ONLY",
 			input: &v1.AdvancedDeploymentSpec{
-				DiskSizeGB: MakePtr(15),
+				DiskSizeGB: toptr.MakePtr(15),
 				ReplicationSpecs: []*v1.AdvancedReplicationSpec{
 					{
 						NumShards: 1,
@@ -217,14 +214,14 @@ func TestAdvancedDeployment_handleAutoscaling(t *testing.T) {
 									DiskIOPS:      nil,
 									EbsVolumeType: "",
 									InstanceSize:  "M40",
-									NodeCount:     MakePtr(1),
+									NodeCount:     toptr.MakePtr(1),
 								},
 								AutoScaling: &v1.AdvancedAutoScalingSpec{
 									DiskGB: &v1.DiskGB{
-										Enabled: MakePtr(true),
+										Enabled: toptr.MakePtr(true),
 									},
 									Compute: &v1.ComputeSpec{
-										Enabled:          MakePtr(false),
+										Enabled:          toptr.MakePtr(false),
 										ScaleDownEnabled: nil,
 										MinInstanceSize:  "M10",
 										MaxInstanceSize:  "M40",
@@ -247,14 +244,14 @@ func TestAdvancedDeployment_handleAutoscaling(t *testing.T) {
 									DiskIOPS:      nil,
 									EbsVolumeType: "",
 									InstanceSize:  "M40",
-									NodeCount:     MakePtr(1),
+									NodeCount:     toptr.MakePtr(1),
 								},
 								AutoScaling: &v1.AdvancedAutoScalingSpec{
 									DiskGB: &v1.DiskGB{
-										Enabled: MakePtr(true),
+										Enabled: toptr.MakePtr(true),
 									},
 									Compute: &v1.ComputeSpec{
-										Enabled:          MakePtr(false),
+										Enabled:          toptr.MakePtr(false),
 										ScaleDownEnabled: nil,
 										MinInstanceSize:  "M10",
 										MaxInstanceSize:  "M40",
@@ -270,7 +267,7 @@ func TestAdvancedDeployment_handleAutoscaling(t *testing.T) {
 		{
 			testName: "Two regions and autoscaling ENABLED for compute AND disk in different regions",
 			input: &v1.AdvancedDeploymentSpec{
-				DiskSizeGB: MakePtr(15),
+				DiskSizeGB: toptr.MakePtr(15),
 				ReplicationSpecs: []*v1.AdvancedReplicationSpec{
 					{
 						NumShards: 1,
@@ -282,14 +279,14 @@ func TestAdvancedDeployment_handleAutoscaling(t *testing.T) {
 									DiskIOPS:      nil,
 									EbsVolumeType: "",
 									InstanceSize:  "M30",
-									NodeCount:     MakePtr(1),
+									NodeCount:     toptr.MakePtr(1),
 								},
 								AutoScaling: &v1.AdvancedAutoScalingSpec{
 									DiskGB: &v1.DiskGB{
-										Enabled: MakePtr(true),
+										Enabled: toptr.MakePtr(true),
 									},
 									Compute: &v1.ComputeSpec{
-										Enabled:          MakePtr(false),
+										Enabled:          toptr.MakePtr(false),
 										ScaleDownEnabled: nil,
 										MinInstanceSize:  "M10",
 										MaxInstanceSize:  "M40",
@@ -302,14 +299,14 @@ func TestAdvancedDeployment_handleAutoscaling(t *testing.T) {
 									DiskIOPS:      nil,
 									EbsVolumeType: "",
 									InstanceSize:  "M20",
-									NodeCount:     MakePtr(1),
+									NodeCount:     toptr.MakePtr(1),
 								},
 								AutoScaling: &v1.AdvancedAutoScalingSpec{
 									DiskGB: &v1.DiskGB{
-										Enabled: MakePtr(false),
+										Enabled: toptr.MakePtr(false),
 									},
 									Compute: &v1.ComputeSpec{
-										Enabled:          MakePtr(true),
+										Enabled:          toptr.MakePtr(true),
 										ScaleDownEnabled: nil,
 										MinInstanceSize:  "M10",
 										MaxInstanceSize:  "M30",
@@ -333,14 +330,14 @@ func TestAdvancedDeployment_handleAutoscaling(t *testing.T) {
 									DiskIOPS:      nil,
 									EbsVolumeType: "",
 									InstanceSize:  "M30",
-									NodeCount:     MakePtr(1),
+									NodeCount:     toptr.MakePtr(1),
 								},
 								AutoScaling: &v1.AdvancedAutoScalingSpec{
 									DiskGB: &v1.DiskGB{
-										Enabled: MakePtr(true),
+										Enabled: toptr.MakePtr(true),
 									},
 									Compute: &v1.ComputeSpec{
-										Enabled:          MakePtr(false),
+										Enabled:          toptr.MakePtr(false),
 										ScaleDownEnabled: nil,
 										MinInstanceSize:  "M10",
 										MaxInstanceSize:  "M40",
@@ -353,14 +350,14 @@ func TestAdvancedDeployment_handleAutoscaling(t *testing.T) {
 									DiskIOPS:      nil,
 									EbsVolumeType: "",
 									InstanceSize:  "",
-									NodeCount:     MakePtr(1),
+									NodeCount:     toptr.MakePtr(1),
 								},
 								AutoScaling: &v1.AdvancedAutoScalingSpec{
 									DiskGB: &v1.DiskGB{
-										Enabled: MakePtr(false),
+										Enabled: toptr.MakePtr(false),
 									},
 									Compute: &v1.ComputeSpec{
-										Enabled:          MakePtr(true),
+										Enabled:          toptr.MakePtr(true),
 										ScaleDownEnabled: nil,
 										MinInstanceSize:  "M10",
 										MaxInstanceSize:  "M30",
@@ -376,7 +373,7 @@ func TestAdvancedDeployment_handleAutoscaling(t *testing.T) {
 		{
 			testName: "One region and autoscaling DISABLED for diskGB AND compute",
 			input: &v1.AdvancedDeploymentSpec{
-				DiskSizeGB: MakePtr(15),
+				DiskSizeGB: toptr.MakePtr(15),
 				ReplicationSpecs: []*v1.AdvancedReplicationSpec{
 					{
 						NumShards: 1,
@@ -387,14 +384,14 @@ func TestAdvancedDeployment_handleAutoscaling(t *testing.T) {
 									DiskIOPS:      nil,
 									EbsVolumeType: "",
 									InstanceSize:  "M20",
-									NodeCount:     MakePtr(1),
+									NodeCount:     toptr.MakePtr(1),
 								},
 								AutoScaling: &v1.AdvancedAutoScalingSpec{
 									DiskGB: &v1.DiskGB{
-										Enabled: MakePtr(false),
+										Enabled: toptr.MakePtr(false),
 									},
 									Compute: &v1.ComputeSpec{
-										Enabled:          MakePtr(false),
+										Enabled:          toptr.MakePtr(false),
 										ScaleDownEnabled: nil,
 										MinInstanceSize:  "M10",
 										MaxInstanceSize:  "M40",
@@ -406,7 +403,7 @@ func TestAdvancedDeployment_handleAutoscaling(t *testing.T) {
 				},
 			},
 			expected: &v1.AdvancedDeploymentSpec{
-				DiskSizeGB: MakePtr(15),
+				DiskSizeGB: toptr.MakePtr(15),
 				ReplicationSpecs: []*v1.AdvancedReplicationSpec{
 					{
 						NumShards: 1,
@@ -417,14 +414,14 @@ func TestAdvancedDeployment_handleAutoscaling(t *testing.T) {
 									DiskIOPS:      nil,
 									EbsVolumeType: "",
 									InstanceSize:  "M20",
-									NodeCount:     MakePtr(1),
+									NodeCount:     toptr.MakePtr(1),
 								},
 								AutoScaling: &v1.AdvancedAutoScalingSpec{
 									DiskGB: &v1.DiskGB{
-										Enabled: MakePtr(false),
+										Enabled: toptr.MakePtr(false),
 									},
 									Compute: &v1.ComputeSpec{
-										Enabled:          MakePtr(false),
+										Enabled:          toptr.MakePtr(false),
 										ScaleDownEnabled: nil,
 										MinInstanceSize:  "M10",
 										MaxInstanceSize:  "M40",

--- a/pkg/controller/atlasdeployment/advanced_deployment_test.go
+++ b/pkg/controller/atlasdeployment/advanced_deployment_test.go
@@ -2,9 +2,10 @@ package atlasdeployment
 
 import (
 	"encoding/json"
-	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/util/toptr"
 	"reflect"
 	"testing"
+
+	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/util/toptr"
 
 	"github.com/stretchr/testify/assert"
 	"go.mongodb.org/atlas/mongodbatlas"

--- a/pkg/controller/atlasdeployment/advanced_deployment_test.go
+++ b/pkg/controller/atlasdeployment/advanced_deployment_test.go
@@ -442,15 +442,15 @@ func TestAdvancedDeployment_handleAutoscaling(t *testing.T) {
 		t.Run(tt.testName, func(t *testing.T) {
 			handleAutoscaling(tt.input)
 			if !reflect.DeepEqual(tt.input, tt.expected) && !tt.shouldFail {
-				expJson, err := json.MarshalIndent(tt.expected, "", " ")
+				expJSON, err := json.MarshalIndent(tt.expected, "", " ")
 				if err != nil {
 					t.Fatalf("err: %v", err)
 				}
-				inpJson, err := json.MarshalIndent(tt.input, "", " ")
+				inpJSON, err := json.MarshalIndent(tt.input, "", " ")
 				if err != nil {
 					t.Fatalf("err: %v", err)
 				}
-				t.Errorf("FAIL. Expected: %v, Got: %v", string(expJson), string(inpJson))
+				t.Errorf("FAIL. Expected: %v, Got: %v", string(expJSON), string(inpJSON))
 			}
 		})
 	}

--- a/pkg/util/toptr/toptr.go
+++ b/pkg/util/toptr/toptr.go
@@ -1,9 +1,5 @@
 package toptr
 
-func Int64ptr(i int64) *int64 {
-	return &i
-}
-
-func Boolptr(b bool) *bool {
-	return &b
+func MakePtr[T comparable](value T) *T {
+	return &value
 }

--- a/scripts/int_local.sh
+++ b/scripts/int_local.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -eou pipefail
+
+if [ -z "${label+x}" ]; then
+  label=""
+fi
+
+
+public_key=$(grep "ATLAS_PUBLIC_KEY" .actrc | cut -d "=" -f 2)
+private_key=$(grep "ATLAS_PRIVATE_KEY" .actrc | cut -d "=" -f 2)
+org_id=$(grep "ATLAS_ORG_ID" .actrc | cut -d "=" -f 2)
+
+export MCLI_OPS_MANAGER_URL="https://cloud-qa.mongodb.com/"
+export MCLI_PUBLIC_API_KEY="${public_key}"
+export MCLI_PRIVATE_API_KEY="${private_key}"
+export MCLI_ORG_ID="${org_id}"
+
+ginkgo --label-filter="${label}" --timeout 80m -v ./test/int -coverprofile cover.out

--- a/test/int/deployment_test.go
+++ b/test/int/deployment_test.go
@@ -905,8 +905,8 @@ var _ = Describe("AtlasDeployment", Label("int", "AtlasDeployment"), func() {
 				Eventually(func(g Gomega) bool {
 					GinkgoWriter.Println("ProjectID", createdProject.ID(), "DeploymentName", createdDeployment.GetDeploymentName())
 					current, _, err := atlasClient.AdvancedClusters.Get(context.Background(), createdProject.ID(), createdDeployment.GetDeploymentName())
-					Expect(err).NotTo(HaveOccurred())
-					Expect(current).NotTo(BeNil())
+					g.Expect(err).NotTo(HaveOccurred())
+					g.Expect(current).NotTo(BeNil())
 
 					g.Expect(current.ReplicationSpecs[0].RegionConfigs[0].AnalyticsSpecs.InstanceSize).To(Equal(
 						previousDeployment.Spec.AdvancedDeploymentSpec.ReplicationSpecs[0].RegionConfigs[0].AnalyticsSpecs.InstanceSize))

--- a/test/int/deployment_test.go
+++ b/test/int/deployment_test.go
@@ -809,13 +809,13 @@ var _ = Describe("AtlasDeployment", Label("int", "AtlasDeployment"), func() {
 			By(fmt.Sprintf("Enable AutoScaling for the Advanced Deployment %s", kube.ObjectKeyFromObject(createdDeployment)), func() {
 				createdDeployment.Spec.AdvancedDeploymentSpec.ReplicationSpecs[0].RegionConfigs[0].AutoScaling = &mdbv1.AdvancedAutoScalingSpec{
 					Compute: &mdbv1.ComputeSpec{
-						Enabled:          toptr.Boolptr(true),
+						Enabled:          toptr.MakePtr(true),
 						MaxInstanceSize:  "M20",
 						MinInstanceSize:  "M10",
-						ScaleDownEnabled: toptr.Boolptr(true),
+						ScaleDownEnabled: toptr.MakePtr(true),
 					},
 					DiskGB: &mdbv1.DiskGB{
-						Enabled: toptr.Boolptr(true),
+						Enabled: toptr.MakePtr(true),
 					},
 				}
 				Expect(k8sClient.Update(context.Background(), createdDeployment)).ToNot(HaveOccurred())
@@ -859,10 +859,10 @@ var _ = Describe("AtlasDeployment", Label("int", "AtlasDeployment"), func() {
 								NodeCount:     intptr(1),
 							},
 							AutoScaling: &mdbv1.AdvancedAutoScalingSpec{
-								DiskGB: &mdbv1.DiskGB{Enabled: toptr.Boolptr(true)},
+								DiskGB: &mdbv1.DiskGB{Enabled: toptr.MakePtr(true)},
 								Compute: &mdbv1.ComputeSpec{
-									Enabled:          toptr.Boolptr(true),
-									ScaleDownEnabled: toptr.Boolptr(true),
+									Enabled:          toptr.MakePtr(true),
+									ScaleDownEnabled: toptr.MakePtr(true),
 									MinInstanceSize:  "M10",
 									MaxInstanceSize:  "M40",
 								},

--- a/test/int/deployment_test.go
+++ b/test/int/deployment_test.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/util/compat"
-	"github.com/mongodb/mongodb-atlas-kubernetes/test/e2e/api/atlas"
 	"net/http"
 	"time"
+
+	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/util/compat"
+	"github.com/mongodb/mongodb-atlas-kubernetes/test/e2e/api/atlas"
 
 	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/controller/connectionsecret"
 
@@ -888,7 +889,7 @@ var _ = Describe("AtlasDeployment", Label("int", "AtlasDeployment"), func() {
 				lastGeneration++
 			})
 
-			By(fmt.Sprintf("Updating the InstanceSize and DiskSizeGB of Advanced Deployment %s should not happend", kube.ObjectKeyFromObject(createdDeployment)), func() {
+			By(fmt.Sprintf("Updating the InstanceSize and DiskSizeGB of Advanced Deployment %s should not happened", kube.ObjectKeyFromObject(createdDeployment)), func() {
 				previousDeployment := mdbv1.AtlasDeployment{}
 				err := compat.JSONCopy(&previousDeployment, createdDeployment)
 				Expect(err).NotTo(HaveOccurred())

--- a/test/int/deployment_test.go
+++ b/test/int/deployment_test.go
@@ -7,10 +7,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/util/compat"
-	"github.com/mongodb/mongodb-atlas-kubernetes/test/e2e/api/atlas"
-
 	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/controller/connectionsecret"
+	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/util/compat"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -905,9 +903,8 @@ var _ = Describe("AtlasDeployment", Label("int", "AtlasDeployment"), func() {
 				Expect(k8sClient.Update(context.Background(), createdDeployment)).ToNot(HaveOccurred())
 
 				Eventually(func(g Gomega) bool {
-					client := atlas.GetClientOrFail()
 					GinkgoWriter.Println("ProjectID", createdProject.ID(), "DeploymentName", createdDeployment.GetDeploymentName())
-					current, err := client.GetAdvancedDeployment(createdProject.ID(), createdDeployment.GetDeploymentName())
+					current, _, err := atlasClient.AdvancedClusters.Get(context.Background(), createdProject.ID(), createdDeployment.GetDeploymentName())
 					Expect(err).NotTo(HaveOccurred())
 					Expect(current).NotTo(BeNil())
 


### PR DESCRIPTION
### All Submissions:

- Prevent changes of `instanceSize` if `autoscaling` is enabled for `compute` for the region
- Prevent changes of `diskSizeGB` if `autoscaling` is enabled for `diskGB`

closes: #648 & #649 

* [x] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [x] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if there is one).
* [ ] Update docs/release-notes/release-notes.md if your changes should be included in the release notes for the next release.
