### PR TITLE
CLOUDP-205248: Build once on release

### DIFF
--- a/.github/actions/build-push-image/action.yaml
+++ b/.github/actions/build-push-image/action.yaml
@@ -11,6 +11,10 @@ inputs:
   version:
     description: The version of the operator will be built
     required: true
+  certified_version:
+    description: The certified version of the operator will be built
+    default: ''
+    required: false
   repository:
     description: The name of repository to build image
     required: true
@@ -58,20 +62,10 @@ runs:
         ref: ${{github.event.pull_request.head.sha}}
         repository: ${{github.event.pull_request.head.repo.full_name}}
         submodules: true
-    - name: "Set up QEMU"
-      uses: docker/setup-qemu-action@v2
-      with:
-        platforms: ${{ inputs.platforms }}
     - name: "Set up Docker Buildx"
       uses: docker/setup-buildx-action@v2
       with:
         platforms: ${{ inputs.platforms }}
-    - name: Login to docker registry
-      if: ${{ inputs.push_to_docker == 'true' }}
-      uses: docker/login-action@v2
-      with:
-        username: ${{ inputs.docker_username }}
-        password: ${{ inputs.docker_password }}
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
@@ -88,18 +82,25 @@ runs:
       shell: bash
       run: |
         go mod download
-    - name: Build and Push Operator to Docker Registry
+    - name: Build all platforms
+      shell: bash
+      run: make all-platforms
+    - name: Fail if send input flags are both unset
+      if: ${{ inputs.push_to_docker != 'true' && inputs.push_to_quay != 'true' }}
+      shell: bash
+      run: exit 1
+    - name: Compute main build tag
+      id: tag
+      shell: bash
+      run: |
+        main_tag=${{ inputs.push_to_docker == 'true' && format('{0}:{1}', inputs.repository, inputs.version) || format('quay.io/{0}:{1}', inputs.repository, inputs.version)}}
+        echo "main_tag=$main_tag" >> $GITHUB_OUTPUT
+    - name: Login to docker registry
       if: ${{ inputs.push_to_docker == 'true' }}
-      uses: docker/build-push-action@v3
+      uses: docker/login-action@v2
       with:
-        context: .
-        file: ${{ inputs.file }}
-        build-args: VERSION=${{ inputs.version }}
-        platforms: ${{ inputs.platforms }}
-        tags: ${{ inputs.repository }}:${{ inputs.version }}
-        cache-from: type=gha
-        cache-to: type=gha,mode=max
-        push: true
+        username: ${{ inputs.docker_username }}
+        password: ${{ inputs.docker_password }}
     - name: Login to quay.io registry
       if: ${{ inputs.push_to_quay == 'true' }}
       uses: docker/login-action@v2
@@ -107,15 +108,31 @@ runs:
         registry: quay.io
         username: ${{ inputs.quay_username }}
         password: ${{ inputs.quay_password }}
-    - name: Build and Push Operator to Quay Registry
-      if: ${{ inputs.push_to_quay == 'true' }}
+    - name: Build and Push Operator to ${{ steps.tag.outputs.main_tag }}
       uses: docker/build-push-action@v3
       with:
         context: .
         file: ${{ inputs.file }}
         build-args: VERSION=${{ inputs.version }}
         platforms: ${{ inputs.platforms }}
-        tags: quay.io/${{ inputs.repository }}:${{ inputs.version }}
         cache-from: type=gha
         cache-to: type=gha,mode=max
+        sbom: true
         push: true
+        tags: ${{ steps.tag.outputs.main_tag }}
+    - name: Push To Quay
+      if: ${{ inputs.push_to_quay == 'true' && inputs.push_to_docker == 'true' }}
+      shell: bash
+      run: |
+        docker pull ${{ steps.tag.outputs.main_tag }}
+        docker tag ${{ steps.tag.outputs.main_tag }} quay.io/${{ inputs.repository }}:${{ inputs.version }}
+        echo "PUSH: docker push quay.io/${{ inputs.repository }}:${{ inputs.version }}"
+        docker push quay.io/${{ inputs.repository }}:${{ inputs.version }}
+    - name: Push Certified to Quay
+      if: ${{ inputs.certified_version != '' && inputs.push_to_quay == 'true' }}
+      shell: bash
+      run: |
+        docker pull ${{ steps.tag.outputs.main_tag }}
+        docker tag ${{ steps.tag.outputs.main_tag }} quay.io/${{ inputs.repository }}:${{ inputs.certified_version }}
+        echo "PUSH: docker push quay.io/${{ inputs.repository }}:${{ inputs.certified_version }}"
+        docker push quay.io/${{ inputs.repository }}:${{ inputs.certified_version }}

--- a/.github/workflows/rebuild-released-images.yaml
+++ b/.github/workflows/rebuild-released-images.yaml
@@ -67,7 +67,7 @@ jobs:
           ref: "v${{ matrix.version }}"
           submodules: true
           fetch-depth: 0
-      - name: Upgrade build Makefile & Dockerfile
+      - name: Upgrade build Makefile & Dockerfile # TODO: remove after version 1.9 is deprecated
         run: |
           git remote show origin
           git checkout origin/${{ github.ref_name }} -- Makefile fast.Dockerfile

--- a/.github/workflows/release-post-merge.yml
+++ b/.github/workflows/release-post-merge.yml
@@ -12,14 +12,36 @@ on:
       version:
         description: "Release version (Be sure `Release-branch` is successful):"
         required: true
-
+      image_repo:
+        type: choice
+        description: "Target image repository for built images"
+        default: mongodb/mongodb-atlas-kubernetes-operator-prerelease
+        required: true
+        options:
+        - mongodb/mongodb-atlas-kubernetes-operator-prerelease
+        - mongodb/mongodb-atlas-kubernetes-operator
+      release_helm:
+        description: "Whether or not to trigger the Helm release as well. Skip by default for tests"
+        default: 'false'
+        required: true
+      certify:
+        description: "Whether or not to certify the OpenShift images. Skip by default for tests"
+        default: 'false'
+        required: true
+      release_to_github:
+        description: "Whether or not to create the GitHub release. Skip by default for tests"
+        default: 'false'
+        required: true
 jobs:
   create-release:
     name: Create Release
     if: ${{ (github.event.pull_request.merged == true && startsWith(github.head_ref, 'release/')) || github.event.inputs.version != '' }}
     runs-on: ubuntu-latest
     env:
-      IMAGE_REPOSITORY: mongodb/mongodb-atlas-kubernetes-operator
+      IMAGE_REPOSITORY: ${{ github.event.inputs.image_repo || 'mongodb/mongodb-atlas-kubernetes-operator' }}
+      RELEASE_HELM: ${{ github.event.inputs.release_helm || 'true' }}
+      CERTIFY: ${{ github.event.inputs.certify || 'true' }}
+      RELEASE_TO_GITHUB: ${{ github.event.inputs.release_to_github || 'true' }}
     steps:
       - name: Free disk space
         run: | 
@@ -47,6 +69,7 @@ jobs:
           echo "tag=$tag" >> $GITHUB_OUTPUT
           echo "certified_version=$certified_version" >> $GITHUB_OUTPUT
       - name: Trigger helm post release workflow
+        if: ${{ env.RELEASE_HELM == 'true' }}
         # Please provide a token with write access to the repository into secrets.HELM_REPO_TOKEN
         run: |
           curl \
@@ -61,22 +84,17 @@ jobs:
         with:
           submodules: true
           fetch-depth: 0
+      - name: Upgrade build Makefile & Dockerfile # TODO: remove after version 1.9 is deprecated
+        run: |
+          git remote show origin
+          git checkout origin/${{ github.ref_name }} -- Makefile fast.Dockerfile
       - name: Build and Push image
         uses: ./.github/actions/build-push-image
         with:
           repository: ${{ env.IMAGE_REPOSITORY }}
+          file: fast.Dockerfile
           version: ${{ steps.tag.outputs.version }}
-          platforms: linux/amd64,linux/arm64
-          docker_username: ${{ secrets.DOCKER_USERNAME }}
-          docker_password: ${{ secrets.DOCKER_PASSWORD }}
-          push_to_quay: true
-          quay_username: mongodb+mongodb_atlas_kubernetes
-          quay_password: ${{ secrets.QUAY_PASSWORD }}
-      - name: Build and Push certified image
-        uses: ./.github/actions/build-push-image
-        with:
-          repository: ${{ env.IMAGE_REPOSITORY }}
-          version: ${{ steps.tag.outputs.certified_version }}
+          certified_version: ${{ steps.tag.outputs.certified_version }}
           platforms: linux/amd64,linux/arm64
           docker_username: ${{ secrets.DOCKER_USERNAME }}
           docker_password: ${{ secrets.DOCKER_PASSWORD }}
@@ -84,6 +102,7 @@ jobs:
           quay_username: mongodb+mongodb_atlas_kubernetes
           quay_password: ${{ secrets.QUAY_PASSWORD }}
       - name: Certify Openshift images
+        if: ${{ env.CERTIFY == 'true' }}
         uses: ./.github/actions/certify-openshift-images
         with:
           repository: ${{ env.IMAGE_REPOSITORY }}
@@ -96,6 +115,7 @@ jobs:
           set -x
           tar czvf atlas-operator-all-in-one-${{ steps.tag.outputs.version }}.tar.gz -C deploy all-in-one.yaml
       - name: Create Release
+        if: ${{ env.RELEASE_TO_GITHUB == 'true' }}
         id: create_release
         uses: actions/create-release@v1
         env:
@@ -107,6 +127,7 @@ jobs:
           draft: true
           prerelease: false
       - name: Upload Release Asset
+        if: ${{ env.RELEASE_TO_GITHUB == 'true' }}
         id: upload-release-asset
         uses: actions/upload-release-asset@v1
         env:


### PR DESCRIPTION
✅  [Create Release (test)](https://github.com/mongodb/mongodb-atlas-kubernetes/actions/runs/6574565626/job/17859870298)
✅  [E2E tests](https://github.com/mongodb/mongodb-atlas-kubernetes/actions/runs/6574580645)
✅  [Integration tests](https://github.com/mongodb/mongodb-atlas-kubernetes/actions/runs/6575123825)

The build-and-push sub-action will:
- **Fail** if both push to docker and quay are unset.
- Set the main build **tag** to push to Docker OR Quay.
- If both flags are set it means it pushed to docker and also must push to quay. If both were unset it would have already failed. If docker was unset then it would have already push to quay. If quay is unset, no need to push to quay.
- If the verified version (`*-certified`) is set AND push to quay is also set, push verified version to quay.

### All Submissions:

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
