### PR TITLE
CLOUDP-202685: Main branch merges in its own queue

### DIFF
--- a/.github/workflows/cloud-tests-forked.yml
+++ b/.github/workflows/cloud-tests-forked.yml
@@ -9,7 +9,7 @@ on:
           default: false
 
 concurrency:
-    group: cloud-tests-forked-${{ github.actor || github.triggering_actor }}
+    group: cloud-tests-forked-${{ github.ref == 'refs/heads/main' && 'main' || github.actor || github.triggering_actor }}
     cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/cloud-tests.yml
+++ b/.github/workflows/cloud-tests.yml
@@ -9,7 +9,7 @@ on:
           default: false
 
 concurrency:
-    group: cloud-tests-${{ github.actor || github.triggering_actor }}
+    group: cloud-tests-${{ github.ref == 'refs/heads/main' && 'main' || github.actor || github.triggering_actor }}
     cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
This makes the merge to `main` use their own unique queue for the expensive cloud tests. That way, they are not affecting by a developer trying to also build a PR while the merge is still ongoing. Note that merges still happen one at a time.

### All Submissions:

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
