### PR TITLE
Make sure PEs are always added to status

### DIFF
--- a/pkg/controller/atlasproject/private_endpoint.go
+++ b/pkg/controller/atlasproject/private_endpoint.go
@@ -245,12 +245,10 @@ func syncPeInterfaceInAtlas(ctx *workflow.Context, projectID string, endpointsTo
 			interfaceConn, response, err := ctx.Client.PrivateEndpoints.AddOnePrivateEndpoint(context.Background(), projectID, string(specPeService.Provider), atlasPeService.ID, interfaceConn)
 			ctx.Log.Debugw("AddOnePrivateEndpoint Reply", "interfaceConn", interfaceConn, "err", err)
 			if err != nil {
-				if response.StatusCode == 400 || response.StatusCode == 409 {
-					ctx.Log.Debugw("failed to create PE Interface", "error", err)
-					continue
+				ctx.Log.Debugw("failed to create PE Interface", "error", err)
+				if response.StatusCode != 400 && response.StatusCode != 409 {
+					return syncedEndpoints, err
 				}
-
-				return syncedEndpoints, err
 			}
 		}
 

--- a/pkg/controller/atlasproject/private_endpoint.go
+++ b/pkg/controller/atlasproject/private_endpoint.go
@@ -3,6 +3,7 @@ package atlasproject
 import (
 	"context"
 	"errors"
+	"net/http"
 
 	"go.mongodb.org/atlas/mongodbatlas"
 
@@ -246,7 +247,7 @@ func syncPeInterfaceInAtlas(ctx *workflow.Context, projectID string, endpointsTo
 			ctx.Log.Debugw("AddOnePrivateEndpoint Reply", "interfaceConn", interfaceConn, "err", err)
 			if err != nil {
 				ctx.Log.Debugw("failed to create PE Interface", "error", err)
-				if response.StatusCode != 400 && response.StatusCode != 409 {
+				if response.StatusCode == http.StatusBadRequest || response.StatusCode == http.StatusConflict {
 					return syncedEndpoints, err
 				}
 			}


### PR DESCRIPTION
When there is an error with PEs the **privateEndpoints** status is missing. This change fixes that.