### PR TITLE
CLOUDP-212564: Kick Helm Chart release using GitHub App

### DIFF
--- a/.github/workflows/release-post-merge.yml
+++ b/.github/workflows/release-post-merge.yml
@@ -2,7 +2,7 @@
 # Trigger release branch should be merge into main
 # TODO add e2e/smoke test for autogen configuration
 
-name: Create Release.
+name: Create Release
 
 on:
   pull_request:
@@ -34,6 +34,7 @@ on:
         required: true
 jobs:
   create-release:
+    environment: release
     name: Create Release
     if: ${{ (github.event.pull_request.merged == true && startsWith(github.head_ref, 'release/')) || github.event.inputs.version != '' }}
     runs-on: ubuntu-latest
@@ -66,22 +67,21 @@ jobs:
           echo "version=$version" >> $GITHUB_OUTPUT
           echo "tag=$tag" >> $GITHUB_OUTPUT
           echo "certified_version=$certified_version" >> $GITHUB_OUTPUT
-      - name: Trigger helm post release workflow
-        if: ${{ env.RELEASE_HELM == 'true' }}
-        # Please provide a token with write access to the repository into secrets.HELM_REPO_TOKEN
-        run: |
-          curl \
-            -X POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${{ secrets.HELM_REPO_TOKEN }}"\
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            https://api.github.com/repos/mongodb/helm-charts/actions/workflows/post-atlas-operator-release.yaml/dispatches \
-            -d '{"ref":"main","inputs":{"version":"'"${{ steps.tag.outputs.version }}"'"}}'
       - name: Check out code
         uses: actions/checkout@v4
         with:
           submodules: true
           fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: "${{ github.workspace }}/tools/makejwt/go.mod"
+      - name: Trigger helm post release workflow
+        if: ${{ env.RELEASE_HELM == 'true' }}
+        run: |
+          make release-helm JWT_RSA_PEM_KEY_BASE64="${{ secrets.AKO_RELEASER_RSA_KEY_BASE64 }}" \
+            JWT_APP_ID="${{ secrets.AKO_RELEASER_APP_ID }}" \
+            VERSION="${{ steps.tag.outputs.version }}"
       - name: Upgrade build Makefile & Dockerfile # TODO: remove after version 1.9 is deprecated
         run: |
           git remote show origin

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ deploy/
 
 # ignore tool binaries
 tools/clean/clean
+tools/makejwt/makejwt

--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,10 @@ BASE_GO_PACKAGE = github.com/mongodb/mongodb-atlas-kubernetes/v2
 GO_LICENSES = go-licenses
 DISALLOWED_LICENSES = restricted,reciprocal
 
+# JWT
+JWT_RSA_PEM_KEY_BASE64 ?= ""
+JWT_APP_ID ?= ""
+
 .DEFAULT_GOAL := help
 .PHONY: help
 help: ## Show this help screen
@@ -392,3 +396,11 @@ actions.txt: .github/workflows/ ## List GitHub Action dependencies
 check-major-version: ## Check that VERSION starts with MAJOR_VERSION
 	@[[ $(VERSION) == $(MAJOR_VERSION).* ]] && echo "Version OK" || \
 	(echo "Bad major version for $(VERSION) expected $(MAJOR_VERSION)"; exit 1)
+
+tools/makejwt/makejwt: tools/makejwt/*.go
+	cd tools/makejwt && go test . && go build .
+
+.PHONY: release-helm
+release-helm: tools/makejwt/makejwt ## kick the operator helm chart release
+	@APP_ID=$(JWT_APP_ID) RSA_PEM_KEY_BASE64=$(JWT_RSA_PEM_KEY_BASE64) \
+	VERSION=$(VERSION) ./scripts/release-helm.sh

--- a/scripts/release-helm.sh
+++ b/scripts/release-helm.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -euo pipefail
+
+helm_charts_installation_id() {
+	JWT=$1
+	curl -s -X GET -H "Accept: application/vnd.github+json" \
+		-H "Authorization: Bearer ${JWT}" \
+		-H "X-GitHub-Api-Version: 2022-11-28" \
+		"https://api.github.com/repos/mongodb/helm-charts/installation" | jq .id
+}
+
+helm_charts_token() {
+	JWT=$1
+	INSTALL_ID=$(helm_charts_installation_id "${JWT}")
+	curl -s -X POST -H "Accept: application/vnd.github+json" \
+		-H "Authorization: Bearer ${JWT}" \
+		-H "X-GitHub-Api-Version: 2022-11-28" \
+		"https://api.github.com/app/installations/${INSTALL_ID}/access_tokens" | jq -rc .token
+}
+
+JWT=$(tools/makejwt/makejwt -appId="${APP_ID}" -key="${RSA_PEM_KEY_BASE64}")
+
+ACCESS_TOKEN=$(helm_charts_token "${JWT}")
+
+curl -s --fail-with-body -X POST -H "Accept: application/vnd.github+json" \
+        -H "Authorization: Bearer ${ACCESS_TOKEN}"\
+        -H "X-GitHub-Api-Version: 2022-11-28" \
+        -d '{"ref":"main","inputs":{"version":"'"${VERSION}"'"}}' \
+        https://api.github.com/repos/mongodb/helm-charts/actions/workflows/post-atlas-operator-release.yaml/dispatches

--- a/tools/makejwt/go.mod
+++ b/tools/makejwt/go.mod
@@ -1,0 +1,5 @@
+module tools/makejwt
+
+go 1.21.4
+
+require github.com/golang-jwt/jwt v3.2.2+incompatible

--- a/tools/makejwt/go.sum
+++ b/tools/makejwt/go.sum
@@ -1,0 +1,2 @@
+github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
+github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=

--- a/tools/makejwt/main.go
+++ b/tools/makejwt/main.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/asn1"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"time"
+
+	"github.com/golang-jwt/jwt"
+)
+
+var (
+	// ErrorEmptyPEMKey when the PEM key was not passed in
+	ErrorEmptyPEMKey = errors.New("empty PEM key or filename")
+
+	// ErrorNoPEMData when the PEM data was not found
+	ErrorNoPEMData = errors.New("no PEM data found")
+
+	// ErrorEmptyAppId when the App ID was not passed in
+	ErrorEmptyAppId = errors.New("empty App Id")
+)
+
+type JWTSpec struct {
+	// Base64PEMBytes is the base64 encoding of the key in PEM format
+	Base64PEMBytes string
+	// AppID is the OAuth Application id
+	AppID string
+	// Duration is how long we want the JWT to be valid for
+	Duration time.Duration
+	// Raw means the CLI outputs the raw JWT and no other debug info, such as the public key
+	Raw bool
+}
+
+type jsonReply struct {
+	PublicKey string `json:"publicKey"`
+	JWT       string `json:"jwt"`
+}
+
+func makeJWT(spec *JWTSpec) (string, error) {
+	// decode base64 of the key to PEM
+	pemBytes, err := base64.StdEncoding.DecodeString(string(spec.Base64PEMBytes))
+	if err != nil {
+		return "", fmt.Errorf("error decoding base64 of the PEM key: %w", err)
+	}
+
+	// Parse PEM block
+	block, _ := pem.Decode(pemBytes)
+	if block == nil {
+		return "", ErrorNoPEMData
+	}
+
+	// Parse RSA private key
+	privateKey, err := x509.ParsePKCS1PrivateKey(block.Bytes)
+	if err != nil {
+		return "", fmt.Errorf("error parsing private key: %w", err)
+	}
+
+	// Create JWT claims
+	now := time.Now()
+	claims := jwt.MapClaims{
+		"iat": now.Unix(),
+		"exp": now.Add(spec.Duration).Unix(),
+		"iss": spec.AppID,
+	}
+
+	// Create JWT token
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+
+	// Sign the token with the private key
+	tokenString, err := token.SignedString(privateKey)
+	if err != nil {
+		return "", fmt.Errorf("error signing token: %w", err)
+	}
+	if spec.Raw {
+		return tokenString, nil
+	}
+	pubKey, ok := (privateKey.Public()).(*rsa.PublicKey)
+	if !ok {
+		return "", errors.New("error expected RSA public key")
+	}
+	return buildJsonReply(pubKey, tokenString)
+}
+
+func buildJsonReply(publicKey *rsa.PublicKey, jwt string) (string, error) {
+	pubKeyDER, err := asn1.Marshal(*publicKey)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal public key into ASN1: %w", err)
+	}
+	pubKeyPem := pem.EncodeToMemory(&pem.Block{Type: "RSA PUBLIC KEY", Bytes: pubKeyDER})
+	jsonBytes, err := json.Marshal(jsonReply{PublicKey: string(pubKeyPem), JWT: jwt})
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal public key into PEM: %w", err)
+	}
+	return string(jsonBytes), nil
+}
+
+func printJWT(w io.Writer, spec *JWTSpec) error {
+	newJWT, err := makeJWT(spec)
+	if err != nil {
+		return fmt.Errorf("failed to create JWT from spec: %w", err)
+	}
+	_, err = fmt.Fprintln(w, newJWT)
+	return err
+}
+
+func parseJWTSpecArgs(args []string) (*JWTSpec, error) {
+	var spec JWTSpec
+	fs := flag.NewFlagSet("jwtSpecFlags", flag.ContinueOnError)
+	fs.StringVar(&spec.Base64PEMBytes, "key", "", "Base64 of the PEM key contents")
+	fs.StringVar(&spec.AppID, "appId", "", "Application ID for the JWT token")
+	fs.DurationVar(&spec.Duration, "duration", 10*time.Minute, "Duration the JWT token will be valid for")
+	fs.BoolVar(&spec.Raw, "raw", true, "Emit the raw JWT or a JSON with the jwt and the public key certificate")
+	if err := fs.Parse(args); err != nil {
+		fs.PrintDefaults()
+		return nil, fmt.Errorf("error parsing command line arguments: %w", err)
+	}
+	if spec.Base64PEMBytes == "" {
+		return nil, ErrorEmptyPEMKey
+	}
+	if spec.AppID == "" {
+		return nil, ErrorEmptyAppId
+	}
+	return &spec, nil
+}
+
+func main() {
+	spec, err := parseJWTSpecArgs(os.Args[1:])
+	if err != nil {
+		log.Fatalf("Failed to parse input arguments: %v", err)
+	}
+	if err := printJWT(os.Stdout, spec); err != nil {
+		log.Fatalf("Failed to create JWT token: %v", err)
+	}
+}

--- a/tools/makejwt/main_test.go
+++ b/tools/makejwt/main_test.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"bytes"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"time"
+
+	"encoding/base64"
+	"testing"
+
+	"github.com/golang-jwt/jwt"
+)
+
+func generateRandomRSAKey() (*rsa.PrivateKey, error) {
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate private key: %w", err)
+	}
+	return privateKey, nil
+}
+
+func asPEM(keyType string, key *rsa.PrivateKey) []byte {
+	// Encode private key to PEM format
+	privateKeyPEMBlock := &pem.Block{
+		Type:  keyType,
+		Bytes: x509.MarshalPKCS1PrivateKey(key),
+	}
+	return pem.EncodeToMemory(privateKeyPEMBlock)
+}
+
+func testSpec(appId, b64Key string) *JWTSpec {
+	return &JWTSpec{
+		AppID: appId,
+		Base64PEMBytes: b64Key,
+		Raw: true,
+		Duration: 10 * time.Minute,
+	}
+}
+
+func TestPrintJWT(t *testing.T) {
+	key, err := generateRandomRSAKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	b64Key := base64.StdEncoding.EncodeToString(asPEM("RSA PRIVATE KEY", key))
+	buf := bytes.NewBufferString("")
+	if err := printJWT(buf, testSpec("123456", b64Key)); err != nil {
+		t.Fatal(err)
+	}
+	keyFunc := func(token *jwt.Token) (interface{}, error) {
+		return key.Public(), nil
+	}
+	if _, err := jwt.Parse(buf.String(), keyFunc); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestParseJWTSpecArgsErrors(t *testing.T) {
+	testCases := []struct {
+		title         string
+		args          []string
+		expectedError error
+	}{
+		{
+			title:         "No args",
+			args:          []string{},
+			expectedError: ErrorEmptyPEMKey,
+		},
+		{
+			title:         "Missing PEM key",
+			args:          []string{"-appId=123456"},
+			expectedError: ErrorEmptyPEMKey,
+		},
+		{
+			title:         "Missing App Id",
+			args:          []string{"-key=fake"},
+			expectedError: ErrorEmptyAppId,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.title, func(t *testing.T) {
+			_, err := parseJWTSpecArgs(tc.args)
+			if !errors.Is(err, tc.expectedError) {
+				t.Fatalf("got %v want %v", err, tc.expectedError)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Use New GH App AKO Releaser to kick off the helm chart release from this repo.

Created a new `makejwt` tool to create a JWT token from the GitHub App RSA key.

Overall process:
1. Build & test the Go tool `makejwt`.
1. Use the new `scripts/release-helm.sh` script to kick of the Helm charts release.

The `scripts/release-helm.sh` needs to do some curl dance to go from the RSA key to a successful REST API call:
1. Run the `makejwt` tool to obtain the **JWT** from the App RSA key.
1. Use the **JWT** to query the **Installation Id** of the helm-charts repo via REST.
1. Use the **JWT** and the **Installation Id** to query **access token** the via REST.
1. Use the **access token** and Version to kick off the helm release via REST.

Test:

✅  [Test to kick Helm Chart release using AKO release GitHub App](https://github.com/mongodb/mongodb-atlas-kubernetes/actions/runs/7086068590/job/19283574246)
✅ [Helm Chart repo release branch job was started](https://github.com/mongodb/helm-charts/actions/runs/7086073058/job/19283588349)

### All Submissions:

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?

