### PR TITLE
Moved `leases.coordination.k8s.io` to its own proxy-role rule

### DIFF
--- a/config/rbac/leader_election_role.yaml
+++ b/config/rbac/leader_election_role.yaml
@@ -6,9 +6,19 @@ metadata:
 rules:
   - apiGroups:
       - ""
-      - coordination.k8s.io
     resources:
       - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
       - leases
     verbs:
       - get


### PR DESCRIPTION
`lease` RBAC cannot be installed in newer version of k8s

See:
- https://github.com/operator-framework/operator-sdk/pull/4835/files
- https://github.com/operator-framework/operator-sdk/releases/tag/v1.7.1

### All Submissions:

* [x] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if there is one).
* [ ] Update docs/release-notes/release-notes.md if your changes should be included in the release notes for the next release.
