### PR TITLE
Fix usage of errgroup to sync team users

### DIFF
--- a/pkg/controller/atlasproject/team_reconciler.go
+++ b/pkg/controller/atlasproject/team_reconciler.go
@@ -180,6 +180,7 @@ func ensureTeamUsersAreInSync(ctx context.Context, workflowCtx *workflow.Context
 		return workflow.Terminate(workflow.TeamUsersNotReady, err.Error())
 	}
 
+	g, taskContext = errgroup.WithContext(ctx)
 	toAdd := make([]string, 0, len(team.Spec.Usernames))
 	lock := sync.Mutex{}
 	for _, username := range team.Spec.Usernames {


### PR DESCRIPTION
### All Submissions:

* [x] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [x] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if there is one).

closes #827 
