### PR TITLE
Run forked test only on labeled PRs

### DIFF
--- a/.github/workflows/test-forked.yml
+++ b/.github/workflows/test-forked.yml
@@ -2,7 +2,7 @@ name: Test Forked
 
 on:
   pull_request_target:
-    types: [labeled, opened, synchronize, reopened, ready_for_review, converted_to_draft]
+    types: [labeled]
     paths-ignore:
       - 'docs/**'
 
@@ -29,9 +29,7 @@ jobs:
       - lint
       - unit-tests
       - paths-filter
-    if: |
-      github.event.pull_request.draft == false &&
-      needs.paths-filter.outputs.production-code-changed == 'true'
+    if: needs.paths-filter.outputs.production-code-changed == 'true'
     uses: ./.github/workflows/cloud-tests-forked.yml
     secrets: inherit
     with:


### PR DESCRIPTION
Should avoid running forked tests when not expected, like here:
https://github.com/mongodb/mongodb-atlas-kubernetes/actions/runs/5890991221?pr=1082

### All Submissions:

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if there is one).
* [ ] Update docs/release-notes/release-notes.md if your changes should be included in the release notes for the next release.
