### PR TITLE
Use go-licenses@v1.0.0 instead of the latest version

### DIFF
--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -45,7 +45,7 @@ jobs:
     - name: Create the licence report file
       run: |
         export PATH="$GOPATH/bin:$PATH"
-        go install github.com/google/go-licenses@latest && go-licenses csv cmd/manager/main.go --stderrthreshold 3 > third_party_licenses.txt
+        go install github.com/google/go-licenses@v1.0.0 && go-licenses csv cmd/manager/main.go --stderrthreshold 3 > third_party_licenses.txt
 
     - name: Configure Git
       run: |


### PR DESCRIPTION
It looks like there is a [change in go-licenses which breaks the current release script](https://github.com/google/go-licenses/issues/128).

[The error](https://github.com/mongodb/mongodb-atlas-kubernetes/actions/runs/3601793096/jobs/6068003604) reads like this:
```
Package command-line-arguments does not have module info. Non go modules projects are no longer supported.
```

Need to investigate why this error appears and why now and maybe even do not merge this PR. 