### PR TITLE
Fixed missing goimports for Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ COPY go.sum go.sum
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
 RUN go mod download
+RUN go install golang.org/x/tools/cmd/goimports@latest
 
 # Copy the go source & git info
 COPY cmd/manager/main.go cmd/manager/main.go


### PR DESCRIPTION
### All Submissions:

Fixed `find: 'goimports': No such file or directory` error when building image

* [x] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
