### PR TITLE
CLOUDP-196968: Put go context within workflow.Context

### DIFF
--- a/pkg/controller/atlasdatabaseuser/atlasdatabaseuser_controller.go
+++ b/pkg/controller/atlasdatabaseuser/atlasdatabaseuser_controller.go
@@ -81,7 +81,7 @@ func (r *AtlasDatabaseUserReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		return workflow.OK().ReconcileResult(), nil
 	}
 
-	workflowCtx := customresource.MarkReconciliationStarted(r.Client, databaseUser, log)
+	workflowCtx := customresource.MarkReconciliationStarted(r.Client, databaseUser, log, ctx)
 	log.Infow("-> Starting AtlasDatabaseUser reconciliation", "spec", databaseUser.Spec, "status", databaseUser.Status)
 	if databaseUser.Spec.PasswordSecret != nil {
 		workflowCtx.AddResourcesToWatch(watch.WatchedObject{ResourceKind: "Secret", Resource: *databaseUser.PasswordSecretObjectKey()})
@@ -93,7 +93,7 @@ func (r *AtlasDatabaseUserReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 	resourceVersionIsValid := customresource.ValidateResourceVersion(workflowCtx, databaseUser, r.Log)
 	if !resourceVersionIsValid.IsOk() {
-		r.Log.Debugf("databaseuser validation result: %v", resourceVersionIsValid)
+		r.Log.Debugf("database user validation result: %v", resourceVersionIsValid)
 
 		return resourceVersionIsValid.ReconcileResult(), nil
 	}

--- a/pkg/controller/atlasdatabaseuser/databaseuser_test.go
+++ b/pkg/controller/atlasdatabaseuser/databaseuser_test.go
@@ -107,7 +107,7 @@ func TestHandleUserNameChange(t *testing.T) {
 		user := *mdbv1.DefaultDBUser("ns", "theuser", "project1")
 		user.Spec.Username = "differentuser"
 		user.Status.UserName = "theuser"
-		ctx := workflow.NewContext(zap.S(), []status.Condition{})
+		ctx := workflow.NewContext(zap.S(), []status.Condition{}, nil)
 		ctx.Client = *mongodbatlas.NewClient(&http.Client{})
 		result := handleUserNameChange(ctx, "", user)
 		assert.True(t, result.IsOk())

--- a/pkg/controller/atlasdeployment/serverless_deployment.go
+++ b/pkg/controller/atlasdeployment/serverless_deployment.go
@@ -13,7 +13,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/controller/workflow"
 )
 
-func (r *AtlasDeploymentReconciler) ensureServerlessInstanceState(ctx context.Context, workflowCtx *workflow.Context, project *mdbv1.AtlasProject, deployment *mdbv1.AtlasDeployment) (atlasDeployment *mongodbatlas.Cluster, _ workflow.Result) {
+func (r *AtlasDeploymentReconciler) ensureServerlessInstanceState(workflowCtx *workflow.Context, project *mdbv1.AtlasProject, deployment *mdbv1.AtlasDeployment) (atlasDeployment *mongodbatlas.Cluster, _ workflow.Result) {
 	if deployment == nil || deployment.Spec.ServerlessSpec == nil {
 		return nil, workflow.Terminate(workflow.ServerlessPrivateEndpointReady, "deployment spec is empty")
 	}
@@ -69,7 +69,7 @@ func (r *AtlasDeploymentReconciler) ensureServerlessInstanceState(ctx context.Co
 			}
 			return atlasDeployment, workflow.InProgress(workflow.DeploymentUpdating, "deployment is updating")
 		}
-		result := ensureServerlessPrivateEndpoints(ctx, workflowCtx, project.ID(), deployment, atlasDeployment.Name, r.SubObjectDeletionProtection)
+		result := ensureServerlessPrivateEndpoints(workflowCtx, project.ID(), deployment, atlasDeployment.Name, r.SubObjectDeletionProtection)
 		return atlasDeployment, result
 
 	case status.StateCREATING:

--- a/pkg/controller/atlasdeployment/serverless_private_endpoint_test.go
+++ b/pkg/controller/atlasdeployment/serverless_private_endpoint_test.go
@@ -24,7 +24,6 @@ func TestCanReconcileServerlessPrivateEndpoints(t *testing.T) {
 	t.Run("when subResourceDeletionProtection is disabled", func(t *testing.T) {
 		protected := false
 		result, err := canServerlessPrivateEndpointsReconcile(
-			context.TODO(),
 			&workflow.Context{},
 			protected,
 			"fake-project-id-wont-be-checked",
@@ -45,9 +44,9 @@ func TestCanReconcileServerlessPrivateEndpoints(t *testing.T) {
 		}
 		deployment := sampleServerlessDeployment()
 		protected := true
-		workflowCtx := workflow.Context{Client: client}
+		workflowCtx := workflow.Context{Client: client, Context: ctx}
 
-		result, err := canServerlessPrivateEndpointsReconcile(ctx, &workflowCtx, protected, fakeProjectID, deployment)
+		result, err := canServerlessPrivateEndpointsReconcile(&workflowCtx, protected, fakeProjectID, deployment)
 
 		require.NoError(t, err)
 		assert.True(t, result)
@@ -65,9 +64,9 @@ func TestCanReconcileServerlessPrivateEndpoints(t *testing.T) {
 		}
 		deployment := sampleAnnotatedServerlessDeployment(endpointsFrom(endpointsConfig))
 		protected := true
-		workflowCtx := workflow.Context{Client: client, Log: debugLogger(t)}
+		workflowCtx := workflow.Context{Client: client, Log: debugLogger(t), Context: ctx}
 
-		result, err := canServerlessPrivateEndpointsReconcile(ctx, &workflowCtx, protected, fakeProjectID, deployment)
+		result, err := canServerlessPrivateEndpointsReconcile(&workflowCtx, protected, fakeProjectID, deployment)
 
 		require.NoError(t, err)
 		assert.True(t, result)
@@ -85,9 +84,9 @@ func TestCanReconcileServerlessPrivateEndpoints(t *testing.T) {
 		}
 		deployment := sampleAnnotatedServerlessDeployment(reverse(endpointsFrom(endpointsConfig)))
 		protected := true
-		workflowCtx := workflow.Context{Client: client, Log: debugLogger(t)}
+		workflowCtx := workflow.Context{Client: client, Log: debugLogger(t), Context: ctx}
 
-		result, err := canServerlessPrivateEndpointsReconcile(ctx, &workflowCtx, protected, fakeProjectID, deployment)
+		result, err := canServerlessPrivateEndpointsReconcile(&workflowCtx, protected, fakeProjectID, deployment)
 
 		require.NoError(t, err)
 		assert.True(t, result)
@@ -107,9 +106,9 @@ func TestCanReconcileServerlessPrivateEndpoints(t *testing.T) {
 		// remove all PEs in the current desired setup
 		deployment.Spec.ServerlessSpec.PrivateEndpoints = []v1.ServerlessPrivateEndpoint{}
 		protected := true
-		workflowCtx := workflow.Context{Client: client, Log: debugLogger(t)}
+		workflowCtx := workflow.Context{Client: client, Log: debugLogger(t), Context: ctx}
 
-		result, err := canServerlessPrivateEndpointsReconcile(ctx, &workflowCtx, protected, fakeProjectID, deployment)
+		result, err := canServerlessPrivateEndpointsReconcile(&workflowCtx, protected, fakeProjectID, deployment)
 
 		require.NoError(t, err)
 		assert.True(t, result)
@@ -131,9 +130,9 @@ func TestCannotReconcileServerlessPrivateEndpoints(t *testing.T) {
 		endpoints[0].Name = "non-matching-fake-name"
 		deployment := sampleAnnotatedServerlessDeployment(endpoints)
 		protected := true
-		workflowCtx := workflow.Context{Client: client, Log: debugLogger(t)}
+		workflowCtx := workflow.Context{Client: client, Log: debugLogger(t), Context: ctx}
 
-		result, err := canServerlessPrivateEndpointsReconcile(ctx, &workflowCtx, protected, fakeProjectID, deployment)
+		result, err := canServerlessPrivateEndpointsReconcile(&workflowCtx, protected, fakeProjectID, deployment)
 
 		require.NoError(t, err)
 		assert.False(t, result)
@@ -154,9 +153,9 @@ func TestCannotReconcileServerlessPrivateEndpoints(t *testing.T) {
 			customresource.AnnotationLastAppliedConfiguration: "{}",
 		}
 		protected := true
-		workflowCtx := workflow.Context{Client: client, Log: debugLogger(t)}
+		workflowCtx := workflow.Context{Client: client, Log: debugLogger(t), Context: ctx}
 
-		result, err := canServerlessPrivateEndpointsReconcile(ctx, &workflowCtx, protected, fakeProjectID, deployment)
+		result, err := canServerlessPrivateEndpointsReconcile(&workflowCtx, protected, fakeProjectID, deployment)
 
 		require.NoError(t, err)
 		assert.False(t, result)
@@ -175,9 +174,9 @@ func TestCannotReconcileServerlessPrivateEndpoints(t *testing.T) {
 		deployment := sampleServerlessDeployment()
 		deployment.Annotations = map[string]string{}
 		protected := true
-		workflowCtx := workflow.Context{Client: client, Log: debugLogger(t)}
+		workflowCtx := workflow.Context{Client: client, Log: debugLogger(t), Context: ctx}
 
-		result, err := canServerlessPrivateEndpointsReconcile(ctx, &workflowCtx, protected, fakeProjectID, deployment)
+		result, err := canServerlessPrivateEndpointsReconcile(&workflowCtx, protected, fakeProjectID, deployment)
 
 		require.NoError(t, err)
 		assert.False(t, result)
@@ -193,9 +192,9 @@ func TestCanReconcileServerlessPrivateEndpointsFail(t *testing.T) {
 			customresource.AnnotationLastAppliedConfiguration: "{",
 		}
 		protected := true
-		workflowCtx := workflow.Context{Client: client, Log: debugLogger(t)}
+		workflowCtx := workflow.Context{Client: client, Log: debugLogger(t), Context: ctx}
 
-		result, err := canServerlessPrivateEndpointsReconcile(ctx, &workflowCtx, protected, fakeProjectID, deployment)
+		result, err := canServerlessPrivateEndpointsReconcile(&workflowCtx, protected, fakeProjectID, deployment)
 
 		require.False(t, result)
 		var aJSONError *json.SyntaxError
@@ -214,9 +213,9 @@ func TestCanReconcileServerlessPrivateEndpointsFail(t *testing.T) {
 		}
 		deployment := sampleServerlessDeployment()
 		protected := true
-		workflowCtx := workflow.Context{Client: client, Log: debugLogger(t)}
+		workflowCtx := workflow.Context{Client: client, Log: debugLogger(t), Context: ctx}
 
-		result, err := canServerlessPrivateEndpointsReconcile(ctx, &workflowCtx, protected, fakeProjectID, deployment)
+		result, err := canServerlessPrivateEndpointsReconcile(&workflowCtx, protected, fakeProjectID, deployment)
 
 		require.False(t, result)
 		assert.ErrorIs(t, err, fakeError)

--- a/pkg/controller/atlasfederatedauth/atlasfederated_auth_controller.go
+++ b/pkg/controller/atlasfederatedauth/atlasfederated_auth_controller.go
@@ -71,7 +71,7 @@ func (r *AtlasFederatedAuthReconciler) Reconcile(ctx context.Context, req ctrl.R
 		return workflow.OK().ReconcileResult(), nil
 	}
 
-	workflowCtx := customresource.MarkReconciliationStarted(r.Client, fedauth, log)
+	workflowCtx := customresource.MarkReconciliationStarted(r.Client, fedauth, log, ctx)
 	log.Infow("-> Starting AtlasFederatedAuth reconciliation")
 
 	defer statushandler.Update(workflowCtx, r.Client, r.EventRecorder, fedauth)

--- a/pkg/controller/atlasproject/cloud_provider_access_test.go
+++ b/pkg/controller/atlasproject/cloud_provider_access_test.go
@@ -26,9 +26,10 @@ func TestSyncCloudProviderAccess(t *testing.T) {
 			},
 		}
 		workflowCtx := &workflow.Context{
-			Client: atlasClient,
+			Client:  atlasClient,
+			Context: context.TODO(),
 		}
-		result, err := syncCloudProviderAccess(context.TODO(), workflowCtx, "projectID", []mdbv1.CloudProviderAccessRole{})
+		result, err := syncCloudProviderAccess(workflowCtx, "projectID", []mdbv1.CloudProviderAccessRole{})
 		assert.EqualError(t, err, "unable to fetch cloud provider access from Atlas: service unavailable")
 		assert.False(t, result)
 	})
@@ -102,10 +103,11 @@ func TestSyncCloudProviderAccess(t *testing.T) {
 			},
 		}
 		workflowCtx := &workflow.Context{
-			Client: atlasClient,
+			Client:  atlasClient,
+			Context: context.TODO(),
 		}
 
-		result, err := syncCloudProviderAccess(context.TODO(), workflowCtx, "projectID", cpas)
+		result, err := syncCloudProviderAccess(workflowCtx, "projectID", cpas)
 		assert.NoError(t, err)
 		assert.False(t, result)
 	})
@@ -156,10 +158,11 @@ func TestSyncCloudProviderAccess(t *testing.T) {
 			},
 		}
 		workflowCtx := &workflow.Context{
-			Client: atlasClient,
+			Client:  atlasClient,
+			Context: context.TODO(),
 		}
 
-		result, err := syncCloudProviderAccess(context.TODO(), workflowCtx, "projectID", cpas)
+		result, err := syncCloudProviderAccess(workflowCtx, "projectID", cpas)
 		assert.NoError(t, err)
 		assert.True(t, result)
 	})
@@ -207,11 +210,12 @@ func TestSyncCloudProviderAccess(t *testing.T) {
 			},
 		}
 		workflowCtx := &workflow.Context{
-			Client: atlasClient,
-			Log:    zaptest.NewLogger(t).Sugar(),
+			Client:  atlasClient,
+			Log:     zaptest.NewLogger(t).Sugar(),
+			Context: context.TODO(),
 		}
 
-		result, err := syncCloudProviderAccess(context.TODO(), workflowCtx, "projectID", cpas)
+		result, err := syncCloudProviderAccess(workflowCtx, "projectID", cpas)
 		assert.EqualError(t, err, "not all items were synchronized successfully")
 		assert.False(t, result)
 	})
@@ -771,10 +775,11 @@ func TestCreateCloudProviderAccess(t *testing.T) {
 			},
 		}
 		workflowCtx := &workflow.Context{
-			Client: atlasClient,
+			Client:  atlasClient,
+			Context: context.TODO(),
 		}
 
-		assert.Equal(t, expected, createCloudProviderAccess(context.TODO(), workflowCtx, "projectID", cpa))
+		assert.Equal(t, expected, createCloudProviderAccess(workflowCtx, "projectID", cpa))
 	})
 
 	t.Run("should fail to create cloud provider access", func(t *testing.T) {
@@ -797,11 +802,12 @@ func TestCreateCloudProviderAccess(t *testing.T) {
 			},
 		}
 		workflowCtx := &workflow.Context{
-			Client: atlasClient,
-			Log:    zaptest.NewLogger(t).Sugar(),
+			Client:  atlasClient,
+			Log:     zaptest.NewLogger(t).Sugar(),
+			Context: context.TODO(),
 		}
 
-		assert.Equal(t, expected, createCloudProviderAccess(context.TODO(), workflowCtx, "projectID", cpa))
+		assert.Equal(t, expected, createCloudProviderAccess(workflowCtx, "projectID", cpa))
 	})
 }
 
@@ -842,10 +848,11 @@ func TestAuthorizeCloudProviderAccess(t *testing.T) {
 			},
 		}
 		workflowCtx := &workflow.Context{
-			Client: atlasClient,
+			Client:  atlasClient,
+			Context: context.TODO(),
 		}
 
-		assert.Equal(t, expected, authorizeCloudProviderAccess(context.TODO(), workflowCtx, "projectID", cpa))
+		assert.Equal(t, expected, authorizeCloudProviderAccess(workflowCtx, "projectID", cpa))
 	})
 
 	t.Run("should fail to authorize cloud provider access", func(t *testing.T) {
@@ -876,11 +883,12 @@ func TestAuthorizeCloudProviderAccess(t *testing.T) {
 			},
 		}
 		workflowCtx := &workflow.Context{
-			Client: atlasClient,
-			Log:    zaptest.NewLogger(t).Sugar(),
+			Client:  atlasClient,
+			Log:     zaptest.NewLogger(t).Sugar(),
+			Context: context.TODO(),
 		}
 
-		assert.Equal(t, expected, authorizeCloudProviderAccess(context.TODO(), workflowCtx, "projectID", cpa))
+		assert.Equal(t, expected, authorizeCloudProviderAccess(workflowCtx, "projectID", cpa))
 	})
 }
 
@@ -905,10 +913,11 @@ func TestDeleteCloudProviderAccess(t *testing.T) {
 			},
 		}
 		workflowCtx := &workflow.Context{
-			Client: atlasClient,
+			Client:  atlasClient,
+			Context: context.TODO(),
 		}
 
-		deleteCloudProviderAccess(context.TODO(), workflowCtx, "projectID", cpa)
+		deleteCloudProviderAccess(workflowCtx, "projectID", cpa)
 		assert.Empty(t, cpa.ErrorMessage)
 	})
 
@@ -930,26 +939,35 @@ func TestDeleteCloudProviderAccess(t *testing.T) {
 			},
 		}
 		workflowCtx := &workflow.Context{
-			Client: atlasClient,
-			Log:    zaptest.NewLogger(t).Sugar(),
+			Client:  atlasClient,
+			Log:     zaptest.NewLogger(t).Sugar(),
+			Context: context.TODO(),
 		}
 
-		deleteCloudProviderAccess(context.TODO(), workflowCtx, "projectID", cpa)
+		deleteCloudProviderAccess(workflowCtx, "projectID", cpa)
 		assert.Equal(t, "service unavailable", cpa.ErrorMessage)
 	})
 }
 
 func TestCanCloudProviderAccessReconcile(t *testing.T) {
 	t.Run("should return true when subResourceDeletionProtection is disabled", func(t *testing.T) {
-		result, err := canCloudProviderAccessReconcile(context.TODO(), mongodbatlas.Client{}, false, &mdbv1.AtlasProject{})
+		workflowCtx := &workflow.Context{
+			Client:  mongodbatlas.Client{},
+			Context: context.TODO(),
+		}
+		result, err := canCloudProviderAccessReconcile(workflowCtx, false, &mdbv1.AtlasProject{})
 		assert.NoError(t, err)
 		assert.True(t, result)
 	})
 
 	t.Run("should return error when unable to deserialize last applied configuration", func(t *testing.T) {
 		akoProject := &mdbv1.AtlasProject{}
+		workflowCtx := &workflow.Context{
+			Client:  mongodbatlas.Client{},
+			Context: context.TODO(),
+		}
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{wrong}"})
-		result, err := canCloudProviderAccessReconcile(context.TODO(), mongodbatlas.Client{}, true, akoProject)
+		result, err := canCloudProviderAccessReconcile(workflowCtx, true, akoProject)
 		assert.EqualError(t, err, "invalid character 'w' looking for beginning of object key string")
 		assert.False(t, result)
 	})
@@ -964,7 +982,11 @@ func TestCanCloudProviderAccessReconcile(t *testing.T) {
 		}
 		akoProject := &mdbv1.AtlasProject{}
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{}"})
-		result, err := canCloudProviderAccessReconcile(context.TODO(), atlasClient, true, akoProject)
+		workflowCtx := &workflow.Context{
+			Client:  atlasClient,
+			Context: context.TODO(),
+		}
+		result, err := canCloudProviderAccessReconcile(workflowCtx, true, akoProject)
 
 		assert.EqualError(t, err, "failed to retrieve data")
 		assert.False(t, result)
@@ -982,7 +1004,11 @@ func TestCanCloudProviderAccessReconcile(t *testing.T) {
 		}
 		akoProject := &mdbv1.AtlasProject{}
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{}"})
-		result, err := canCloudProviderAccessReconcile(context.TODO(), atlasClient, true, akoProject)
+		workflowCtx := &workflow.Context{
+			Client:  atlasClient,
+			Context: context.TODO(),
+		}
+		result, err := canCloudProviderAccessReconcile(workflowCtx, true, akoProject)
 
 		assert.NoError(t, err)
 		assert.True(t, result)
@@ -1014,7 +1040,11 @@ func TestCanCloudProviderAccessReconcile(t *testing.T) {
 			},
 		}
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{\"cloudProviderAccessRoles\":[{\"providerName\":\"AWS\",\"iamAssumedRoleArn\":\"arn1\"}]}"})
-		result, err := canCloudProviderAccessReconcile(context.TODO(), atlasClient, true, akoProject)
+		workflowCtx := &workflow.Context{
+			Client:  atlasClient,
+			Context: context.TODO(),
+		}
+		result, err := canCloudProviderAccessReconcile(workflowCtx, true, akoProject)
 
 		assert.NoError(t, err)
 		assert.True(t, result)
@@ -1054,7 +1084,11 @@ func TestCanCloudProviderAccessReconcile(t *testing.T) {
 			},
 		}
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{\"cloudProviderAccessRoles\":[{\"providerName\":\"AWS\",\"iamAssumedRoleArn\":\"arn1\"}]}"})
-		result, err := canCloudProviderAccessReconcile(context.TODO(), atlasClient, true, akoProject)
+		workflowCtx := &workflow.Context{
+			Client:  atlasClient,
+			Context: context.TODO(),
+		}
+		result, err := canCloudProviderAccessReconcile(workflowCtx, true, akoProject)
 
 		assert.NoError(t, err)
 		assert.True(t, result)
@@ -1085,7 +1119,11 @@ func TestCanCloudProviderAccessReconcile(t *testing.T) {
 			},
 		}
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{\"cloudProviderAccessRoles\":[{\"providerName\":\"AWS\",\"iamAssumedRoleArn\":\"arn1\"}]}"})
-		result, err := canCloudProviderAccessReconcile(context.TODO(), atlasClient, true, akoProject)
+		workflowCtx := &workflow.Context{
+			Client:  atlasClient,
+			Context: context.TODO(),
+		}
+		result, err := canCloudProviderAccessReconcile(workflowCtx, true, akoProject)
 
 		assert.NoError(t, err)
 		assert.True(t, result)
@@ -1125,7 +1163,11 @@ func TestCanCloudProviderAccessReconcile(t *testing.T) {
 			},
 		}
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{\"cloudProviderAccessRoles\":[{\"providerName\":\"AWS\",\"iamAssumedRoleArn\":\"arn1\"}]}"})
-		result, err := canCloudProviderAccessReconcile(context.TODO(), atlasClient, true, akoProject)
+		workflowCtx := &workflow.Context{
+			Client:  atlasClient,
+			Context: context.TODO(),
+		}
+		result, err := canCloudProviderAccessReconcile(workflowCtx, true, akoProject)
 
 		assert.NoError(t, err)
 		assert.False(t, result)
@@ -1144,9 +1186,10 @@ func TestEnsureCloudProviderAccess(t *testing.T) {
 		akoProject := &mdbv1.AtlasProject{}
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{}"})
 		workflowCtx := &workflow.Context{
-			Client: atlasClient,
+			Client:  atlasClient,
+			Context: context.TODO(),
 		}
-		result := ensureProviderAccessStatus(context.TODO(), workflowCtx, akoProject, true)
+		result := ensureProviderAccessStatus(workflowCtx, akoProject, true)
 
 		assert.Equal(t, workflow.Terminate(workflow.Internal, "unable to resolve ownership for deletion protection: failed to retrieve data"), result)
 	})
@@ -1186,9 +1229,10 @@ func TestEnsureCloudProviderAccess(t *testing.T) {
 		}
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{\"cloudProviderAccessRoles\":[{\"providerName\":\"AWS\",\"iamAssumedRoleArn\":\"arn1\"}]}"})
 		workflowCtx := &workflow.Context{
-			Client: atlasClient,
+			Client:  atlasClient,
+			Context: context.TODO(),
 		}
-		result := ensureProviderAccessStatus(context.TODO(), workflowCtx, akoProject, true)
+		result := ensureProviderAccessStatus(workflowCtx, akoProject, true)
 
 		assert.Equal(
 			t,
@@ -1202,8 +1246,8 @@ func TestEnsureCloudProviderAccess(t *testing.T) {
 
 	t.Run("should return earlier when there are not items to operate", func(t *testing.T) {
 		akoProject := &mdbv1.AtlasProject{}
-		workflowCtx := &workflow.Context{}
-		result := ensureProviderAccessStatus(context.TODO(), workflowCtx, akoProject, false)
+		workflowCtx := &workflow.Context{Context: context.TODO()}
+		result := ensureProviderAccessStatus(workflowCtx, akoProject, false)
 		assert.Equal(
 			t,
 			workflow.OK(),
@@ -1234,9 +1278,10 @@ func TestEnsureCloudProviderAccess(t *testing.T) {
 			},
 		}
 		workflowCtx := &workflow.Context{
-			Client: atlasClient,
+			Client:  atlasClient,
+			Context: context.TODO(),
 		}
-		result := ensureProviderAccessStatus(context.TODO(), workflowCtx, akoProject, false)
+		result := ensureProviderAccessStatus(workflowCtx, akoProject, false)
 		assert.Equal(
 			t,
 			workflow.Terminate(workflow.ProjectCloudAccessRolesIsNotReadyInAtlas, "unable to fetch cloud provider access from Atlas: failed to retrieve data"),
@@ -1317,9 +1362,10 @@ func TestEnsureCloudProviderAccess(t *testing.T) {
 			},
 		}
 		workflowCtx := &workflow.Context{
-			Client: atlasClient,
+			Client:  atlasClient,
+			Context: context.TODO(),
 		}
-		result := ensureProviderAccessStatus(context.TODO(), workflowCtx, akoProject, false)
+		result := ensureProviderAccessStatus(workflowCtx, akoProject, false)
 		assert.Equal(
 			t,
 			workflow.InProgress(workflow.ProjectCloudAccessRolesIsNotReadyInAtlas, "not all entries are authorized"),
@@ -1377,9 +1423,10 @@ func TestEnsureCloudProviderAccess(t *testing.T) {
 			},
 		}
 		workflowCtx := &workflow.Context{
-			Client: atlasClient,
+			Client:  atlasClient,
+			Context: context.TODO(),
 		}
-		result := ensureProviderAccessStatus(context.TODO(), workflowCtx, akoProject, false)
+		result := ensureProviderAccessStatus(workflowCtx, akoProject, false)
 		assert.Equal(
 			t,
 			workflow.OK(),

--- a/pkg/controller/atlasproject/custom_roles_test.go
+++ b/pkg/controller/atlasproject/custom_roles_test.go
@@ -114,7 +114,7 @@ func TestSyncCustomRolesStatus(t *testing.T) {
 				Status: status.CustomRoleStatusOK,
 			},
 		}
-		ctx := workflow.NewContext(zap.S(), []status.Condition{})
+		ctx := workflow.NewContext(zap.S(), []status.Condition{}, nil)
 
 		assert.Equal(
 			t,
@@ -182,7 +182,7 @@ func TestSyncCustomRolesStatus(t *testing.T) {
 				Status: status.CustomRoleStatusOK,
 			},
 		}
-		ctx := workflow.NewContext(zap.S(), []status.Condition{})
+		ctx := workflow.NewContext(zap.S(), []status.Condition{}, nil)
 
 		assert.Equal(
 			t,
@@ -217,7 +217,11 @@ func TestSyncCustomRolesStatus(t *testing.T) {
 
 func TestCanCustomRolesReconcile(t *testing.T) {
 	t.Run("should return true when subResourceDeletionProtection is disabled", func(t *testing.T) {
-		result, err := canCustomRolesReconcile(context.TODO(), mongodbatlas.Client{}, false, &mdbv1.AtlasProject{})
+		workflowCtx := workflow.Context{
+			Client:  mongodbatlas.Client{},
+			Context: context.TODO(),
+		}
+		result, err := canCustomRolesReconcile(&workflowCtx, false, &mdbv1.AtlasProject{})
 		assert.NoError(t, err)
 		assert.True(t, result)
 	})
@@ -225,7 +229,11 @@ func TestCanCustomRolesReconcile(t *testing.T) {
 	t.Run("should return error when unable to deserialize last applied configuration", func(t *testing.T) {
 		akoProject := &mdbv1.AtlasProject{}
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{wrong}"})
-		result, err := canCustomRolesReconcile(context.TODO(), mongodbatlas.Client{}, true, akoProject)
+		workflowCtx := &workflow.Context{
+			Client:  mongodbatlas.Client{},
+			Context: context.TODO(),
+		}
+		result, err := canCustomRolesReconcile(workflowCtx, true, akoProject)
 		assert.EqualError(t, err, "invalid character 'w' looking for beginning of object key string")
 		assert.False(t, result)
 	})
@@ -240,7 +248,11 @@ func TestCanCustomRolesReconcile(t *testing.T) {
 		}
 		akoProject := &mdbv1.AtlasProject{}
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{}"})
-		result, err := canCustomRolesReconcile(context.TODO(), atlasClient, true, akoProject)
+		workflowCtx := &workflow.Context{
+			Client:  atlasClient,
+			Context: context.TODO(),
+		}
+		result, err := canCustomRolesReconcile(workflowCtx, true, akoProject)
 
 		assert.EqualError(t, err, "failed to retrieve data")
 		assert.False(t, result)
@@ -256,7 +268,11 @@ func TestCanCustomRolesReconcile(t *testing.T) {
 		}
 		akoProject := &mdbv1.AtlasProject{}
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{}"})
-		result, err := canCustomRolesReconcile(context.TODO(), atlasClient, true, akoProject)
+		workflowCtx := &workflow.Context{
+			Client:  atlasClient,
+			Context: context.TODO(),
+		}
+		result, err := canCustomRolesReconcile(workflowCtx, true, akoProject)
 
 		assert.NoError(t, err)
 		assert.True(t, result)
@@ -272,7 +288,11 @@ func TestCanCustomRolesReconcile(t *testing.T) {
 		}
 		akoProject := &mdbv1.AtlasProject{}
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{}"})
-		result, err := canCustomRolesReconcile(context.TODO(), atlasClient, true, akoProject)
+		workflowCtx := &workflow.Context{
+			Client:  atlasClient,
+			Context: context.TODO(),
+		}
+		result, err := canCustomRolesReconcile(workflowCtx, true, akoProject)
 
 		assert.NoError(t, err)
 		assert.True(t, result)
@@ -324,7 +344,11 @@ func TestCanCustomRolesReconcile(t *testing.T) {
 			},
 		}
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: `{"customRoles":[{"name":"testRole1","actions":[{"name":"INSERT","resources":[{"database":"testDB","collection":"testCollection"}]}]}]}`})
-		result, err := canCustomRolesReconcile(context.TODO(), atlasClient, true, akoProject)
+		workflowCtx := &workflow.Context{
+			Client:  atlasClient,
+			Context: context.TODO(),
+		}
+		result, err := canCustomRolesReconcile(workflowCtx, true, akoProject)
 
 		assert.NoError(t, err)
 		assert.True(t, result)
@@ -376,7 +400,11 @@ func TestCanCustomRolesReconcile(t *testing.T) {
 			},
 		}
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: `{"customRoles":[{"name":"testRole1","actions":[{"name":"INSERT","resources":[{"database":"testDB","collection":"testCollection"}]}]}]}`})
-		result, err := canCustomRolesReconcile(context.TODO(), atlasClient, true, akoProject)
+		workflowCtx := &workflow.Context{
+			Client:  atlasClient,
+			Context: context.TODO(),
+		}
+		result, err := canCustomRolesReconcile(workflowCtx, true, akoProject)
 
 		assert.NoError(t, err)
 		assert.True(t, result)
@@ -430,7 +458,11 @@ func TestCanCustomRolesReconcile(t *testing.T) {
 			},
 		}
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: `{"customRoles":[{"name":"testRole1","actions":[{"name":"INSERT","resources":[{"cluster":false,"database":"testDB","collection":"testCollection"}]}]}]}`})
-		result, err := canCustomRolesReconcile(context.TODO(), atlasClient, true, akoProject)
+		workflowCtx := &workflow.Context{
+			Client:  atlasClient,
+			Context: context.TODO(),
+		}
+		result, err := canCustomRolesReconcile(workflowCtx, true, akoProject)
 
 		assert.NoError(t, err)
 		assert.False(t, result)
@@ -449,9 +481,10 @@ func TestEnsureCustomRoles(t *testing.T) {
 		akoProject := &mdbv1.AtlasProject{}
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{}"})
 		workflowCtx := &workflow.Context{
-			Client: atlasClient,
+			Client:  atlasClient,
+			Context: context.TODO(),
 		}
-		result := ensureCustomRoles(context.TODO(), workflowCtx, akoProject, true)
+		result := ensureCustomRoles(workflowCtx, akoProject, true)
 
 		require.Equal(t, workflow.Terminate(workflow.Internal, "unable to resolve ownership for deletion protection: failed to retrieve data"), result)
 	})
@@ -505,9 +538,10 @@ func TestEnsureCustomRoles(t *testing.T) {
 		}
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: `{"customRoles":[{"name":"testRole1","actions":[{"name":"INSERT","resources":[{"cluster":false,"database":"testDB","collection":"testCollection"}]}]}]}`})
 		workflowCtx := &workflow.Context{
-			Client: atlasClient,
+			Client:  atlasClient,
+			Context: context.TODO(),
 		}
-		result := ensureCustomRoles(context.TODO(), workflowCtx, akoProject, true)
+		result := ensureCustomRoles(workflowCtx, akoProject, true)
 
 		require.Equal(
 			t,

--- a/pkg/controller/atlasproject/encryption_at_rest_test.go
+++ b/pkg/controller/atlasproject/encryption_at_rest_test.go
@@ -23,7 +23,11 @@ import (
 
 func TestCanEncryptionAtRestReconcile(t *testing.T) {
 	t.Run("should return true when subResourceDeletionProtection is disabled", func(t *testing.T) {
-		result, err := canEncryptionAtRestReconcile(context.TODO(), mongodbatlas.Client{}, false, &mdbv1.AtlasProject{})
+		workflowCtx := &workflow.Context{
+			Client:  mongodbatlas.Client{},
+			Context: context.TODO(),
+		}
+		result, err := canEncryptionAtRestReconcile(workflowCtx, false, &mdbv1.AtlasProject{})
 		require.NoError(t, err)
 		require.True(t, result)
 	})
@@ -31,7 +35,11 @@ func TestCanEncryptionAtRestReconcile(t *testing.T) {
 	t.Run("should return error when unable to deserialize last applied configuration", func(t *testing.T) {
 		akoProject := &mdbv1.AtlasProject{}
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{wrong}"})
-		result, err := canEncryptionAtRestReconcile(context.TODO(), mongodbatlas.Client{}, true, akoProject)
+		workflowCtx := &workflow.Context{
+			Client:  mongodbatlas.Client{},
+			Context: context.TODO(),
+		}
+		result, err := canEncryptionAtRestReconcile(workflowCtx, true, akoProject)
 		require.EqualError(t, err, "invalid character 'w' looking for beginning of object key string")
 		require.False(t, result)
 	})
@@ -46,7 +54,11 @@ func TestCanEncryptionAtRestReconcile(t *testing.T) {
 		}
 		akoProject := &mdbv1.AtlasProject{}
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{}"})
-		result, err := canEncryptionAtRestReconcile(context.TODO(), atlasClient, true, akoProject)
+		workflowCtx := &workflow.Context{
+			Client:  atlasClient,
+			Context: context.TODO(),
+		}
+		result, err := canEncryptionAtRestReconcile(workflowCtx, true, akoProject)
 
 		require.EqualError(t, err, "failed to retrieve data")
 		require.False(t, result)
@@ -72,7 +84,11 @@ func TestCanEncryptionAtRestReconcile(t *testing.T) {
 		}
 		akoProject := &mdbv1.AtlasProject{}
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{}"})
-		result, err := canEncryptionAtRestReconcile(context.TODO(), atlasClient, true, akoProject)
+		workflowCtx := &workflow.Context{
+			Client:  atlasClient,
+			Context: context.TODO(),
+		}
+		result, err := canEncryptionAtRestReconcile(workflowCtx, true, akoProject)
 
 		require.NoError(t, err)
 		require.True(t, result)
@@ -118,7 +134,11 @@ func TestCanEncryptionAtRestReconcile(t *testing.T) {
 				customresource.AnnotationLastAppliedConfiguration: `{"encryptionAtRest":{"awsKms":{"enabled":true,"customerMasterKeyID":"aws-kms-master-key","region":"eu-west-1","roleId":"aws:id:arn/my-role"},"azureKeyVault":{},"googleCloudKms":{}}}`,
 			},
 		)
-		result, err := canEncryptionAtRestReconcile(context.TODO(), atlasClient, true, akoProject)
+		workflowCtx := &workflow.Context{
+			Client:  atlasClient,
+			Context: context.TODO(),
+		}
+		result, err := canEncryptionAtRestReconcile(workflowCtx, true, akoProject)
 
 		require.NoError(t, err)
 		require.True(t, result)
@@ -164,7 +184,11 @@ func TestCanEncryptionAtRestReconcile(t *testing.T) {
 				customresource.AnnotationLastAppliedConfiguration: `{"encryptionAtRest":{"awsKms":{"enabled":true,"customerMasterKeyID":"aws-kms-master-key","region":"eu-west-2","roleId":"aws:id:arn/my-role"},"azureKeyVault":{},"googleCloudKms":{}}}`,
 			},
 		)
-		result, err := canEncryptionAtRestReconcile(context.TODO(), atlasClient, true, akoProject)
+		workflowCtx := &workflow.Context{
+			Client:  atlasClient,
+			Context: context.TODO(),
+		}
+		result, err := canEncryptionAtRestReconcile(workflowCtx, true, akoProject)
 
 		require.NoError(t, err)
 		require.True(t, result)
@@ -210,7 +234,11 @@ func TestCanEncryptionAtRestReconcile(t *testing.T) {
 				customresource.AnnotationLastAppliedConfiguration: `{"encryptionAtRest":{"awsKms":{"enabled":true,"customerMasterKeyID":"aws-kms-master-key","region":"eu-west-2","roleId":"aws:id:arn/my-role"},"azureKeyVault":{},"googleCloudKms":{}}}`,
 			},
 		)
-		result, err := canEncryptionAtRestReconcile(context.TODO(), atlasClient, true, akoProject)
+		workflowCtx := &workflow.Context{
+			Client:  atlasClient,
+			Context: context.TODO(),
+		}
+		result, err := canEncryptionAtRestReconcile(workflowCtx, true, akoProject)
 
 		require.NoError(t, err)
 		require.False(t, result)
@@ -229,12 +257,13 @@ func TestEnsureEncryptionAtRest(t *testing.T) {
 		akoProject := &mdbv1.AtlasProject{}
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{}"})
 		workflowCtx := &workflow.Context{
-			Client: atlasClient,
+			Client:  atlasClient,
+			Context: context.TODO(),
 		}
 		reconciler := &AtlasProjectReconciler{
 			SubObjectDeletionProtection: true,
 		}
-		result := reconciler.ensureEncryptionAtRest(context.TODO(), workflowCtx, akoProject, true)
+		result := reconciler.ensureEncryptionAtRest(workflowCtx, akoProject, true)
 
 		require.Equal(t, workflow.Terminate(workflow.Internal, "unable to resolve ownership for deletion protection: failed to retrieve data"), result)
 	})
@@ -280,12 +309,13 @@ func TestEnsureEncryptionAtRest(t *testing.T) {
 			},
 		)
 		workflowCtx := &workflow.Context{
-			Client: atlasClient,
+			Client:  atlasClient,
+			Context: context.TODO(),
 		}
 		reconciler := &AtlasProjectReconciler{
 			SubObjectDeletionProtection: true,
 		}
-		result := reconciler.ensureEncryptionAtRest(context.TODO(), workflowCtx, akoProject, true)
+		result := reconciler.ensureEncryptionAtRest(workflowCtx, akoProject, true)
 
 		require.Equal(
 			t,
@@ -383,7 +413,7 @@ func TestReadEncryptionAtRestSecrets(t *testing.T) {
 	t.Run("AWS with missing fields", func(t *testing.T) {
 		secretData := map[string][]byte{
 			"AccessKeyID":         []byte("testKeyID"),
-			"SecretAccessKey":     []byte("testSecretAccesssKey"),
+			"SecretAccessKey":     []byte("testSecretAccessKey"),
 			"CustomerMasterKeyID": []byte("testCustomerMasterKeyID"),
 		}
 
@@ -674,7 +704,7 @@ func TestAtlasInSync(t *testing.T) {
 
 	areInSync, err = AtlasInSync(&atlas, &spec)
 	assert.NoError(t, err)
-	assert.True(t, areInSync, "Realistic exampel. should be equal")
+	assert.True(t, areInSync, "Realistic example. should be equal")
 }
 
 func TestAreAzureConfigEqual(t *testing.T) {

--- a/pkg/controller/atlasproject/integrations_test.go
+++ b/pkg/controller/atlasproject/integrations_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/api/v1/common"
 	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/api/v1/project"
 	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/controller/customresource"
+	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/controller/workflow"
 )
 
 func TestToAlias(t *testing.T) {
@@ -50,7 +51,11 @@ func TestAreIntegrationsEqual(t *testing.T) {
 
 func TestCanIntegrationsReconcile(t *testing.T) {
 	t.Run("should return true when subResourceDeletionProtection is disabled", func(t *testing.T) {
-		result, err := canIntegrationsReconcile(context.TODO(), mongodbatlas.Client{}, false, &mdbv1.AtlasProject{})
+		workflowCtx := &workflow.Context{
+			Client:  mongodbatlas.Client{},
+			Context: context.TODO(),
+		}
+		result, err := canIntegrationsReconcile(workflowCtx, false, &mdbv1.AtlasProject{})
 		require.NoError(t, err)
 		require.True(t, result)
 	})
@@ -58,7 +63,11 @@ func TestCanIntegrationsReconcile(t *testing.T) {
 	t.Run("should return error when unable to deserialize last applied configuration", func(t *testing.T) {
 		akoProject := &mdbv1.AtlasProject{}
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{wrong}"})
-		result, err := canIntegrationsReconcile(context.TODO(), mongodbatlas.Client{}, true, akoProject)
+		workflowCtx := &workflow.Context{
+			Client:  mongodbatlas.Client{},
+			Context: context.TODO(),
+		}
+		result, err := canIntegrationsReconcile(workflowCtx, true, akoProject)
 		require.EqualError(t, err, "invalid character 'w' looking for beginning of object key string")
 		require.False(t, result)
 	})
@@ -73,7 +82,11 @@ func TestCanIntegrationsReconcile(t *testing.T) {
 		}
 		akoProject := &mdbv1.AtlasProject{}
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{}"})
-		result, err := canIntegrationsReconcile(context.TODO(), atlasClient, true, akoProject)
+		workflowCtx := &workflow.Context{
+			Client:  atlasClient,
+			Context: context.TODO(),
+		}
+		result, err := canIntegrationsReconcile(workflowCtx, true, akoProject)
 
 		require.EqualError(t, err, "failed to retrieve data")
 		require.False(t, result)
@@ -89,7 +102,11 @@ func TestCanIntegrationsReconcile(t *testing.T) {
 		}
 		akoProject := &mdbv1.AtlasProject{}
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{}"})
-		result, err := canIntegrationsReconcile(context.TODO(), atlasClient, true, akoProject)
+		workflowCtx := &workflow.Context{
+			Client:  atlasClient,
+			Context: context.TODO(),
+		}
+		result, err := canIntegrationsReconcile(workflowCtx, true, akoProject)
 
 		require.NoError(t, err)
 		require.True(t, result)
@@ -131,7 +148,11 @@ func TestCanIntegrationsReconcile(t *testing.T) {
 				customresource.AnnotationLastAppliedConfiguration: "{\"integrations\":[{\"type\":\"DATADOG\",\"apiKeyRef\":{\"name\":\"datadog-secret\",\"namespace\":\"project-namespace\"},\"region\":\"US\"}]}",
 			},
 		)
-		result, err := canIntegrationsReconcile(context.TODO(), atlasClient, true, akoProject)
+		workflowCtx := &workflow.Context{
+			Client:  atlasClient,
+			Context: context.TODO(),
+		}
+		result, err := canIntegrationsReconcile(workflowCtx, true, akoProject)
 
 		require.NoError(t, err)
 		require.True(t, result)
@@ -173,7 +194,11 @@ func TestCanIntegrationsReconcile(t *testing.T) {
 				customresource.AnnotationLastAppliedConfiguration: "{\"integrations\":[{\"type\":\"DATADOG\",\"apiKeyRef\":{\"name\":\"datadog-secret\",\"namespace\":\"project-namespace\"},\"region\":\"US\"}]}",
 			},
 		)
-		result, err := canIntegrationsReconcile(context.TODO(), atlasClient, true, akoProject)
+		workflowCtx := &workflow.Context{
+			Client:  atlasClient,
+			Context: context.TODO(),
+		}
+		result, err := canIntegrationsReconcile(workflowCtx, true, akoProject)
 
 		require.NoError(t, err)
 		require.True(t, result)
@@ -215,7 +240,11 @@ func TestCanIntegrationsReconcile(t *testing.T) {
 				customresource.AnnotationLastAppliedConfiguration: "{\"integrations\":[{\"type\":\"PAGER_DUTY\",\"serviceKeyRef\":{\"name\":\"pager-duty-secret\",\"namespace\":\"project-namespace\"},\"region\":\"EU\"}]}",
 			},
 		)
-		result, err := canIntegrationsReconcile(context.TODO(), atlasClient, true, akoProject)
+		workflowCtx := &workflow.Context{
+			Client:  atlasClient,
+			Context: context.TODO(),
+		}
+		result, err := canIntegrationsReconcile(workflowCtx, true, akoProject)
 
 		require.NoError(t, err)
 		require.False(t, result)

--- a/pkg/controller/atlasproject/ipaccess_list_test.go
+++ b/pkg/controller/atlasproject/ipaccess_list_test.go
@@ -212,9 +212,10 @@ func TestEnsureIPAccessList(t *testing.T) {
 		akoProject := &mdbv1.AtlasProject{}
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{}"})
 		workflowCtx := &workflow.Context{
-			Client: atlasClient,
+			Client:  atlasClient,
+			Context: context.TODO(),
 		}
-		result := ensureIPAccessList(context.TODO(), workflowCtx, atlas.CustomIPAccessListStatus(&atlasClient), akoProject, true)
+		result := ensureIPAccessList(workflowCtx, atlas.CustomIPAccessListStatus(&atlasClient), akoProject, true)
 
 		require.Equal(t, workflow.Terminate(workflow.Internal, "unable to resolve ownership for deletion protection: failed to retrieve data"), result)
 	})
@@ -253,9 +254,10 @@ func TestEnsureIPAccessList(t *testing.T) {
 		}
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{\"projectIpAccessList\":[{\"cidrBlock\":\"192.168.0.0/24\"}]}"})
 		workflowCtx := &workflow.Context{
-			Client: atlasClient,
+			Client:  atlasClient,
+			Context: context.TODO(),
 		}
-		result := ensureIPAccessList(context.TODO(), workflowCtx, atlas.CustomIPAccessListStatus(&atlasClient), akoProject, true)
+		result := ensureIPAccessList(workflowCtx, atlas.CustomIPAccessListStatus(&atlasClient), akoProject, true)
 
 		require.Equal(
 			t,
@@ -310,10 +312,10 @@ func TestEnsureIPAccessList(t *testing.T) {
 			},
 		}
 		workflowCtx := &workflow.Context{
-			Client: atlasClient,
+			Client:  atlasClient,
+			Context: context.TODO(),
 		}
 		result := ensureIPAccessList(
-			context.TODO(),
 			workflowCtx,
 			func(ctx context.Context, projectID, entryValue string) (string, error) {
 				return "ACTIVE", nil
@@ -346,10 +348,11 @@ func TestSyncIPAccessList(t *testing.T) {
 			},
 		}
 		workflowCtx := &workflow.Context{
-			Client: atlasClient,
+			Client:  atlasClient,
+			Context: context.TODO(),
 		}
 
-		assert.ErrorContains(t, syncIPAccessList(context.TODO(), workflowCtx, "projectID", current, desired), "failed")
+		assert.ErrorContains(t, syncIPAccessList(workflowCtx, "projectID", current, desired), "failed")
 	})
 
 	t.Run("should fail to perform creation", func(t *testing.T) {
@@ -374,10 +377,11 @@ func TestSyncIPAccessList(t *testing.T) {
 			},
 		}
 		workflowCtx := &workflow.Context{
-			Client: atlasClient,
+			Client:  atlasClient,
+			Context: context.TODO(),
 		}
 
-		assert.ErrorContains(t, syncIPAccessList(context.TODO(), workflowCtx, "projectID", current, desired), "failed")
+		assert.ErrorContains(t, syncIPAccessList(workflowCtx, "projectID", current, desired), "failed")
 	})
 
 	t.Run("should succeed when there are no changes", func(t *testing.T) {
@@ -393,9 +397,10 @@ func TestSyncIPAccessList(t *testing.T) {
 		}
 		atlasClient := mongodbatlas.Client{}
 		workflowCtx := &workflow.Context{
-			Client: atlasClient,
+			Client:  atlasClient,
+			Context: context.TODO(),
 		}
 
-		assert.NoError(t, syncIPAccessList(context.TODO(), workflowCtx, "projectID", current, desired))
+		assert.NoError(t, syncIPAccessList(workflowCtx, "projectID", current, desired))
 	})
 }

--- a/pkg/controller/atlasproject/maintenancewindow_test.go
+++ b/pkg/controller/atlasproject/maintenancewindow_test.go
@@ -133,7 +133,11 @@ func TestValidateMaintenanceWindow(t *testing.T) {
 
 func TestCanMaintenanceWindowReconcile(t *testing.T) {
 	t.Run("should return true when subResourceDeletionProtection is disabled", func(t *testing.T) {
-		result, err := canMaintenanceWindowReconcile(context.TODO(), mongodbatlas.Client{}, false, &mdbv1.AtlasProject{})
+		workflowCtx := &workflow.Context{
+			Client:  mongodbatlas.Client{},
+			Context: context.TODO(),
+		}
+		result, err := canMaintenanceWindowReconcile(workflowCtx, false, &mdbv1.AtlasProject{})
 		require.NoError(t, err)
 		require.True(t, result)
 	})
@@ -141,7 +145,11 @@ func TestCanMaintenanceWindowReconcile(t *testing.T) {
 	t.Run("should return error when unable to deserialize last applied configuration", func(t *testing.T) {
 		akoProject := &mdbv1.AtlasProject{}
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{wrong}"})
-		result, err := canMaintenanceWindowReconcile(context.TODO(), mongodbatlas.Client{}, true, akoProject)
+		workflowCtx := &workflow.Context{
+			Client:  mongodbatlas.Client{},
+			Context: context.TODO(),
+		}
+		result, err := canMaintenanceWindowReconcile(workflowCtx, true, akoProject)
 		require.EqualError(t, err, "invalid character 'w' looking for beginning of object key string")
 		require.False(t, result)
 	})
@@ -156,7 +164,11 @@ func TestCanMaintenanceWindowReconcile(t *testing.T) {
 		}
 		akoProject := &mdbv1.AtlasProject{}
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{}"})
-		result, err := canMaintenanceWindowReconcile(context.TODO(), atlasClient, true, akoProject)
+		workflowCtx := &workflow.Context{
+			Client:  atlasClient,
+			Context: context.TODO(),
+		}
+		result, err := canMaintenanceWindowReconcile(workflowCtx, true, akoProject)
 
 		require.EqualError(t, err, "failed to retrieve data")
 		require.False(t, result)
@@ -172,7 +184,11 @@ func TestCanMaintenanceWindowReconcile(t *testing.T) {
 		}
 		akoProject := &mdbv1.AtlasProject{}
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{}"})
-		result, err := canMaintenanceWindowReconcile(context.TODO(), atlasClient, true, akoProject)
+		workflowCtx := &workflow.Context{
+			Client:  atlasClient,
+			Context: context.TODO(),
+		}
+		result, err := canMaintenanceWindowReconcile(workflowCtx, true, akoProject)
 
 		require.NoError(t, err)
 		require.True(t, result)
@@ -198,7 +214,11 @@ func TestCanMaintenanceWindowReconcile(t *testing.T) {
 			},
 		}
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{\"maintenanceWindow\":{\"dayOfWeek\":1,\"hourOfDay\":1}}"})
-		result, err := canMaintenanceWindowReconcile(context.TODO(), atlasClient, true, akoProject)
+		workflowCtx := &workflow.Context{
+			Client:  atlasClient,
+			Context: context.TODO(),
+		}
+		result, err := canMaintenanceWindowReconcile(workflowCtx, true, akoProject)
 
 		require.NoError(t, err)
 		require.True(t, result)
@@ -224,7 +244,11 @@ func TestCanMaintenanceWindowReconcile(t *testing.T) {
 			},
 		}
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{\"maintenanceWindow\":{\"dayOfWeek\":7,\"hourOfDay\":20}}"})
-		result, err := canMaintenanceWindowReconcile(context.TODO(), atlasClient, true, akoProject)
+		workflowCtx := &workflow.Context{
+			Client:  atlasClient,
+			Context: context.TODO(),
+		}
+		result, err := canMaintenanceWindowReconcile(workflowCtx, true, akoProject)
 
 		require.NoError(t, err)
 		require.True(t, result)
@@ -251,7 +275,11 @@ func TestCanMaintenanceWindowReconcile(t *testing.T) {
 			},
 		}
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{\"maintenanceWindow\":{\"dayOfWeek\":1,\"hourOfDay\":1}}"})
-		result, err := canMaintenanceWindowReconcile(context.TODO(), atlasClient, true, akoProject)
+		workflowCtx := &workflow.Context{
+			Client:  atlasClient,
+			Context: context.TODO(),
+		}
+		result, err := canMaintenanceWindowReconcile(workflowCtx, true, akoProject)
 
 		require.NoError(t, err)
 		require.False(t, result)
@@ -270,9 +298,10 @@ func TestEnsureMaintenanceWindow(t *testing.T) {
 		akoProject := &mdbv1.AtlasProject{}
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{}"})
 		workflowCtx := &workflow.Context{
-			Client: atlasClient,
+			Client:  atlasClient,
+			Context: context.TODO(),
 		}
-		result := ensureMaintenanceWindow(context.TODO(), workflowCtx, akoProject, true)
+		result := ensureMaintenanceWindow(workflowCtx, akoProject, true)
 
 		require.Equal(t, workflow.Terminate(workflow.Internal, "unable to resolve ownership for deletion protection: failed to retrieve data"), result)
 	})
@@ -301,9 +330,10 @@ func TestEnsureMaintenanceWindow(t *testing.T) {
 		}
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{\"maintenanceWindow\":{\"dayOfWeek\":1,\"hourOfDay\":20,\"startASAP\":true,\"autoDefer\":true}}"})
 		workflowCtx := &workflow.Context{
-			Client: atlasClient,
+			Client:  atlasClient,
+			Context: context.TODO(),
 		}
-		result := ensureMaintenanceWindow(context.TODO(), workflowCtx, akoProject, true)
+		result := ensureMaintenanceWindow(workflowCtx, akoProject, true)
 
 		require.Equal(
 			t,

--- a/pkg/controller/atlasproject/network_peering_test.go
+++ b/pkg/controller/atlasproject/network_peering_test.go
@@ -17,7 +17,11 @@ import (
 
 func TestCanNetworkPeeringReconcile(t *testing.T) {
 	t.Run("should return true when subResourceDeletionProtection is disabled", func(t *testing.T) {
-		result, err := canNetworkPeeringReconcile(context.TODO(), mongodbatlas.Client{}, false, &mdbv1.AtlasProject{})
+		workflowCtx := &workflow.Context{
+			Client:  mongodbatlas.Client{},
+			Context: context.TODO(),
+		}
+		result, err := canNetworkPeeringReconcile(workflowCtx, false, &mdbv1.AtlasProject{})
 		require.NoError(t, err)
 		require.True(t, result)
 	})
@@ -25,7 +29,11 @@ func TestCanNetworkPeeringReconcile(t *testing.T) {
 	t.Run("should return error when unable to deserialize last applied configuration", func(t *testing.T) {
 		akoProject := &mdbv1.AtlasProject{}
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{wrong}"})
-		result, err := canNetworkPeeringReconcile(context.TODO(), mongodbatlas.Client{}, true, akoProject)
+		workflowCtx := &workflow.Context{
+			Client:  mongodbatlas.Client{},
+			Context: context.TODO(),
+		}
+		result, err := canNetworkPeeringReconcile(workflowCtx, true, akoProject)
 		require.EqualError(t, err, "invalid character 'w' looking for beginning of object key string")
 		require.False(t, result)
 	})
@@ -40,7 +48,11 @@ func TestCanNetworkPeeringReconcile(t *testing.T) {
 		}
 		akoProject := &mdbv1.AtlasProject{}
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{}"})
-		result, err := canNetworkPeeringReconcile(context.TODO(), atlasClient, true, akoProject)
+		workflowCtx := &workflow.Context{
+			Client:  atlasClient,
+			Context: context.TODO(),
+		}
+		result, err := canNetworkPeeringReconcile(workflowCtx, true, akoProject)
 
 		require.EqualError(t, err, "failed to retrieve data")
 		require.False(t, result)
@@ -61,7 +73,11 @@ func TestCanNetworkPeeringReconcile(t *testing.T) {
 		}
 		akoProject := &mdbv1.AtlasProject{}
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{}"})
-		result, err := canNetworkPeeringReconcile(context.TODO(), atlasClient, true, akoProject)
+		workflowCtx := &workflow.Context{
+			Client:  atlasClient,
+			Context: context.TODO(),
+		}
+		result, err := canNetworkPeeringReconcile(workflowCtx, true, akoProject)
 
 		require.EqualError(t, err, "failed to retrieve data")
 		require.False(t, result)
@@ -82,7 +98,11 @@ func TestCanNetworkPeeringReconcile(t *testing.T) {
 		}
 		akoProject := &mdbv1.AtlasProject{}
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{\"networkPeers\":[{\"providerName\":\"AWS\",\"accepterRegionName\":\"eu-west-1\",\"atlasCidrBlock\":\"192.168.0.0/24\"}]}"})
-		result, err := canNetworkPeeringReconcile(context.TODO(), atlasClient, true, akoProject)
+		workflowCtx := &workflow.Context{
+			Client:  atlasClient,
+			Context: context.TODO(),
+		}
+		result, err := canNetworkPeeringReconcile(workflowCtx, true, akoProject)
 
 		require.NoError(t, err)
 		require.True(t, result)
@@ -135,7 +155,11 @@ func TestCanNetworkPeeringReconcile(t *testing.T) {
 					customresource.AnnotationLastAppliedConfiguration: "{\"networkPeers\":[{\"accepterRegionName\":\"eu-west-1\",\"awsAccountId\":\"123456\",\"providerName\":\"AWS\",\"routeTableCidrBlock\":\"10.8.0.0/22\",\"vpcId\":\"654321\",\"atlasCidrBlock\":\"192.168.0.0/24\"}]}",
 				},
 			)
-			result, err := canNetworkPeeringReconcile(context.TODO(), atlasClient, true, akoProject)
+			workflowCtx := &workflow.Context{
+				Client:  atlasClient,
+				Context: context.TODO(),
+			}
+			result, err := canNetworkPeeringReconcile(workflowCtx, true, akoProject)
 
 			require.NoError(t, err)
 			require.True(t, result)
@@ -184,7 +208,11 @@ func TestCanNetworkPeeringReconcile(t *testing.T) {
 					customresource.AnnotationLastAppliedConfiguration: "{\"networkPeers\":[{\"accepterRegionName\":\"europe-west-1\",\"providerName\":\"GCP\",\"gcpProjectId\":\"my-project\",\"networkName\":\"my-network\",\"atlasCidrBlock\":\"192.168.0.0/24\"}]}",
 				},
 			)
-			result, err := canNetworkPeeringReconcile(context.TODO(), atlasClient, true, akoProject)
+			workflowCtx := &workflow.Context{
+				Client:  atlasClient,
+				Context: context.TODO(),
+			}
+			result, err := canNetworkPeeringReconcile(workflowCtx, true, akoProject)
 
 			require.NoError(t, err)
 			require.True(t, result)
@@ -238,7 +266,11 @@ func TestCanNetworkPeeringReconcile(t *testing.T) {
 					customresource.AnnotationLastAppliedConfiguration: "{\"networkPeers\":[{\"accepterRegionName\":\"GERMANY_CENTRAL\",\"providerName\":\"AZURE\",\"atlasCidrBlock\":\"192.168.0.0/24\",\"azureSubscriptionId\":\"123\",\"azureDirectoryId\":\"456\",\"resourceGroupName\":\"my-rg\",\"vnetName\":\"my-vnet\"}]}",
 				},
 			)
-			result, err := canNetworkPeeringReconcile(context.TODO(), atlasClient, true, akoProject)
+			workflowCtx := &workflow.Context{
+				Client:  atlasClient,
+				Context: context.TODO(),
+			}
+			result, err := canNetworkPeeringReconcile(workflowCtx, true, akoProject)
 
 			require.NoError(t, err)
 			require.True(t, result)
@@ -292,7 +324,11 @@ func TestCanNetworkPeeringReconcile(t *testing.T) {
 					customresource.AnnotationLastAppliedConfiguration: "{\"networkPeers\":[{\"accepterRegionName\":\"eu-west-1\",\"awsAccountId\":\"123456\",\"providerName\":\"AWS\",\"routeTableCidrBlock\":\"10.8.0.0/22\",\"vpcId\":\"654321\",\"atlasCidrBlock\":\"192.168.0.0/24\"}]}",
 				},
 			)
-			result, err := canNetworkPeeringReconcile(context.TODO(), atlasClient, true, akoProject)
+			workflowCtx := &workflow.Context{
+				Client:  atlasClient,
+				Context: context.TODO(),
+			}
+			result, err := canNetworkPeeringReconcile(workflowCtx, true, akoProject)
 
 			require.NoError(t, err)
 			require.False(t, result)
@@ -341,7 +377,11 @@ func TestCanNetworkPeeringReconcile(t *testing.T) {
 					customresource.AnnotationLastAppliedConfiguration: "{\"networkPeers\":[{\"accepterRegionName\":\"europe-west-1\",\"providerName\":\"GCP\",\"gcpProjectId\":\"my-project\",\"networkName\":\"my-network\",\"atlasCidrBlock\":\"192.168.0.0/24\"}]}",
 				},
 			)
-			result, err := canNetworkPeeringReconcile(context.TODO(), atlasClient, true, akoProject)
+			workflowCtx := &workflow.Context{
+				Client:  atlasClient,
+				Context: context.TODO(),
+			}
+			result, err := canNetworkPeeringReconcile(workflowCtx, true, akoProject)
 
 			require.NoError(t, err)
 			require.False(t, result)
@@ -395,7 +435,11 @@ func TestCanNetworkPeeringReconcile(t *testing.T) {
 					customresource.AnnotationLastAppliedConfiguration: "{\"networkPeers\":[{\"accepterRegionName\":\"GERMANY_CENTRAL\",\"providerName\":\"AZURE\",\"atlasCidrBlock\":\"192.168.0.0/24\",\"azureSubscriptionId\":\"123\",\"azureDirectoryId\":\"456\",\"resourceGroupName\":\"my-rg\",\"vnetName\":\"my-vnet\"}]}",
 				},
 			)
-			result, err := canNetworkPeeringReconcile(context.TODO(), atlasClient, true, akoProject)
+			workflowCtx := &workflow.Context{
+				Client:  atlasClient,
+				Context: context.TODO(),
+			}
+			result, err := canNetworkPeeringReconcile(workflowCtx, true, akoProject)
 
 			require.NoError(t, err)
 			require.False(t, result)
@@ -449,7 +493,11 @@ func TestCanNetworkPeeringReconcile(t *testing.T) {
 					customresource.AnnotationLastAppliedConfiguration: "{\"networkPeers\":[{\"accepterRegionName\":\"eu-west-1\",\"awsAccountId\":\"123456\",\"providerName\":\"AWS\",\"routeTableCidrBlock\":\"10.8.0.0/22\",\"vpcId\":\"654321\",\"atlasCidrBlock\":\"192.168.0.0/24\"}]}",
 				},
 			)
-			result, err := canNetworkPeeringReconcile(context.TODO(), atlasClient, true, akoProject)
+			workflowCtx := &workflow.Context{
+				Client:  atlasClient,
+				Context: context.TODO(),
+			}
+			result, err := canNetworkPeeringReconcile(workflowCtx, true, akoProject)
 
 			require.NoError(t, err)
 			require.False(t, result)
@@ -497,7 +545,11 @@ func TestCanNetworkPeeringReconcile(t *testing.T) {
 					customresource.AnnotationLastAppliedConfiguration: "{\"networkPeers\":[{\"accepterRegionName\":\"europe-west-1\",\"providerName\":\"GCP\",\"gcpProjectId\":\"my-project\",\"networkName\":\"my-network\",\"atlasCidrBlock\":\"192.168.0.0/24\"}]}",
 				},
 			)
-			result, err := canNetworkPeeringReconcile(context.TODO(), atlasClient, true, akoProject)
+			workflowCtx := &workflow.Context{
+				Client:  atlasClient,
+				Context: context.TODO(),
+			}
+			result, err := canNetworkPeeringReconcile(workflowCtx, true, akoProject)
 
 			require.NoError(t, err)
 			require.False(t, result)
@@ -551,7 +603,11 @@ func TestCanNetworkPeeringReconcile(t *testing.T) {
 					customresource.AnnotationLastAppliedConfiguration: "{\"networkPeers\":[{\"accepterRegionName\":\"GERMANY_CENTRAL\",\"providerName\":\"AZURE\",\"atlasCidrBlock\":\"192.168.0.0/24\",\"azureSubscriptionId\":\"123\",\"azureDirectoryId\":\"456\",\"resourceGroupName\":\"my-rg\",\"vnetName\":\"my-vnet\"}]}",
 				},
 			)
-			result, err := canNetworkPeeringReconcile(context.TODO(), atlasClient, true, akoProject)
+			workflowCtx := &workflow.Context{
+				Client:  atlasClient,
+				Context: context.TODO(),
+			}
+			result, err := canNetworkPeeringReconcile(workflowCtx, true, akoProject)
 
 			require.NoError(t, err)
 			require.False(t, result)
@@ -571,9 +627,10 @@ func TestEnsureNetworkPeers(t *testing.T) {
 		akoProject := &mdbv1.AtlasProject{}
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{}"})
 		workflowCtx := &workflow.Context{
-			Client: atlasClient,
+			Client:  atlasClient,
+			Context: context.TODO(),
 		}
-		result := ensureNetworkPeers(context.TODO(), workflowCtx, akoProject, true)
+		result := ensureNetworkPeers(workflowCtx, akoProject, true)
 
 		require.Equal(t, workflow.Terminate(workflow.Internal, "unable to resolve ownership for deletion protection: failed to retrieve data"), result)
 	})
@@ -625,9 +682,10 @@ func TestEnsureNetworkPeers(t *testing.T) {
 			},
 		)
 		workflowCtx := &workflow.Context{
-			Client: atlasClient,
+			Client:  atlasClient,
+			Context: context.TODO(),
 		}
-		result := ensureNetworkPeers(context.TODO(), workflowCtx, akoProject, true)
+		result := ensureNetworkPeers(workflowCtx, akoProject, true)
 
 		require.Equal(
 			t,

--- a/pkg/controller/atlasproject/project_settings_test.go
+++ b/pkg/controller/atlasproject/project_settings_test.go
@@ -18,7 +18,11 @@ import (
 
 func TestProjectSettingsReconcile(t *testing.T) {
 	t.Run("should return true when subResourceDeletionProtection is disabled", func(t *testing.T) {
-		result, err := canProjectSettingsReconcile(context.TODO(), mongodbatlas.Client{}, false, &mdbv1.AtlasProject{})
+		workflowCtx := &workflow.Context{
+			Client:  mongodbatlas.Client{},
+			Context: context.TODO(),
+		}
+		result, err := canProjectSettingsReconcile(workflowCtx, false, &mdbv1.AtlasProject{})
 		require.NoError(t, err)
 		require.True(t, result)
 	})
@@ -26,7 +30,11 @@ func TestProjectSettingsReconcile(t *testing.T) {
 	t.Run("should return error when unable to deserialize last applied configuration", func(t *testing.T) {
 		akoProject := &mdbv1.AtlasProject{}
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{wrong}"})
-		result, err := canProjectSettingsReconcile(context.TODO(), mongodbatlas.Client{}, true, akoProject)
+		workflowCtx := &workflow.Context{
+			Client:  mongodbatlas.Client{},
+			Context: context.TODO(),
+		}
+		result, err := canProjectSettingsReconcile(workflowCtx, true, akoProject)
 		require.EqualError(t, err, "invalid character 'w' looking for beginning of object key string")
 		require.False(t, result)
 	})
@@ -41,7 +49,11 @@ func TestProjectSettingsReconcile(t *testing.T) {
 		}
 		akoProject := &mdbv1.AtlasProject{}
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{}"})
-		result, err := canProjectSettingsReconcile(context.TODO(), atlasClient, true, akoProject)
+		workflowCtx := &workflow.Context{
+			Client:  atlasClient,
+			Context: context.TODO(),
+		}
+		result, err := canProjectSettingsReconcile(workflowCtx, true, akoProject)
 
 		require.EqualError(t, err, "failed to retrieve data")
 		require.False(t, result)
@@ -57,7 +69,11 @@ func TestProjectSettingsReconcile(t *testing.T) {
 		}
 		akoProject := &mdbv1.AtlasProject{}
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{}"})
-		result, err := canProjectSettingsReconcile(context.TODO(), atlasClient, true, akoProject)
+		workflowCtx := &workflow.Context{
+			Client:  atlasClient,
+			Context: context.TODO(),
+		}
+		result, err := canProjectSettingsReconcile(workflowCtx, true, akoProject)
 
 		require.NoError(t, err)
 		require.True(t, result)
@@ -102,7 +118,11 @@ func TestProjectSettingsReconcile(t *testing.T) {
 }}`,
 			},
 		)
-		result, err := canProjectSettingsReconcile(context.TODO(), atlasClient, true, akoProject)
+		workflowCtx := &workflow.Context{
+			Client:  atlasClient,
+			Context: context.TODO(),
+		}
+		result, err := canProjectSettingsReconcile(workflowCtx, true, akoProject)
 
 		require.NoError(t, err)
 		require.True(t, result)
@@ -148,7 +168,11 @@ func TestProjectSettingsReconcile(t *testing.T) {
 }}`,
 			},
 		)
-		result, err := canProjectSettingsReconcile(context.TODO(), atlasClient, true, akoProject)
+		workflowCtx := &workflow.Context{
+			Client:  atlasClient,
+			Context: context.TODO(),
+		}
+		result, err := canProjectSettingsReconcile(workflowCtx, true, akoProject)
 
 		require.NoError(t, err)
 		require.True(t, result)
@@ -194,7 +218,11 @@ func TestProjectSettingsReconcile(t *testing.T) {
 }}`,
 			},
 		)
-		result, err := canProjectSettingsReconcile(context.TODO(), atlasClient, true, akoProject)
+		workflowCtx := &workflow.Context{
+			Client:  atlasClient,
+			Context: context.TODO(),
+		}
+		result, err := canProjectSettingsReconcile(workflowCtx, true, akoProject)
 
 		require.NoError(t, err)
 		require.False(t, result)
@@ -213,9 +241,10 @@ func TestEnsureProjectSettings(t *testing.T) {
 		akoProject := &mdbv1.AtlasProject{}
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{}"})
 		workflowCtx := &workflow.Context{
-			Client: atlasClient,
+			Client:  atlasClient,
+			Context: context.TODO(),
 		}
-		result := ensureProjectSettings(context.TODO(), workflowCtx, akoProject, true)
+		result := ensureProjectSettings(workflowCtx, akoProject, true)
 
 		require.Equal(t, workflow.Terminate(workflow.Internal, "unable to resolve ownership for deletion protection: failed to retrieve data"), result)
 	})
@@ -261,9 +290,10 @@ func TestEnsureProjectSettings(t *testing.T) {
 			},
 		)
 		workflowCtx := &workflow.Context{
-			Client: atlasClient,
+			Client:  atlasClient,
+			Context: context.TODO(),
 		}
-		result := ensureProjectSettings(context.TODO(), workflowCtx, akoProject, true)
+		result := ensureProjectSettings(workflowCtx, akoProject, true)
 
 		require.Equal(
 			t,

--- a/pkg/controller/atlasproject/team_reconciler_test.go
+++ b/pkg/controller/atlasproject/team_reconciler_test.go
@@ -12,18 +12,27 @@ import (
 	v1 "github.com/mongodb/mongodb-atlas-kubernetes/pkg/api/v1"
 	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/api/v1/status"
 	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/controller/atlas"
+	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/controller/workflow"
 )
 
 func TestTeamManagedByAtlas(t *testing.T) {
 	t.Run("should return error when passing wrong resource", func(t *testing.T) {
-		checker := teamsManagedByAtlas(context.TODO(), mongodbatlas.Client{}, "orgID")
+		workflowCtx := &workflow.Context{
+			Client:  mongodbatlas.Client{},
+			Context: context.TODO(),
+		}
+		checker := teamsManagedByAtlas(workflowCtx, "orgID")
 		result, err := checker(&v1.AtlasProject{})
 		assert.EqualError(t, err, "failed to match resource type as AtlasTeams")
 		assert.False(t, result)
 	})
 
 	t.Run("should return false when resource has no Atlas Team ID", func(t *testing.T) {
-		checker := teamsManagedByAtlas(context.TODO(), mongodbatlas.Client{}, "orgID")
+		workflowCtx := &workflow.Context{
+			Client:  mongodbatlas.Client{},
+			Context: context.TODO(),
+		}
+		checker := teamsManagedByAtlas(workflowCtx, "orgID")
 		result, err := checker(&v1.AtlasTeam{})
 		assert.NoError(t, err)
 		assert.False(t, result)
@@ -42,7 +51,11 @@ func TestTeamManagedByAtlas(t *testing.T) {
 				ID: "team-id-1",
 			},
 		}
-		checker := teamsManagedByAtlas(context.TODO(), atlasClient, "orgID")
+		workflowCtx := &workflow.Context{
+			Client:  atlasClient,
+			Context: context.TODO(),
+		}
+		checker := teamsManagedByAtlas(workflowCtx, "orgID")
 		result, err := checker(team)
 		assert.NoError(t, err)
 		assert.False(t, result)
@@ -61,7 +74,11 @@ func TestTeamManagedByAtlas(t *testing.T) {
 				ID: "team-id-1",
 			},
 		}
-		checker := teamsManagedByAtlas(context.TODO(), atlasClient, "orgID")
+		workflowCtx := &workflow.Context{
+			Client:  atlasClient,
+			Context: context.TODO(),
+		}
+		checker := teamsManagedByAtlas(workflowCtx, "orgID")
 		result, err := checker(team)
 		assert.EqualError(t, err, "unavailable")
 		assert.False(t, result)
@@ -88,7 +105,11 @@ func TestTeamManagedByAtlas(t *testing.T) {
 				ID: "team-id-1",
 			},
 		}
-		checker := teamsManagedByAtlas(context.TODO(), atlasClient, "orgID-1")
+		workflowCtx := &workflow.Context{
+			Client:  atlasClient,
+			Context: context.TODO(),
+		}
+		checker := teamsManagedByAtlas(workflowCtx, "orgID-1")
 		result, err := checker(team)
 		assert.NoError(t, err)
 		assert.False(t, result)
@@ -115,7 +136,11 @@ func TestTeamManagedByAtlas(t *testing.T) {
 				ID: "team-id-1",
 			},
 		}
-		checker := teamsManagedByAtlas(context.TODO(), atlasClient, "orgID-1")
+		workflowCtx := &workflow.Context{
+			Client:  atlasClient,
+			Context: context.TODO(),
+		}
+		checker := teamsManagedByAtlas(workflowCtx, "orgID-1")
 		result, err := checker(team)
 		assert.NoError(t, err)
 		assert.True(t, result)

--- a/pkg/controller/atlasproject/teams_test.go
+++ b/pkg/controller/atlasproject/teams_test.go
@@ -51,7 +51,11 @@ func TestCanAssignedTeamsReconcile(t *testing.T) {
 		Build()
 
 	t.Run("should return true when subResourceDeletionProtection is disabled", func(t *testing.T) {
-		result, err := canAssignedTeamsReconcile(context.TODO(), mongodbatlas.Client{}, k8sClient, false, &mdbv1.AtlasProject{})
+		workflowCtx := &workflow.Context{
+			Client:  mongodbatlas.Client{},
+			Context: context.TODO(),
+		}
+		result, err := canAssignedTeamsReconcile(workflowCtx, k8sClient, false, &mdbv1.AtlasProject{})
 		assert.NoError(t, err)
 		assert.True(t, result)
 	})
@@ -59,7 +63,11 @@ func TestCanAssignedTeamsReconcile(t *testing.T) {
 	t.Run("should return error when unable to deserialize last applied configuration", func(t *testing.T) {
 		akoProject := &mdbv1.AtlasProject{}
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{wrong}"})
-		result, err := canAssignedTeamsReconcile(context.TODO(), mongodbatlas.Client{}, k8sClient, true, akoProject)
+		workflowCtx := &workflow.Context{
+			Client:  mongodbatlas.Client{},
+			Context: context.TODO(),
+		}
+		result, err := canAssignedTeamsReconcile(workflowCtx, k8sClient, true, akoProject)
 		assert.EqualError(t, err, "invalid character 'w' looking for beginning of object key string")
 		assert.False(t, result)
 	})
@@ -74,7 +82,11 @@ func TestCanAssignedTeamsReconcile(t *testing.T) {
 		}
 		akoProject := &mdbv1.AtlasProject{}
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{}"})
-		result, err := canAssignedTeamsReconcile(context.TODO(), atlasClient, k8sClient, true, akoProject)
+		workflowCtx := &workflow.Context{
+			Client:  atlasClient,
+			Context: context.TODO(),
+		}
+		result, err := canAssignedTeamsReconcile(workflowCtx, k8sClient, true, akoProject)
 
 		assert.EqualError(t, err, "failed to retrieve data")
 		assert.False(t, result)
@@ -90,7 +102,11 @@ func TestCanAssignedTeamsReconcile(t *testing.T) {
 		}
 		akoProject := &mdbv1.AtlasProject{}
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{}"})
-		result, err := canAssignedTeamsReconcile(context.TODO(), atlasClient, k8sClient, true, akoProject)
+		workflowCtx := &workflow.Context{
+			Client:  atlasClient,
+			Context: context.TODO(),
+		}
+		result, err := canAssignedTeamsReconcile(workflowCtx, k8sClient, true, akoProject)
 
 		assert.NoError(t, err)
 		assert.True(t, result)
@@ -106,7 +122,11 @@ func TestCanAssignedTeamsReconcile(t *testing.T) {
 		}
 		akoProject := &mdbv1.AtlasProject{}
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{}"})
-		result, err := canAssignedTeamsReconcile(context.TODO(), atlasClient, k8sClient, true, akoProject)
+		workflowCtx := &workflow.Context{
+			Client:  atlasClient,
+			Context: context.TODO(),
+		}
+		result, err := canAssignedTeamsReconcile(workflowCtx, k8sClient, true, akoProject)
 
 		assert.NoError(t, err)
 		assert.True(t, result)
@@ -142,7 +162,11 @@ func TestCanAssignedTeamsReconcile(t *testing.T) {
 			},
 		}
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: `{"teams":[{"teamRef":{"name":"team1","namespace":"default"},"roles":["GROUP_OWNER"]}]}`})
-		result, err := canAssignedTeamsReconcile(context.TODO(), atlasClient, k8sClient, true, akoProject)
+		workflowCtx := &workflow.Context{
+			Client:  atlasClient,
+			Context: context.TODO(),
+		}
+		result, err := canAssignedTeamsReconcile(workflowCtx, k8sClient, true, akoProject)
 
 		assert.NoError(t, err)
 		assert.True(t, result)
@@ -178,7 +202,11 @@ func TestCanAssignedTeamsReconcile(t *testing.T) {
 			},
 		}
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: `{"teams":[{"teamRef":{"name":"team1","namespace":"default"},"roles":["GROUP_OWNER"]}]}`})
-		result, err := canAssignedTeamsReconcile(context.TODO(), atlasClient, k8sClient, true, akoProject)
+		workflowCtx := &workflow.Context{
+			Client:  atlasClient,
+			Context: context.TODO(),
+		}
+		result, err := canAssignedTeamsReconcile(workflowCtx, k8sClient, true, akoProject)
 
 		assert.NoError(t, err)
 		assert.True(t, result)
@@ -214,7 +242,11 @@ func TestCanAssignedTeamsReconcile(t *testing.T) {
 			},
 		}
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: `{"teams":[{"teamRef":{"name":"team1","namespace":"default"},"roles":["GROUP_OWNER"]}]}`})
-		result, err := canAssignedTeamsReconcile(context.TODO(), atlasClient, k8sClient, true, akoProject)
+		workflowCtx := &workflow.Context{
+			Client:  atlasClient,
+			Context: context.TODO(),
+		}
+		result, err := canAssignedTeamsReconcile(workflowCtx, k8sClient, true, akoProject)
 
 		assert.NoError(t, err)
 		assert.False(t, result)
@@ -234,13 +266,14 @@ func TestEnsureAssignedTeams(t *testing.T) {
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{}"})
 		logger := zaptest.NewLogger(t).Sugar()
 		workflowCtx := &workflow.Context{
-			Client: atlasClient,
-			Log:    logger,
+			Client:  atlasClient,
+			Log:     logger,
+			Context: context.TODO(),
 		}
 		reconciler := &AtlasProjectReconciler{
 			Log: logger,
 		}
-		result := reconciler.ensureAssignedTeams(context.TODO(), workflowCtx, akoProject, true)
+		result := reconciler.ensureAssignedTeams(workflowCtx, akoProject, true)
 
 		require.Equal(t, workflow.Terminate(workflow.Internal, "unable to resolve ownership for deletion protection: failed to retrieve data"), result)
 	})
@@ -304,14 +337,15 @@ func TestEnsureAssignedTeams(t *testing.T) {
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: `{"teams":[{"teamRef":{"name":"team1","namespace":"default"},"roles":["GROUP_OWNER"]}]}`})
 		logger := zaptest.NewLogger(t).Sugar()
 		workflowCtx := &workflow.Context{
-			Client: atlasClient,
-			Log:    logger,
+			Client:  atlasClient,
+			Log:     logger,
+			Context: context.TODO(),
 		}
 		reconciler := &AtlasProjectReconciler{
 			Client: k8sClient,
 			Log:    logger,
 		}
-		result := reconciler.ensureAssignedTeams(context.TODO(), workflowCtx, akoProject, true)
+		result := reconciler.ensureAssignedTeams(workflowCtx, akoProject, true)
 
 		require.Equal(
 			t,
@@ -347,7 +381,7 @@ func TestUpdateTeamState(t *testing.T) {
 				Namespace: "testNS",
 			},
 			Status: status.TeamStatus{
-				ID: "testTeamStaatus",
+				ID: "testTeamStatus",
 				Projects: []status.TeamProject{
 					{
 						ID:   project.Status.ID,

--- a/pkg/controller/customresource/customresource.go
+++ b/pkg/controller/customresource/customresource.go
@@ -78,10 +78,10 @@ func ValidateResourceVersion(ctx *workflow.Context, resource mdbv1.AtlasCustomRe
 
 // MarkReconciliationStarted updates the status of the Atlas Resource to indicate that the Operator has started working on it.
 // Internally this will also update the 'observedGeneration' field that notify clients that the resource is being worked on
-func MarkReconciliationStarted(client client.Client, resource mdbv1.AtlasCustomResource, log *zap.SugaredLogger) *workflow.Context {
+func MarkReconciliationStarted(client client.Client, resource mdbv1.AtlasCustomResource, log *zap.SugaredLogger, context context.Context) *workflow.Context {
 	updatedConditions := status.EnsureConditionExists(status.FalseCondition(status.ReadyType), resource.GetStatus().GetConditions())
 
-	ctx := workflow.NewContext(log, updatedConditions)
+	ctx := workflow.NewContext(log, updatedConditions, context)
 	statushandler.Update(ctx, client, nil, resource)
 
 	return ctx

--- a/pkg/controller/workflow/context.go
+++ b/pkg/controller/workflow/context.go
@@ -1,6 +1,8 @@
 package workflow
 
 import (
+	"context"
+
 	"go.mongodb.org/atlas/mongodbatlas"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
@@ -12,7 +14,7 @@ import (
 
 // Context is a container for some information that is needed on all levels of function calls during reconciliation.
 // It's mutable by design.
-// Note, that it's completely different from the Go Context
+// Note, that it's NOT a Go Context but can carry one
 type Context struct {
 	// Log is the root logger used in the reconciliation. Used just for convenience to avoid passing log to each
 	// method.
@@ -37,12 +39,16 @@ type Context struct {
 
 	// A list of sub-resources to add to a resource watcher after the Reconcile loop
 	resourcesToWatch []watch.WatchedObject
+
+	// Go context, when appropriate
+	Context context.Context
 }
 
-func NewContext(log *zap.SugaredLogger, conditions []status.Condition) *Context {
+func NewContext(log *zap.SugaredLogger, conditions []status.Condition, context context.Context) *Context {
 	return &Context{
-		status: NewStatus(conditions),
-		Log:    log,
+		status:  NewStatus(conditions),
+		Log:     log,
+		Context: context,
 	}
 }
 


### PR DESCRIPTION
This change looks bug, it is actually the effect of just 3 changes:
1. Add a `Context context.Context` field into the `workflow.Context` struct.
1. Use that new field to embed the Go context that used to be around inside the `workflow.Context`.
1. Collapse the argument pair of a Go context and a MongoDB Client into a single `workflow.Context`, which now contains both.

There are a few typo fixes as well.

### All Submissions:

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* ~Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if there is one)~.
* ~Update docs/release-notes/release-notes.md if your changes should be included in the release notes for the next release~.
