### PR TITLE
HELP-48316: Fixed missing private endpoint connection string for sharded clusters

### DIFF
--- a/pkg/controller/connectionsecret/connectionsecrets.go
+++ b/pkg/controller/connectionsecret/connectionsecrets.go
@@ -2,6 +2,7 @@ package connectionsecret
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -188,8 +189,9 @@ func FillPrivateConnStrings(connStrings *mongodbatlas.ConnectionStrings, data *C
 
 	for _, pe := range connStrings.PrivateEndpoint {
 		data.PrivateConnURLs = append(data.PrivateConnURLs, PrivateLinkConnURLs{
-			PvtConnURL:    pe.ConnectionString,
-			PvtSrvConnURL: pe.SRVConnectionString,
+			PvtConnURL:      pe.ConnectionString,
+			PvtSrvConnURL:   pe.SRVConnectionString,
+			PvtShardConnURL: pe.SRVShardOptimizedConnectionString,
 		})
 	}
 }

--- a/pkg/controller/connectionsecret/connectionsecrets.go
+++ b/pkg/controller/connectionsecret/connectionsecrets.go
@@ -2,7 +2,6 @@ package connectionsecret
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 

--- a/pkg/controller/connectionsecret/ensuresecret.go
+++ b/pkg/controller/connectionsecret/ensuresecret.go
@@ -19,12 +19,13 @@ const (
 	TypeLabelKey           = "atlas.mongodb.com/type"
 	CredLabelVal           = "credentials"
 
-	standardKey    string = "connectionStringStandard"
-	standardKeySrv string = "connectionStringStandardSrv"
-	privateKey     string = "connectionStringPrivate"
-	privateKeySrv  string = "connectionStringPrivateSrv"
-	userNameKey    string = "username"
-	passwordKey    string = "password"
+	standardKey     string = "connectionStringStandard"
+	standardKeySrv  string = "connectionStringStandardSrv"
+	privateKey      string = "connectionStringPrivate"
+	privateKeySrv   string = "connectionStringPrivateSrv"
+	privateShardKey string = "connectionStringPrivateShard"
+	userNameKey     string = "username"
+	passwordKey     string = "password"
 )
 
 type ConnectionData struct {
@@ -36,8 +37,9 @@ type ConnectionData struct {
 }
 
 type PrivateLinkConnURLs struct {
-	PvtConnURL    string
-	PvtSrvConnURL string
+	PvtConnURL      string
+	PvtSrvConnURL   string
+	PvtShardConnURL string
 }
 
 // Ensure creates or updates the connection Secret for the specific cluster and db user. Returns the name of the Secret
@@ -77,6 +79,9 @@ func fillSecret(secret *corev1.Secret, projectID string, clusterName string, dat
 		if data.PrivateConnURLs[idx].PvtSrvConnURL, err = AddCredentialsToConnectionURL(privateConn.PvtSrvConnURL, data.DBUserName, data.Password); err != nil {
 			return err
 		}
+		if data.PrivateConnURLs[idx].PvtShardConnURL, err = AddCredentialsToConnectionURL(privateConn.PvtShardConnURL, data.DBUserName, data.Password); err != nil {
+			return err
+		}
 	}
 
 	secret.Labels = map[string]string{
@@ -98,6 +103,7 @@ func fillSecret(secret *corev1.Secret, projectID string, clusterName string, dat
 		suffix := getSuffix(idx)
 		secret.Data[privateKey+suffix] = []byte(privateConn.PvtConnURL)
 		secret.Data[privateKeySrv+suffix] = []byte(privateConn.PvtSrvConnURL)
+		secret.Data[privateShardKey+suffix] = []byte(privateConn.PvtShardConnURL)
 	}
 
 	return nil

--- a/pkg/controller/connectionsecret/ensuresecret_test.go
+++ b/pkg/controller/connectionsecret/ensuresecret_test.go
@@ -84,12 +84,13 @@ func validateSecret(t *testing.T, fakeClient client.Client, namespace, projectNa
 	assert.NoError(t, err)
 
 	expectedData := map[string][]byte{
-		"connectionStringStandard":    []byte(buildConnectionURL(data.ConnURL, data.DBUserName, data.Password)),
-		"connectionStringStandardSrv": []byte(buildConnectionURL(data.SrvConnURL, data.DBUserName, data.Password)),
-		"connectionStringPrivate":     []byte(buildConnectionURL(data.PrivateConnURLs[0].PvtConnURL, data.DBUserName, data.Password)),
-		"connectionStringPrivateSrv":  []byte(buildConnectionURL(data.PrivateConnURLs[0].PvtSrvConnURL, data.DBUserName, data.Password)),
-		"username":                    []byte(data.DBUserName),
-		"password":                    []byte(data.Password),
+		"connectionStringStandard":     []byte(buildConnectionURL(data.ConnURL, data.DBUserName, data.Password)),
+		"connectionStringStandardSrv":  []byte(buildConnectionURL(data.SrvConnURL, data.DBUserName, data.Password)),
+		"connectionStringPrivate":      []byte(buildConnectionURL(data.PrivateConnURLs[0].PvtConnURL, data.DBUserName, data.Password)),
+		"connectionStringPrivateSrv":   []byte(buildConnectionURL(data.PrivateConnURLs[0].PvtSrvConnURL, data.DBUserName, data.Password)),
+		"username":                     []byte(data.DBUserName),
+		"password":                     []byte(data.Password),
+		"connectionStringPrivateShard": []byte(data.PrivateConnURLs[0].PvtShardConnURL),
 	}
 	expectedLabels := map[string]string{
 		"atlas.mongodb.com/project-id":   projectID,


### PR DESCRIPTION
### All Submissions:

Fixed missing private endpoint connection string for sharded clusters

* [x] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if there is one).
* [ ] Update docs/release-notes/release-notes.md if your changes should be included in the release notes for the next release.
