### PR TITLE
CLOUDP-212063: Fix k8s project delete and update race conditions

### DIFF
--- a/test/int/integration_suite_test.go
+++ b/test/int/integration_suite_test.go
@@ -199,8 +199,10 @@ func prepareControllers(deletionProtection bool) (*corev1.Namespace, context.Can
 		},
 	}
 
-	By("Creating the namespace " + namespace.Name)
+	By("Creating the namespace " + namespace.GenerateName + "...")
 	Expect(k8sClient.Create(context.Background(), &namespace)).ToNot(HaveOccurred())
+	Expect(namespace.Name).ToNot(BeEmpty())
+	GinkgoWriter.Printf("Generated namespace %q\n", namespace.Name)
 
 	// +kubebuilder:scaffold:scheme
 	logger := ctrzap.NewRaw(ctrzap.UseDevMode(true), ctrzap.WriteTo(GinkgoWriter), ctrzap.StacktraceLevel(zap.ErrorLevel))

--- a/test/int/project_test.go
+++ b/test/int/project_test.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"sync"
 
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/version"
 
 	"time"
@@ -54,8 +56,7 @@ var _ = Describe("AtlasProject", Label("int", "AtlasProject"), func() {
 	AfterEach(func() {
 		if createdProject != nil && createdProject.Status.ID != "" {
 			By("Removing Atlas Project " + createdProject.Status.ID)
-			Expect(k8sClient.Get(context.Background(), kube.ObjectKeyFromObject(createdProject), createdProject)).To(Succeed())
-			Expect(k8sClient.Delete(context.Background(), createdProject)).To(Succeed())
+			Eventually(deleteK8sObject(createdProject), 20, interval).Should(BeTrue())
 			Eventually(checkAtlasProjectRemoved(createdProject.Status.ID), 20, interval).Should(BeTrue())
 		}
 		removeControllersAndNamespace()
@@ -369,7 +370,7 @@ var _ = Describe("AtlasProject", Label("int", "AtlasProject"), func() {
 		var secondProject *mdbv1.AtlasProject
 		It("Should Succeed", func() {
 			By("Creating two projects first", func() {
-				createdProject = mdbv1.DefaultProject(namespace.Name, connectionSecret.Name)
+				createdProject = mdbv1.DefaultProject(namespace.Name, connectionSecret.Name).WithName("first-project")
 				Expect(k8sClient.Create(context.Background(), createdProject)).ToNot(HaveOccurred())
 
 				secondProject = mdbv1.DefaultProject(namespace.Name, connectionSecret.Name).WithName("second-project").WithAtlasName("second-project")
@@ -388,12 +389,13 @@ var _ = Describe("AtlasProject", Label("int", "AtlasProject"), func() {
 				connectionSecret.StringData["publicApiKey"] = "non-existing"
 				Expect(k8sClient.Update(context.Background(), &connectionSecret)).To(Succeed())
 
-				Expect(k8sClient.Get(context.Background(), kube.ObjectKeyFromObject(createdProject), createdProject)).To(Succeed())
-				createdProject.Spec.AlertConfigurationSyncEnabled = true
-				Expect(k8sClient.Update(context.Background(), createdProject)).To(Succeed())
-				Expect(k8sClient.Get(context.Background(), kube.ObjectKeyFromObject(secondProject), secondProject)).To(Succeed())
-				secondProject.Spec.AlertConfigurationSyncEnabled = true
-				Expect(k8sClient.Update(context.Background(), secondProject)).To(Succeed())
+				Eventually(updateK8sObject[*mdbv1.AtlasProject](createdProject, func(createdProject *mdbv1.AtlasProject) {
+					createdProject.Spec.AlertConfigurationSyncEnabled = true
+				})).WithPolling(interval).WithTimeout(20 * time.Second).Should(BeTrue())
+
+				Eventually(updateK8sObject[*mdbv1.AtlasProject](secondProject, func(secondProject *mdbv1.AtlasProject) {
+					secondProject.Spec.AlertConfigurationSyncEnabled = true
+				})).WithPolling(interval).WithTimeout(20 * time.Second).Should(BeTrue())
 
 				// Both projects are expected to get to Failed state right away
 				expectedCondition := status.FalseCondition(status.ProjectReadyType).WithReason(string(workflow.ProjectNotCreatedInAtlas))
@@ -629,7 +631,7 @@ var _ = Describe("AtlasProject", Label("int", "AtlasProject"), func() {
 		})
 		It("Should Fail if the global Secret doesn't exist", func() {
 			By("Creating without a global Secret", func() {
-				createdProject = mdbv1.DefaultProject(namespace.Name, "")
+				createdProject = mdbv1.DefaultProject(namespace.Name, "").WithName("project-no-secret")
 
 				Expect(k8sClient.Create(context.Background(), createdProject)).ToNot(HaveOccurred())
 
@@ -726,5 +728,40 @@ func validateNoErrorsMaintenanceWindowDuringUpdate(g Gomega) func(a mdbv1.AtlasC
 		condition, ok := testutil.FindConditionByType(c.Status.Conditions, status.MaintenanceWindowReadyType)
 		g.Expect(ok).To(BeTrue())
 		g.Expect(condition.Reason).To(BeEmpty())
+	}
+}
+
+func deleteK8sObject(obj client.Object) func() bool {
+	return func() bool {
+		nn := kube.ObjectKeyFromObject(obj)
+		GinkgoWriter.Printf("Deleting %s/%s\n", nn.Namespace, nn.Name)
+		err := k8sClient.Get(context.Background(), nn, obj)
+		if err == nil {
+			err = k8sClient.Delete(context.Background(), obj)
+		}
+		if err != nil {
+			GinkgoWriter.Printf("Attempt to delete %s/%s failed: %v\n", nn.Namespace, nn.Name, err)
+			return false
+		}
+		GinkgoWriter.Printf("Deleted %s/%s\n", nn.Namespace, nn.Name)
+		return true
+	}
+}
+
+func updateK8sObject[T client.Object](obj T, updateFn func(T)) func() bool {
+	return func() bool {
+		nn := kube.ObjectKeyFromObject(obj)
+		GinkgoWriter.Printf("Updating %s/%s\n", nn.Namespace, nn.Name)
+		err := k8sClient.Get(context.Background(), nn, obj)
+		if err == nil {
+			updateFn(obj)
+			err = k8sClient.Update(context.Background(), obj)
+		}
+		if err != nil {
+			GinkgoWriter.Printf("Failed to update %s/%s: %v\n", nn.Namespace, nn.Name, err)
+			return false
+		}
+		GinkgoWriter.Printf("Updated %s/%s\n", nn.Namespace, nn.Name)
+		return true
 	}
 }


### PR DESCRIPTION
This fix includes several race condition fixes on Kubernetes object deletion and update.

It also includes a few project renames on the Kubernetes side that seem to fix some flakiness. I believe some tests were interfering with each other on the same project test set.

### All Submissions:

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
