### PR TITLE
CLOUDP-194416: Isolate CI unit tests to always run

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -1,17 +1,12 @@
 name: Integration tests non-forked
 
 on:
-  push:
-    branches:
-      - 'main'
-    paths-ignore:
-      - 'docs/**'
-  pull_request:
-    branches:
-      - '**'
-    paths-ignore:
-      - 'docs/**'
-  workflow_dispatch:
+  workflow_call:
+    inputs:
+      forked:
+        type: boolean
+        required: false
+        default: false
 
 concurrency:
   group: int-test-${{ github.head_ref || github.ref_name }}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -3,12 +3,12 @@
 name: Lint
 
 on:
-  pull_request:
-    branches:
-      - '**'
-    paths-ignore:
-      - 'docs/**'
-  workflow_dispatch:
+  workflow_call:
+    inputs:
+      forked:
+        type: boolean
+        required: false
+        default: false
 
 jobs:
   lint:

--- a/.github/workflows/test-forked.yml
+++ b/.github/workflows/test-forked.yml
@@ -11,6 +11,16 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  lint:
+    uses: ./.github/workflows/lint.yaml
+    with:
+      forked: false
+  
+  unit-tests:
+    uses: ./.github/workflows/test-unit.yml
+    with:
+      forked: false
+
   allowed-forked:
     name: Allowed action
     runs-on: ubuntu-latest
@@ -19,9 +29,9 @@ jobs:
       - name: allowed message
         run: echo "Allowed to run"
 
-  unit-tests-forked:
+  int-tests:
     needs: allowed-forked
-    uses: ./.github/workflows/test-unit.yml
+    uses: ./.github/workflows/integration-test.yml
     secrets: inherit
     with:
       forked: true

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -1,4 +1,4 @@
-name: Unit Tests.
+name: Unit Tests
 
 on:
   workflow_call:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,7 @@ on:
     paths-ignore:
       - 'docs/**'
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, converted_to_draft]
     branches:
       - '**'
     paths-ignore:
@@ -18,13 +19,29 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  lint:
+    uses: ./.github/workflows/lint.yaml
+    with:
+      forked: false
+  
+  unit-tests:
+    uses: ./.github/workflows/test-unit.yml
+    with:
+      forked: false
+
   allowed:
+    needs:
+      - unit-tests
+      - lint
     name: Allowed
     runs-on: ubuntu-latest
     if: |
-      github.event_name == 'workflow_dispatch' ||
-      github.ref == 'refs/heads/main' ||
-      (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]')
+      github.event.pull_request.draft == false &&
+      (
+        github.event_name == 'workflow_dispatch' ||
+        github.ref == 'refs/heads/main' ||
+        (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]')
+      )
     steps:
       - name: allowed message
         run: echo "Allowed to run"
@@ -50,9 +67,9 @@ jobs:
         run: |
           gh pr comment ${{ github.event.pull_request.number }} -R mongodb/mongodb-atlas-kubernetes -b "https://app.codecov.io/github/mongodb/mongodb-atlas-kubernetes/commit/${{ github.event.pull_request.head.sha }}"
 
-  unit-tests:
+  int-tests:
     needs: allowed
-    uses: ./.github/workflows/test-unit.yml
+    uses: ./.github/workflows/integration-test.yml
     secrets: inherit
     with:
       forked: false


### PR DESCRIPTION
Both `lint` and `unit-test`
- Run now as part of the `Test` workflow.
- Will **always** run on `push`, `PR` and workflow dispatch. Nothing can stop them.
- Are required to run any cloud bound tests: `integration' and `e2e` tests. 

Additionally, `e2e` and `integration` tests will NOT run on draft by default, so this also completes [CLOUDP-192963: Atlas CI/CD: Do not run CI/CD pipeline for draft PRs](https://jira.mongodb.org/browse/CLOUDP-192963)

### All Submissions:

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if there is one).
* [ ] Update docs/release-notes/release-notes.md if your changes should be included in the release notes for the next release.
