### PR TITLE
Move leases.coordination.k8s.io to its own proxy-role rule

### DIFF
--- a/config/rbac/leader_election_role.yaml
+++ b/config/rbac/leader_election_role.yaml
@@ -5,11 +5,21 @@ metadata:
   name: leader-election-role
 rules:
   - apiGroups:
-      - ""
       - coordination.k8s.io
     resources:
-      - configmaps
       - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
     verbs:
       - get
       - list


### PR DESCRIPTION
### All Submissions:

Move `leases.coordination.k8s.io` to its own proxy-role rule

* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if there is one).
* [ ] Update docs/release-notes/release-notes.md if your changes should be included in the release notes for the next release.
