### PR TITLE
CLOUDP-179084: Enable dialy build testing

### DIFF
--- a/.github/workflows/rebuild-released-images.yaml
+++ b/.github/workflows/rebuild-released-images.yaml
@@ -5,6 +5,16 @@ on:
   schedule:
     - cron: "0 1 * * 1-5"
     - cron: "0 3 * * 1-5"
+  workflow_dispatch:
+    inputs:
+      image_repo:
+        type: choice
+        description: "Target image repository for built images"
+        default: mongodb/mongodb-atlas-kubernetes-operator-prerelease
+        required: true
+        options:
+        - mongodb/mongodb-atlas-kubernetes-operator-prerelease
+        - mongodb/mongodb-atlas-kubernetes-operator
 
 jobs:
   read-versions:
@@ -35,7 +45,7 @@ jobs:
   build-and-publish-image:
     runs-on: ubuntu-latest
     env:
-      IMAGE_REPOSITORY: mongodb/mongodb-atlas-kubernetes-operator
+      IMAGE_REPOSITORY:  ${{ github.event.inputs.image_repo || 'mongodb/mongodb-atlas-kubernetes-operator' }} 
     needs:
       - read-versions
     strategy:


### PR DESCRIPTION
By default the schedules keep on working as before, on schedule calls `github.event.inputs.image_repo` is not set and therefore `IMAGE_REPOSITORY` is set to `"mongodb/mongodb-atlas-kubernetes-operator"`.

When invoked manually in a workflow dispatch, if the user does not change it, the default repo is set to the prereleases one  `"mongodb/mongodb-atlas-kubernetes-operator-prerelease"`. Still the releases repo is available to be selected, as needed.

### All Submissions:

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
