### PR TITLE
Run Cloud Test on  label

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
     paths-ignore:
       - 'docs/**'
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review, converted_to_draft]
+    types: [opened, synchronize, reopened, ready_for_review, converted_to_draft, labeled, unlabeled]
     branches:
       - '**'
     paths-ignore:
@@ -38,8 +38,9 @@ jobs:
       - unit-tests
       - paths-filter
     if: |
-      github.event.pull_request.draft == false &&
-      needs.paths-filter.outputs.production-code-changed == 'true'
+      contains(github.event.pull_request.labels.*.name, 'cloud-tests') ||
+      (github.event.pull_request.draft == false &&
+      needs.paths-filter.outputs.production-code-changed == 'true')
     uses: ./.github/workflows/cloud-tests.yml
     secrets: inherit
     with:


### PR DESCRIPTION
- Tested that `cloud-tests` triggers [the expensive cloud tests: integration and e2e](https://github.com/mongodb/mongodb-atlas-kubernetes/actions/runs/6585982699/job/17893468648?pr=1184)
- Tested that removing the `cloud-tests` even with tests in progress, will skip the cloud tests.

### All Submissions:

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?

