### PR TITLE
CLOUDP-136586: Allow autoscaling instanceSize and diskSizeGB outside of the manually set instanceSize and diskSizeGB

### DIFF
--- a/pkg/controller/atlasdeployment/advanced_deployment.go
+++ b/pkg/controller/atlasdeployment/advanced_deployment.go
@@ -241,6 +241,7 @@ func normalizeInstanceSize(currentInstanceSize string, autoscaling *mdbv1.Advanc
 	return currentInstanceSize
 }
 
+// extractNumberFromInstanceTypeName get the existing number from a given instance type name, fail when the name is incorrect
 func extractNumberFromInstanceTypeName(instanceTypeName string) int {
 	name := strings.TrimPrefix(instanceTypeName, "M")
 	name = strings.TrimPrefix(name, "R")

--- a/pkg/controller/atlasdeployment/advanced_deployment.go
+++ b/pkg/controller/atlasdeployment/advanced_deployment.go
@@ -3,11 +3,12 @@ package atlasdeployment
 import (
 	"context"
 	"fmt"
+	"net/http"
+
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"go.mongodb.org/atlas/mongodbatlas"
 	"go.uber.org/zap"
-	"net/http"
 
 	mdbv1 "github.com/mongodb/mongodb-atlas-kubernetes/pkg/api/v1"
 	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/controller/workflow"

--- a/pkg/controller/atlasdeployment/advanced_deployment.go
+++ b/pkg/controller/atlasdeployment/advanced_deployment.go
@@ -120,7 +120,7 @@ func handleAutoscaling(ctx *workflow.Context, desiredDeployment *mdbv1.AdvancedD
 				return err
 			}
 
-			if size == currentDeployment.ReplicationSpecs[0].RegionConfigs[0].ElectableSpecs.InstanceSize {
+			if isInstanceSizeTheSame(currentDeployment, size) {
 				size = ""
 			}
 
@@ -277,4 +277,8 @@ func normalizeInstanceSize(ctx *workflow.Context, currentInstanceSize string, au
 	}
 
 	return currentInstanceSize, nil
+}
+
+func isInstanceSizeTheSame(currentDeployment *mongodbatlas.AdvancedCluster, desiredInstanceSize string) bool {
+	return desiredInstanceSize == currentDeployment.ReplicationSpecs[0].RegionConfigs[0].ElectableSpecs.InstanceSize
 }

--- a/pkg/controller/atlasdeployment/advanced_deployment_test.go
+++ b/pkg/controller/atlasdeployment/advanced_deployment_test.go
@@ -116,7 +116,7 @@ func TestAdvancedDeployment_handleAutoscaling(t *testing.T) {
 								ElectableSpecs: &v1.Specs{
 									DiskIOPS:      nil,
 									EbsVolumeType: "",
-									InstanceSize:  "",
+									InstanceSize:  "M30",
 									NodeCount:     toptr.MakePtr(1),
 								},
 								AutoScaling: &v1.AdvancedAutoScalingSpec{
@@ -180,7 +180,7 @@ func TestAdvancedDeployment_handleAutoscaling(t *testing.T) {
 								ElectableSpecs: &v1.Specs{
 									DiskIOPS:      nil,
 									EbsVolumeType: "",
-									InstanceSize:  "",
+									InstanceSize:  "M40",
 									NodeCount:     toptr.MakePtr(1),
 								},
 								AutoScaling: &v1.AdvancedAutoScalingSpec{
@@ -350,7 +350,7 @@ func TestAdvancedDeployment_handleAutoscaling(t *testing.T) {
 								ElectableSpecs: &v1.Specs{
 									DiskIOPS:      nil,
 									EbsVolumeType: "",
-									InstanceSize:  "",
+									InstanceSize:  "M20",
 									NodeCount:     toptr.MakePtr(1),
 								},
 								AutoScaling: &v1.AdvancedAutoScalingSpec{
@@ -425,6 +425,112 @@ func TestAdvancedDeployment_handleAutoscaling(t *testing.T) {
 										Enabled:          toptr.MakePtr(false),
 										ScaleDownEnabled: nil,
 										MinInstanceSize:  "M10",
+										MaxInstanceSize:  "M40",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			shouldFail: false,
+		},
+		{
+			testName: "Two regions and autoscaling ENABLED for compute and InstanceSize outside of boundaries",
+			input: &v1.AdvancedDeploymentSpec{
+				DiskSizeGB: toptr.MakePtr(15),
+				ReplicationSpecs: []*v1.AdvancedReplicationSpec{
+					{
+						NumShards: 1,
+						ZoneName:  "us-east-1",
+						RegionConfigs: []*v1.AdvancedRegionConfig{
+							{
+								RegionName: "WESTERN_EUROPE",
+								ElectableSpecs: &v1.Specs{
+									DiskIOPS:      nil,
+									EbsVolumeType: "",
+									InstanceSize:  "M50",
+									NodeCount:     toptr.MakePtr(1),
+								},
+								AutoScaling: &v1.AdvancedAutoScalingSpec{
+									DiskGB: &v1.DiskGB{
+										Enabled: toptr.MakePtr(true),
+									},
+									Compute: &v1.ComputeSpec{
+										Enabled:          toptr.MakePtr(true),
+										ScaleDownEnabled: nil,
+										MinInstanceSize:  "M10",
+										MaxInstanceSize:  "M40",
+									},
+								},
+							},
+							{
+								RegionName: "EASTERN_EUROPE",
+								ElectableSpecs: &v1.Specs{
+									DiskIOPS:      nil,
+									EbsVolumeType: "",
+									InstanceSize:  "M10",
+									NodeCount:     toptr.MakePtr(1),
+								},
+								AutoScaling: &v1.AdvancedAutoScalingSpec{
+									DiskGB: &v1.DiskGB{
+										Enabled: toptr.MakePtr(false),
+									},
+									Compute: &v1.ComputeSpec{
+										Enabled:          toptr.MakePtr(true),
+										ScaleDownEnabled: nil,
+										MinInstanceSize:  "M20",
+										MaxInstanceSize:  "M40",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: &v1.AdvancedDeploymentSpec{
+				DiskSizeGB: nil,
+				ReplicationSpecs: []*v1.AdvancedReplicationSpec{
+					{
+						NumShards: 1,
+						ZoneName:  "us-east-1",
+						RegionConfigs: []*v1.AdvancedRegionConfig{
+							{
+								RegionName: "WESTERN_EUROPE",
+								ElectableSpecs: &v1.Specs{
+									DiskIOPS:      nil,
+									EbsVolumeType: "",
+									InstanceSize:  "M40",
+									NodeCount:     toptr.MakePtr(1),
+								},
+								AutoScaling: &v1.AdvancedAutoScalingSpec{
+									DiskGB: &v1.DiskGB{
+										Enabled: toptr.MakePtr(true),
+									},
+									Compute: &v1.ComputeSpec{
+										Enabled:          toptr.MakePtr(true),
+										ScaleDownEnabled: nil,
+										MinInstanceSize:  "M10",
+										MaxInstanceSize:  "M40",
+									},
+								},
+							},
+							{
+								RegionName: "EASTERN_EUROPE",
+								ElectableSpecs: &v1.Specs{
+									DiskIOPS:      nil,
+									EbsVolumeType: "",
+									InstanceSize:  "M20",
+									NodeCount:     toptr.MakePtr(1),
+								},
+								AutoScaling: &v1.AdvancedAutoScalingSpec{
+									DiskGB: &v1.DiskGB{
+										Enabled: toptr.MakePtr(false),
+									},
+									Compute: &v1.ComputeSpec{
+										Enabled:          toptr.MakePtr(true),
+										ScaleDownEnabled: nil,
+										MinInstanceSize:  "M20",
 										MaxInstanceSize:  "M40",
 									},
 								},

--- a/pkg/controller/atlasdeployment/advanced_deployment_test.go
+++ b/pkg/controller/atlasdeployment/advanced_deployment_test.go
@@ -564,8 +564,8 @@ func TestNormalizeInstanceSize(t *testing.T) {
 	t.Run("InstanceSizeName should not change when inside of autoscaling configuration boundaries", func(t *testing.T) {
 		autoscaling := &v1.AdvancedAutoScalingSpec{
 			Compute: &v1.ComputeSpec{
-				Enabled:          boolptr(true),
-				ScaleDownEnabled: boolptr(true),
+				Enabled:          toptr.MakePtr(true),
+				ScaleDownEnabled: toptr.MakePtr(true),
 				MinInstanceSize:  "M10",
 				MaxInstanceSize:  "M30",
 			},
@@ -576,8 +576,8 @@ func TestNormalizeInstanceSize(t *testing.T) {
 	t.Run("InstanceSizeName should change to minimum size when outside of the bottom autoscaling configuration boundaries", func(t *testing.T) {
 		autoscaling := &v1.AdvancedAutoScalingSpec{
 			Compute: &v1.ComputeSpec{
-				Enabled:          boolptr(true),
-				ScaleDownEnabled: boolptr(true),
+				Enabled:          toptr.MakePtr(true),
+				ScaleDownEnabled: toptr.MakePtr(true),
 				MinInstanceSize:  "M20",
 				MaxInstanceSize:  "M30",
 			},
@@ -588,8 +588,8 @@ func TestNormalizeInstanceSize(t *testing.T) {
 	t.Run("InstanceSizeName should change to maximum size when outside of the top autoscaling configuration boundaries", func(t *testing.T) {
 		autoscaling := &v1.AdvancedAutoScalingSpec{
 			Compute: &v1.ComputeSpec{
-				Enabled:          boolptr(true),
-				ScaleDownEnabled: boolptr(true),
+				Enabled:          toptr.MakePtr(true),
+				ScaleDownEnabled: toptr.MakePtr(true),
 				MinInstanceSize:  "M20",
 				MaxInstanceSize:  "M30",
 			},
@@ -623,8 +623,4 @@ func TestExtractNumberFromInstanceTypeName(t *testing.T) {
 			assert.Equal(t, test.Number, extractNumberFromInstanceTypeName(test.Name))
 		})
 	}
-}
-
-func boolptr(b bool) *bool {
-	return &b
 }

--- a/pkg/controller/atlasdeployment/advanced_deployment_test.go
+++ b/pkg/controller/atlasdeployment/advanced_deployment_test.go
@@ -3,12 +3,13 @@ package atlasdeployment
 import (
 	"encoding/json"
 	"errors"
-	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/api/v1/status"
-	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/controller/workflow"
-	"go.uber.org/zap"
 	"reflect"
 	"testing"
 
+	"go.uber.org/zap"
+
+	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/api/v1/status"
+	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/controller/workflow"
 	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/util/toptr"
 
 	"github.com/stretchr/testify/assert"

--- a/pkg/controller/atlasdeployment/instance_size.go
+++ b/pkg/controller/atlasdeployment/instance_size.go
@@ -54,7 +54,7 @@ func NewFromInstanceSizeName(instanceSizeName string) (InstanceSize, error) {
 
 	number, err := strconv.Atoi(pieces[0][1:])
 	if err != nil {
-		return InstanceSize{}, fmt.Errorf("instance size is invalid. %e", err)
+		return InstanceSize{}, fmt.Errorf("instance size is invalid. %w", err)
 	}
 
 	return InstanceSize{

--- a/pkg/controller/atlasdeployment/instance_size.go
+++ b/pkg/controller/atlasdeployment/instance_size.go
@@ -1,0 +1,65 @@
+package atlasdeployment
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+type InstanceSize struct {
+	Family string
+	Size   int
+	IsNVME bool
+}
+
+func CompareInstanceSizes(is1 InstanceSize, is2 InstanceSize) int {
+	if is1.Family != is2.Family {
+		if is1.Family == "M" {
+			return -1
+		} else {
+			return 1
+		}
+	}
+
+	if is1.Size != is2.Size {
+		if is1.Size < is2.Size {
+			return -1
+		} else {
+			return 1
+		}
+	}
+
+	if is1.IsNVME != is2.IsNVME {
+		if !is1.IsNVME {
+			return -1
+		} else {
+			return 1
+		}
+	}
+
+	return 0
+}
+
+func NewFromInstanceSizeName(instanceSizeName string) (InstanceSize, error) {
+	if len(instanceSizeName) < 2 {
+		return InstanceSize{}, errors.New("instance size is invalid")
+	}
+
+	pieces := strings.Split(instanceSizeName, "_")
+
+	if pieces[0][0] != 'M' && pieces[0][0] != 'R' {
+		return InstanceSize{}, errors.New("instance size is invalid. instance family should be M or R")
+	}
+
+	number, err := strconv.Atoi(pieces[0][1:])
+	if err != nil {
+		return InstanceSize{}, fmt.Errorf("instance size is invalid. %e", err)
+	}
+
+	return InstanceSize{
+		Family: string(pieces[0][0]),
+		Size:   number,
+		IsNVME: len(pieces) == 2 && pieces[1] == "NVME",
+	}, nil
+}

--- a/pkg/controller/atlasdeployment/instance_size_test.go
+++ b/pkg/controller/atlasdeployment/instance_size_test.go
@@ -1,0 +1,184 @@
+package atlasdeployment
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestNewFromInstanceSizeName(t *testing.T) {
+	t.Run("should return error when instance size name is invalid", func(t *testing.T) {
+		is, err := NewFromInstanceSizeName("a")
+
+		assert.EqualError(t, err, "instance size is invalid")
+		assert.Empty(t, is)
+	})
+
+	t.Run("should return error when instance is from wrong family", func(t *testing.T) {
+		is, err := NewFromInstanceSizeName("Z10")
+
+		assert.EqualError(t, err, "instance size is invalid. instance family should be M or R")
+		assert.Empty(t, is)
+	})
+
+	t.Run("should return error when instance is malformed", func(t *testing.T) {
+		is, err := NewFromInstanceSizeName("MZ")
+
+		assert.EqualError(t, err, "instance size is invalid. &{%!e(string=Atoi) %!e(string=Z) %!e(*errors.errorString=&{invalid syntax})}")
+		assert.Empty(t, is)
+	})
+
+	t.Run("should return a general instance size parsed", func(t *testing.T) {
+		is, err := NewFromInstanceSizeName("M10")
+
+		assert.NoError(t, err)
+		assert.Equal(
+			t,
+			InstanceSize{
+				Family: "M",
+				Size:   10,
+				IsNVME: false,
+			},
+			is,
+		)
+	})
+
+	t.Run("should return a NVME instance size parsed", func(t *testing.T) {
+		is, err := NewFromInstanceSizeName("M10_NVME")
+
+		assert.NoError(t, err)
+		assert.Equal(
+			t,
+			InstanceSize{
+				Family: "M",
+				Size:   10,
+				IsNVME: true,
+			},
+			is,
+		)
+	})
+}
+
+func TestCompareInstanceSizes(t *testing.T) {
+	t.Run("should return -1 when instance 1 family is less than instance 2 family", func(t *testing.T) {
+		assert.Equal(
+			t,
+			-1,
+			CompareInstanceSizes(
+				InstanceSize{
+					Family: "M",
+					Size:   10,
+				},
+				InstanceSize{
+					Family: "R",
+					Size:   10,
+				},
+			),
+		)
+	})
+
+	t.Run("should return 1 when instance 1 family is greater than instance 2 family", func(t *testing.T) {
+		assert.Equal(
+			t,
+			1,
+			CompareInstanceSizes(
+				InstanceSize{
+					Family: "R",
+					Size:   10,
+				},
+				InstanceSize{
+					Family: "M",
+					Size:   10,
+				},
+			),
+		)
+	})
+
+	t.Run("should return -1 when instance 1 size is less than instance 2 size", func(t *testing.T) {
+		assert.Equal(
+			t,
+			-1,
+			CompareInstanceSizes(
+				InstanceSize{
+					Family: "M",
+					Size:   10,
+				},
+				InstanceSize{
+					Family: "M",
+					Size:   20,
+				},
+			),
+		)
+	})
+
+	t.Run("should return 1 when instance 1 size is greater than instance 2 size", func(t *testing.T) {
+		assert.Equal(
+			t,
+			1,
+			CompareInstanceSizes(
+				InstanceSize{
+					Family: "M",
+					Size:   20,
+				},
+				InstanceSize{
+					Family: "M",
+					Size:   10,
+				},
+			),
+		)
+	})
+
+	t.Run("should return -1 when instance 1 is not NVME and instance 2 is NVME", func(t *testing.T) {
+		assert.Equal(
+			t,
+			-1,
+			CompareInstanceSizes(
+				InstanceSize{
+					Family: "M",
+					Size:   50,
+				},
+				InstanceSize{
+					Family: "M",
+					Size:   50,
+					IsNVME: true,
+				},
+			),
+		)
+	})
+
+	t.Run("should return -1 when instance 1 is NVME and instance 2 is not NVME", func(t *testing.T) {
+		assert.Equal(
+			t,
+			1,
+			CompareInstanceSizes(
+				InstanceSize{
+					Family: "M",
+					Size:   50,
+					IsNVME: true,
+				},
+				InstanceSize{
+					Family: "M",
+					Size:   50,
+				},
+			),
+		)
+	})
+
+	t.Run("should return 0 when instance 1 and 2 are equal", func(t *testing.T) {
+		assert.Equal(
+			t,
+			0,
+			CompareInstanceSizes(
+				InstanceSize{
+					Family: "M",
+					Size:   50,
+					IsNVME: true,
+				},
+				InstanceSize{
+					Family: "M",
+					Size:   50,
+					IsNVME: true,
+				},
+			),
+		)
+	})
+}

--- a/pkg/controller/atlasdeployment/instance_size_test.go
+++ b/pkg/controller/atlasdeployment/instance_size_test.go
@@ -24,7 +24,7 @@ func TestNewFromInstanceSizeName(t *testing.T) {
 	t.Run("should return error when instance is malformed", func(t *testing.T) {
 		is, err := NewFromInstanceSizeName("MZ")
 
-		assert.EqualError(t, err, "instance size is invalid. &{%!e(string=Atoi) %!e(string=Z) %!e(*errors.errorString=&{invalid syntax})}")
+		assert.EqualError(t, err, "instance size is invalid. strconv.Atoi: parsing \"Z\": invalid syntax")
 		assert.Empty(t, is)
 	})
 

--- a/pkg/controller/atlasdeployment/instance_size_test.go
+++ b/pkg/controller/atlasdeployment/instance_size_test.go
@@ -1,8 +1,9 @@
 package atlasdeployment
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestNewFromInstanceSizeName(t *testing.T) {

--- a/pkg/controller/validate/validate.go
+++ b/pkg/controller/validate/validate.go
@@ -79,21 +79,29 @@ func instanceSizeForAdvancedDeployment(replicationSpecs []*mdbv1.AdvancedReplica
 	var instanceSize string
 	err := errors.New("instance size must be the same for all nodes in all regions and across all replication specs for advanced deployment ")
 
+	isInstanceSizeEqual := func(nodeInstanceType string) bool {
+		if instanceSize == "" {
+			instanceSize = nodeInstanceType
+		}
+
+		return nodeInstanceType == instanceSize
+	}
+
 	for _, replicationSpec := range replicationSpecs {
 		for _, regionSpec := range replicationSpec.RegionConfigs {
 			if instanceSize == "" {
 				instanceSize = regionSpec.ElectableSpecs.InstanceSize
 			}
 
-			if regionSpec.ElectableSpecs.InstanceSize != instanceSize {
+			if regionSpec.ElectableSpecs != nil && !isInstanceSizeEqual(regionSpec.ElectableSpecs.InstanceSize) {
 				return err
 			}
 
-			if regionSpec.ReadOnlySpecs.InstanceSize != instanceSize {
+			if regionSpec.ReadOnlySpecs != nil && !isInstanceSizeEqual(regionSpec.ReadOnlySpecs.InstanceSize) {
 				return err
 			}
 
-			if regionSpec.AnalyticsSpecs.InstanceSize != instanceSize {
+			if regionSpec.AnalyticsSpecs != nil && !isInstanceSizeEqual(regionSpec.AnalyticsSpecs.InstanceSize) {
 				return err
 			}
 		}

--- a/pkg/controller/validate/validate_test.go
+++ b/pkg/controller/validate/validate_test.go
@@ -3,6 +3,8 @@ package validate
 import (
 	"testing"
 
+	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/util/toptr"
+
 	"github.com/stretchr/testify/assert"
 
 	mdbv1 "github.com/mongodb/mongodb-atlas-kubernetes/pkg/api/v1"
@@ -36,6 +38,144 @@ func TestClusterValidation(t *testing.T) {
 			}}
 			assert.Error(t, DeploymentSpec(spec))
 		})
+		t.Run("different instance sizes for advanced deployment", func(t *testing.T) {
+			t.Run("different instance size in the same region", func(t *testing.T) {
+				spec := mdbv1.AtlasDeploymentSpec{
+					AdvancedDeploymentSpec: &mdbv1.AdvancedDeploymentSpec{
+						ReplicationSpecs: []*mdbv1.AdvancedReplicationSpec{
+							{
+								RegionConfigs: []*mdbv1.AdvancedRegionConfig{
+									{
+										ElectableSpecs: &mdbv1.Specs{InstanceSize: "M10"},
+										ReadOnlySpecs:  &mdbv1.Specs{InstanceSize: "M10"},
+										AnalyticsSpecs: &mdbv1.Specs{InstanceSize: "M20"},
+									},
+								},
+							},
+						},
+					},
+				}
+				assert.Error(t, DeploymentSpec(spec))
+			})
+			t.Run("different instance size in different regions", func(t *testing.T) {
+				spec := mdbv1.AtlasDeploymentSpec{
+					AdvancedDeploymentSpec: &mdbv1.AdvancedDeploymentSpec{
+						ReplicationSpecs: []*mdbv1.AdvancedReplicationSpec{
+							{
+								RegionConfigs: []*mdbv1.AdvancedRegionConfig{
+									{
+										ElectableSpecs: &mdbv1.Specs{InstanceSize: "M10"},
+										ReadOnlySpecs:  &mdbv1.Specs{InstanceSize: "M10"},
+										AnalyticsSpecs: &mdbv1.Specs{InstanceSize: "M10"},
+									},
+									{
+										ElectableSpecs: &mdbv1.Specs{InstanceSize: "M10"},
+										ReadOnlySpecs:  &mdbv1.Specs{InstanceSize: "M20"},
+										AnalyticsSpecs: &mdbv1.Specs{InstanceSize: "M10"},
+									},
+								},
+							},
+						},
+					},
+				}
+				assert.Error(t, DeploymentSpec(spec))
+			})
+			t.Run("different instance size in different replications", func(t *testing.T) {
+				spec := mdbv1.AtlasDeploymentSpec{
+					AdvancedDeploymentSpec: &mdbv1.AdvancedDeploymentSpec{
+						ReplicationSpecs: []*mdbv1.AdvancedReplicationSpec{
+							{
+								RegionConfigs: []*mdbv1.AdvancedRegionConfig{
+									{
+										ElectableSpecs: &mdbv1.Specs{InstanceSize: "M10"},
+										ReadOnlySpecs:  &mdbv1.Specs{InstanceSize: "M10"},
+										AnalyticsSpecs: &mdbv1.Specs{InstanceSize: "M10"},
+									},
+								},
+							},
+							{
+								RegionConfigs: []*mdbv1.AdvancedRegionConfig{
+									{
+										ElectableSpecs: &mdbv1.Specs{InstanceSize: "M20"},
+										ReadOnlySpecs:  &mdbv1.Specs{InstanceSize: "M10"},
+										AnalyticsSpecs: &mdbv1.Specs{InstanceSize: "M10"},
+									},
+								},
+							},
+						},
+					},
+				}
+				assert.Error(t, DeploymentSpec(spec))
+			})
+		})
+		t.Run("different autoscaling for advanced deployment", func(t *testing.T) {
+			t.Run("different instance size in different regions", func(t *testing.T) {
+				spec := mdbv1.AtlasDeploymentSpec{
+					AdvancedDeploymentSpec: &mdbv1.AdvancedDeploymentSpec{
+						ReplicationSpecs: []*mdbv1.AdvancedReplicationSpec{
+							{
+								RegionConfigs: []*mdbv1.AdvancedRegionConfig{
+									{
+										ElectableSpecs: &mdbv1.Specs{InstanceSize: "M10"},
+										ReadOnlySpecs:  &mdbv1.Specs{InstanceSize: "M10"},
+										AnalyticsSpecs: &mdbv1.Specs{InstanceSize: "M10"},
+										AutoScaling: &mdbv1.AdvancedAutoScalingSpec{
+											Compute: &mdbv1.ComputeSpec{
+												Enabled:          toptr.MakePtr(true),
+												ScaleDownEnabled: toptr.MakePtr(true),
+												MinInstanceSize:  "M10",
+												MaxInstanceSize:  "M30",
+											},
+										},
+									},
+									{
+										ElectableSpecs: &mdbv1.Specs{InstanceSize: "M10"},
+										ReadOnlySpecs:  &mdbv1.Specs{InstanceSize: "M10"},
+										AnalyticsSpecs: &mdbv1.Specs{InstanceSize: "M10"},
+									},
+								},
+							},
+						},
+					},
+				}
+				assert.Error(t, DeploymentSpec(spec))
+			})
+			t.Run("different autoscaling in different replications", func(t *testing.T) {
+				spec := mdbv1.AtlasDeploymentSpec{
+					AdvancedDeploymentSpec: &mdbv1.AdvancedDeploymentSpec{
+						ReplicationSpecs: []*mdbv1.AdvancedReplicationSpec{
+							{
+								RegionConfigs: []*mdbv1.AdvancedRegionConfig{
+									{
+										ElectableSpecs: &mdbv1.Specs{InstanceSize: "M10"},
+										ReadOnlySpecs:  &mdbv1.Specs{InstanceSize: "M10"},
+										AnalyticsSpecs: &mdbv1.Specs{InstanceSize: "M10"},
+										AutoScaling: &mdbv1.AdvancedAutoScalingSpec{
+											Compute: &mdbv1.ComputeSpec{
+												Enabled:          toptr.MakePtr(true),
+												ScaleDownEnabled: toptr.MakePtr(true),
+												MinInstanceSize:  "M10",
+												MaxInstanceSize:  "M30",
+											},
+										},
+									},
+								},
+							},
+							{
+								RegionConfigs: []*mdbv1.AdvancedRegionConfig{
+									{
+										ElectableSpecs: &mdbv1.Specs{InstanceSize: "M20"},
+										ReadOnlySpecs:  &mdbv1.Specs{InstanceSize: "M10"},
+										AnalyticsSpecs: &mdbv1.Specs{InstanceSize: "M10"},
+									},
+								},
+							},
+						},
+					},
+				}
+				assert.Error(t, DeploymentSpec(spec))
+			})
+		})
 	})
 	t.Run("Valid cluster specs", func(t *testing.T) {
 		t.Run("Advanced cluster spec specified", func(t *testing.T) {
@@ -55,6 +195,50 @@ func TestClusterValidation(t *testing.T) {
 					ProviderName: "SERVERLESS",
 				},
 			}}
+			assert.NoError(t, DeploymentSpec(spec))
+			assert.Nil(t, DeploymentSpec(spec))
+		})
+		t.Run("Advanced cluster with replication config", func(t *testing.T) {
+			spec := mdbv1.AtlasDeploymentSpec{
+				AdvancedDeploymentSpec: &mdbv1.AdvancedDeploymentSpec{
+					ReplicationSpecs: []*mdbv1.AdvancedReplicationSpec{
+						{
+							RegionConfigs: []*mdbv1.AdvancedRegionConfig{
+								{
+									ElectableSpecs: &mdbv1.Specs{InstanceSize: "M10"},
+									ReadOnlySpecs:  &mdbv1.Specs{InstanceSize: "M10"},
+									AnalyticsSpecs: &mdbv1.Specs{InstanceSize: "M10"},
+									AutoScaling: &mdbv1.AdvancedAutoScalingSpec{
+										Compute: &mdbv1.ComputeSpec{
+											Enabled:          toptr.MakePtr(true),
+											ScaleDownEnabled: toptr.MakePtr(true),
+											MinInstanceSize:  "M10",
+											MaxInstanceSize:  "M30",
+										},
+									},
+								},
+							},
+						},
+						{
+							RegionConfigs: []*mdbv1.AdvancedRegionConfig{
+								{
+									ElectableSpecs: &mdbv1.Specs{InstanceSize: "M10"},
+									ReadOnlySpecs:  &mdbv1.Specs{InstanceSize: "M10"},
+									AnalyticsSpecs: &mdbv1.Specs{InstanceSize: "M10"},
+									AutoScaling: &mdbv1.AdvancedAutoScalingSpec{
+										Compute: &mdbv1.ComputeSpec{
+											Enabled:          toptr.MakePtr(true),
+											ScaleDownEnabled: toptr.MakePtr(true),
+											MinInstanceSize:  "M10",
+											MaxInstanceSize:  "M30",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
 			assert.NoError(t, DeploymentSpec(spec))
 			assert.Nil(t, DeploymentSpec(spec))
 		})


### PR DESCRIPTION
### All Submissions:

* [x] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [x] Update docs/release-notes/release-notes.md if your changes should be included in the release notes for the next release.
