### PR TITLE
CLOUDP-196136: Use UBI micro base image instead of minimal

### DIFF
--- a/.github/workflows/paths-filter.yml
+++ b/.github/workflows/paths-filter.yml
@@ -21,6 +21,7 @@ jobs:
               production-code-changed:
                 - 'cmd/**/!(*_test.go)'
                 - 'pkg/**/!(*_test.go)'
+                - 'Dockerfile'
         # run only if 'production-code' files were changed
         - name: production code changed
           if: steps.filter.outputs.production-code-changed == 'true'

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -7,6 +7,7 @@ on:
         type: boolean
         required: false
         default: false
+  workflow_dispatch:
 
 jobs:
   prepare-e2e:

--- a/.github/workflows/test-int.yml
+++ b/.github/workflows/test-int.yml
@@ -7,6 +7,7 @@ on:
         type: boolean
         required: false
         default: false
+  workflow_dispatch:
 
 jobs:
   int-test:

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,18 +27,7 @@ ENV TARGET_OS=${TARGETOS}
 
 RUN make manager
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.2
-
-RUN microdnf install -y yum &&\
-  yum -y update &&\
-  yum -y upgrade &&\
-  yum clean all &&\
-  dnf remove python3-pip -y &&\
-  microdnf clean all
-
-#FROM registry.access.redhat.com/ubi8/ubi
-#
-#RUN dnf -y update-minimal --security --sec-severity=Important --sec-severity=Critical
+FROM registry.access.redhat.com/ubi9/ubi-micro:9.2
 
 LABEL name="MongoDB Atlas Operator" \
   maintainer="support@mongodb.com" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,7 @@ LABEL name="MongoDB Atlas Operator" \
 WORKDIR /
 COPY --from=builder /workspace/bin/manager .
 COPY hack/licenses licenses
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
 
 USER 1001:0
 ENTRYPOINT ["/manager"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN go install golang.org/x/tools/cmd/goimports@latest
 COPY cmd/manager/main.go cmd/manager/main.go
 COPY .git/ .git/
 COPY pkg/ pkg/
+COPY internal/ internal/
 COPY Makefile Makefile
 COPY config/ config/
 COPY hack/ hack/


### PR DESCRIPTION
Use Red Hat's Micro Universal Base Image, rather than Minimal. This cuts the compressed size (download from Dockerhub) from ~90mb to ~30mb, and the uncompressed (on disk) from ~260mb to ~77mb. 

This should also reduce security exposure through simply having less packages in the image; [micro has 20](https://catalog.redhat.com/software/containers/ubi9/ubi-micro/615bdf943f6014fa45ae1b58?container-tabs=packages) compared to [minimal's 102](https://catalog.redhat.com/software/containers/ubi9/ubi-minimal/615bd9b4075b022acc111bf5?container-tabs=packages).

### All Submissions:

* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if there is one).
* [ ] Update docs/release-notes/release-notes.md if your changes should be included in the release notes for the next release.
