### PR TITLE
Result of re-running gen-install-scripts/entrypoint.sh

### DIFF
--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -1,9 +1,5 @@
 FROM scratch
 
-LABEL com.redhat.openshift.versions="v4.8"
-LABEL com.redhat.delivery.backport=true
-LABEL com.redhat.delivery.operator.bundle=true
-
 # Core bundle labels.
 LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
@@ -11,7 +7,7 @@ LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=mongodb-atlas-kubernetes
 LABEL operators.operatorframework.io.bundle.channels.v1=stable
 LABEL operators.operatorframework.io.bundle.channel.default.v1=stable
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.15.0+git
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.32.0
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v2
 

--- a/bundle/manifests/atlas.mongodb.com_atlasbackupschedules.yaml
+++ b/bundle/manifests/atlas.mongodb.com_atlasbackupschedules.yaml
@@ -70,10 +70,6 @@ spec:
                       description: Target region to copy snapshots belonging to replicationSpecId
                         to.
                       type: string
-                    replicationSpecId:
-                      description: Unique identifier that identifies the replication
-                        object for a zone in a cluster.
-                      type: string
                     shouldCopyOplogs:
                       description: Flag that indicates whether to copy the oplogs
                         to the target region.

--- a/bundle/manifests/mongodb-atlas-kubernetes.clusterserviceversion.yaml
+++ b/bundle/manifests/mongodb-atlas-kubernetes.clusterserviceversion.yaml
@@ -124,10 +124,11 @@ metadata:
       ]
     capabilities: Full Lifecycle
     categories: Database
+    createdAt: "2023-10-25T07:51:36Z"
     description: The MongoDB Atlas Kubernetes Operator enables easy management of Clusters in MongoDB Atlas
-    operators.operatorframework.io/builder: operator-sdk-v1.15.0+git
+    operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
-    containerImage: mongodb/mongodb-atlas-kubernetes-operator:1.9.0
+    containerImage: mongodb/mongodb-atlas-kubernetes-operator
   labels:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.arm64: supported
@@ -456,7 +457,11 @@ spec:
                 - update
           serviceAccountName: mongodb-atlas-operator
       deployments:
-        - name: mongodb-atlas-operator
+        - label:
+            app.kubernetes.io/component: controller
+            app.kubernetes.io/instance: mongodb-atlas-kubernetes-operator
+            app.kubernetes.io/name: mongodb-atlas-kubernetes-operator
+          name: mongodb-atlas-operator
           spec:
             replicas: 1
             selector:
@@ -495,7 +500,7 @@ spec:
                         valueFrom:
                           fieldRef:
                             fieldPath: metadata.annotations['olm.targetNamespaces']
-                    image: mongodb/mongodb-atlas-kubernetes-operator:1.9.0
+                    image: mongodb/mongodb-atlas-kubernetes-operator:latest
                     imagePullPolicy: Always
                     livenessProbe:
                       httpGet:
@@ -581,4 +586,4 @@ spec:
   provider:
     name: MongoDB, Inc
   version: 1.9.0
-  replaces: mongodb-atlas-kubernetes.v1.8.2
+  replaces: mongodb-atlas-kubernetes.v1.9.0

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -6,7 +6,7 @@ annotations:
   operators.operatorframework.io.bundle.package.v1: mongodb-atlas-kubernetes
   operators.operatorframework.io.bundle.channels.v1: stable
   operators.operatorframework.io.bundle.channel.default.v1: stable
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.15.0+git
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.32.0
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v2
 

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -7,5 +7,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: mongodb-atlas-controller
-  newTag: latest
+  newName: mongodb/mongodb-atlas-kubernetes-operator

--- a/deploy/all-in-one.yaml
+++ b/deploy/all-in-one.yaml
@@ -245,10 +245,6 @@ spec:
                       description: Target region to copy snapshots belonging to replicationSpecId
                         to.
                       type: string
-                    replicationSpecId:
-                      description: Unique identifier that identifies the replication
-                        object for a zone in a cluster.
-                      type: string
                     shouldCopyOplogs:
                       description: Flag that indicates whether to copy the oplogs
                         to the target region.

--- a/deploy/clusterwide/crds.yaml
+++ b/deploy/clusterwide/crds.yaml
@@ -228,10 +228,6 @@ spec:
                       description: Target region to copy snapshots belonging to replicationSpecId
                         to.
                       type: string
-                    replicationSpecId:
-                      description: Unique identifier that identifies the replication
-                        object for a zone in a cluster.
-                      type: string
                     shouldCopyOplogs:
                       description: Flag that indicates whether to copy the oplogs
                         to the target region.

--- a/deploy/crds/atlas.mongodb.com_atlasbackupschedules.yaml
+++ b/deploy/crds/atlas.mongodb.com_atlasbackupschedules.yaml
@@ -67,10 +67,6 @@ spec:
                       description: Target region to copy snapshots belonging to replicationSpecId
                         to.
                       type: string
-                    replicationSpecId:
-                      description: Unique identifier that identifies the replication
-                        object for a zone in a cluster.
-                      type: string
                     shouldCopyOplogs:
                       description: Flag that indicates whether to copy the oplogs
                         to the target region.

--- a/deploy/namespaced/crds.yaml
+++ b/deploy/namespaced/crds.yaml
@@ -228,10 +228,6 @@ spec:
                       description: Target region to copy snapshots belonging to replicationSpecId
                         to.
                       type: string
-                    replicationSpecId:
-                      description: Unique identifier that identifies the replication
-                        object for a zone in a cluster.
-                      type: string
                     shouldCopyOplogs:
                       description: Flag that indicates whether to copy the oplogs
                         to the target region.

--- a/deploy/openshift/crds.yaml
+++ b/deploy/openshift/crds.yaml
@@ -228,10 +228,6 @@ spec:
                       description: Target region to copy snapshots belonging to replicationSpecId
                         to.
                       type: string
-                    replicationSpecId:
-                      description: Unique identifier that identifies the replication
-                        object for a zone in a cluster.
-                      type: string
                     shouldCopyOplogs:
                       description: Flag that indicates whether to copy the oplogs
                         to the target region.

--- a/go.sum
+++ b/go.sum
@@ -315,12 +315,8 @@ github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRW
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/onsi/ginkgo/v2 v2.13.0 h1:0jY9lJquiL8fcf3M4LAXN5aMlS/b2BV86HFFPCPMgE4=
 github.com/onsi/ginkgo/v2 v2.13.0/go.mod h1:TE309ZR8s5FsKKpuB1YAQYBzCaAfUgatB/xlT/ETL/o=
-github.com/onsi/gomega v1.28.0 h1:i2rg/p9n/UqIDAMFUJ6qIUUMcsqOuUHgbpbu235Vr1c=
-github.com/onsi/gomega v1.28.0/go.mod h1:A1H2JE76sI14WIP57LMKj7FVfCHx3g3BcZVjJG8bjX8=
 github.com/onsi/gomega v1.28.1 h1:MijcGUbfYuznzK/5R4CPNoUP/9Xvuo20sXfEm6XxoTA=
 github.com/onsi/gomega v1.28.1/go.mod h1:9sxs+SwGrKI0+PWe4Fxa9tFQQBG5xSsSbMXOI8PPpoQ=
-github.com/pborman/uuid v1.2.1 h1:+ZZIw58t/ozdjRaXh/3awHfmWRbzYxJoAdNJxe/3pvw=
-github.com/pborman/uuid v1.2.1/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 h1:KoWmjvw+nsYOo29YJK9vDA65RGE3NrOnUtO7a+RF9HU=
 github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8/go.mod h1:HKlIX3XHQyzLZPlr7++PzdhaXEj94dEiJgZDTsxEqUI=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/go.work.sum
+++ b/go.work.sum
@@ -1,6 +1,4 @@
 cloud.google.com/go v0.110.2/go.mod h1:k04UEeEtb6ZBRTv3dZz4CeJC3jKGxyhl0sAiVVquxiw=
-cloud.google.com/go v0.110.8 h1:tyNdfIxjzaWctIiLYOTalaLKZ17SI44SKFW26QbOhME=
-cloud.google.com/go v0.110.8/go.mod h1:Iz8AkXJf1qmxC3Oxoep8R1T36w8B92yU29PcBhHO5fk=
 cloud.google.com/go/accessapproval v1.7.1 h1:/5YjNhR6lzCvmJZAnByYkfEgWjfAKwYP6nkuTk6nKFE=
 cloud.google.com/go/accessapproval v1.7.1/go.mod h1:JYczztsHRMK7NTXb6Xw+dwbs/WnOJxbo/2mTI+Kgg68=
 cloud.google.com/go/accesscontextmanager v1.8.1 h1:WIAt9lW9AXtqw/bnvrEUaE8VG/7bAAeMzRCBGMkc4+w=
@@ -119,14 +117,14 @@ cloud.google.com/go/grafeas v0.3.0/go.mod h1:P7hgN24EyONOTMyeJH6DxG4zD7fwiYa5Q6G
 cloud.google.com/go/gsuiteaddons v1.6.1 h1:mi9jxZpzVjLQibTS/XfPZvl+Jr6D5Bs8pGqUjllRb00=
 cloud.google.com/go/gsuiteaddons v1.6.1/go.mod h1:CodrdOqRZcLp5WOwejHWYBjZvfY0kOphkAKpF/3qdZY=
 cloud.google.com/go/iam v0.13.0/go.mod h1:ljOg+rcNfzZ5d6f1nAUJ8ZIxOaZUVoS14bKCtaLZ/D0=
-cloud.google.com/go/iam v1.1.2 h1:gacbrBdWcoVmGLozRuStX45YKvJtzIjJdAolzUs1sm4=
-cloud.google.com/go/iam v1.1.2/go.mod h1:A5avdyVL2tCppe4unb0951eI9jreack+RJ0/d+KUZOU=
+cloud.google.com/go/iam v1.1.0/go.mod h1:nxdHjaKfCr7fNYx/HJMM8LgiMugmveWlkatear5gVyk=
 cloud.google.com/go/iap v1.9.0 h1:RNhVq/6OMI99/wjPVhqFxjlBxYOBRdaG6rLpBvyaqYY=
 cloud.google.com/go/iap v1.9.0/go.mod h1:01OFxd1R+NFrg78S+hoPV5PxEzv22HXaNqUUlmNHFuY=
 cloud.google.com/go/ids v1.4.1 h1:khXYmSoDDhWGEVxHl4c4IgbwSRR+qE/L4hzP3vaU9Hc=
 cloud.google.com/go/ids v1.4.1/go.mod h1:np41ed8YMU8zOgv53MMMoCntLTn2lF+SUzlM+O3u/jw=
 cloud.google.com/go/iot v1.7.1 h1:yrH0OSmicD5bqGBoMlWG8UltzdLkYzNUwNVUVz7OT54=
 cloud.google.com/go/iot v1.7.1/go.mod h1:46Mgw7ev1k9KqK1ao0ayW9h0lI+3hxeanz+L1zmbbbk=
+cloud.google.com/go/kms v1.15.2/go.mod h1:3hopT4+7ooWRCjc2DxgnpESFxhIraaI2IpAVUEhbT/w=
 cloud.google.com/go/language v1.11.0 h1:KnYolG0T5Oex722ZW/sP5QErhVAVNcqpJ16tVJd9RTw=
 cloud.google.com/go/language v1.11.0/go.mod h1:uDx+pFDdAKTY8ehpWbiXyQdz8tDSYLJbQcXsCkjYyvQ=
 cloud.google.com/go/lifesciences v0.9.1 h1:axkANGx1wiBXHiPcJZAE+TDjjYoJRIDzbHC/WYllCBU=
@@ -493,9 +491,11 @@ google.golang.org/genproto/googleapis/api v0.0.0-20230711160842-782d3b101e98/go.
 google.golang.org/genproto/googleapis/api v0.0.0-20230920204549-e6e6cdab5c13/go.mod h1:RdyHbowztCGQySiCvQPgWQWgWhGnouTdCflKoDBt32U=
 google.golang.org/genproto/googleapis/bytestream v0.0.0-20231009173412-8bfb1ae86b6c h1:9tZedXBlwql0v/dLZx1E4Rcz9ESc8j1KZk71903wKEg=
 google.golang.org/genproto/googleapis/bytestream v0.0.0-20231009173412-8bfb1ae86b6c/go.mod h1:itlFWGBbEyD32PUeJsTG8h8Wz7iJXfVK4gt1EJ+pAG0=
+google.golang.org/genproto/googleapis/bytestream v0.0.0-20231012201019-e917dd12ba7a/go.mod h1:+34luvCflYKiKylNwGJfn9cFBbcL/WrkciMmDmsTQ/A=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20230530153820-e85fd2cbaebc/go.mod h1:66JfowdXAEgad5O9NnYcsNPLCPZJD++2L9X0PCMODrA=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20230711160842-782d3b101e98/go.mod h1:TUfxEVdsvPg18p6AslUXFoLdpED4oBnGwyqk3dV1XzM=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20230822172742-b8732ec3820d/go.mod h1:+Bk1OCOj40wS2hwAMA+aCW9ypzm63QTBBHp6lQ3p+9M=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20230920204549-e6e6cdab5c13/go.mod h1:KSqppvjFjtoCI+KGd4PELB0qLNxdJHRGqRI09mB6pQA=
 google.golang.org/grpc v1.33.1/go.mod h1:fr5YgcSWrqhRRxogOsw7RzIpsmvOZ6IcH4kBYTpR3n0=
 google.golang.org/grpc v1.36.0/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
 google.golang.org/grpc v1.37.0/go.mod h1:NREThFqKR1f3iQ6oBuvc5LadQuXVGo9rkm5ZGrQdJfM=


### PR DESCRIPTION
Result of running:

```bash
INPUT_VERSION=1.9.0 INPUT_ENV=prod INPUT_IMAGE_URL=mongodb/mongodb-atlas-kubernetes-operator .github/actions/gen-install-scripts/entrypoint.sh
```

With some cleanups:
- Do not commit changes in `deploy/samples/*`
- Keep using version tag `:1.9.0` rather than `:latest`.

### All Submissions:

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
