### PR TITLE
CLOUDP-212108: Fix net peering cleanups

### DIFF
--- a/tools/clean/atlas/atlas.go
+++ b/tools/clean/atlas/atlas.go
@@ -52,7 +52,7 @@ func (c *Cleaner) Clean(ctx context.Context, lifetime int) error {
 	for _, proj := range projects {
 		p := proj
 
-		fmt.Println(text.FgHiWhite.Sprintf("\tStarting deletion of project %s(%s) ...", p.GetName(), p.GetId()))
+		fmt.Println(text.FgHiWhite.Sprintf("\tStarting deletion of project %s(%s) (created at %v)...", p.GetName(), p.GetId(), p.Created))
 
 		if time.Since(p.Created) < time.Duration(lifetime)*time.Hour {
 			fmt.Println(text.FgYellow.Sprintf("\tProject %s(%s) skipped once created less than %d hour ago", p.GetName(), p.GetId(), lifetime))


### PR DESCRIPTION
Seems that `ListPeeringConnections` would render only AWS related peering by default.

Apart from that, GCP VPC removals could not be done before removing their subnets.

Fixing both here should probably fix the issues for GCP. For Azure we have not detected stuck entries so far.

### All Submissions:

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
