### PR TITLE
CLOUDP-213620: Store JSON metrics on separate branch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,9 @@ BASE_GO_PACKAGE = github.com/mongodb/mongodb-atlas-kubernetes/v2
 GO_LICENSES = go-licenses
 DISALLOWED_LICENSES = restricted,reciprocal
 
+METRICS_COLLECTION := flaky
+METRICS_JSON_BASE64 := "WK10" # base64("[]")
+
 .DEFAULT_GOAL := help
 .PHONY: help
 help: ## Show this help screen
@@ -392,3 +395,21 @@ actions.txt: .github/workflows/ ## List GitHub Action dependencies
 check-major-version: ## Check that VERSION starts with MAJOR_VERSION
 	@[[ $(VERSION) == $(MAJOR_VERSION).* ]] && echo "Version OK" || \
 	(echo "Bad major version for $(VERSION) expected $(MAJOR_VERSION)"; exit 1)
+
+.PHONY: clone-metrics
+clone-metrics: ## Clone the metrics branch into direcotry metrics
+	git clone git@github.com:mongodb/mongodb-atlas-kubernetes.git -b metrics metrics/ || echo "metrics already cloned"
+
+.PHONY: push-metrics
+push-metrics: ## Commit changes in the metrics branch at metrics dir and remove the dir
+	cd metrics && git add . && git commit -m "Added metrics"
+	cd metrics && git push -u origin metrics
+
+# We use base64 of the metric to avoid makefile interpreting and trying to expand $ such as for $date
+.PHONY: add-metrics-data
+add-metrics-data:
+	COLLECTION='$(METRICS_COLLECTION)' METRICS_JSON='$(shell echo $(METRICS_JSON_BASE64) |base64 -d)' scripts/add-metrics.sh
+
+.PHONY: add-metrics
+add-metrics: clone-metrics add-metrics-data push-metrics ## Add some JSON metrics to the metrics' repo branch
+	rm -rf metrics

--- a/scripts/add-metrics.sh
+++ b/scripts/add-metrics.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -eup pipefail
+
+dir=${METRICS_DIR:-metrics}
+collection=${COLLECTION:-collection}
+metrics=${METRICS_JSON:-"[]"}
+
+echo "Inserting into ${collection} metrics: ${metrics}"
+mkdir -p "${dir}"
+if [ ! -f "${dir}/${collection}.json" ]; then
+	echo "[]" > "${dir}/${collection}.json"
+fi
+jq ". += ${metrics}" < "${dir}/${collection}.json" > "${dir}/${collection}.new.json"
+mv "${dir}/${collection}.new.json" "${dir}/${collection}.json"

--- a/scripts/query-metrics.sh
+++ b/scripts/query-metrics.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -euo pipefail
+
+dbpath=${DB_PATH:-/tmp/mdb}
+dblogs=${DB_LOGS:-/tmp/mdb.log}
+import_dir=${IMPORT_DIR:-imports}
+collections=${COLLECTIONS:-flaky}
+
+mkdir -p "${import_dir}"
+mongod --dbpath="${dbpath}" --logpath="${dblogs}" --fork
+
+for collection in ${collections}; do
+	mongoimport --collection="${collection}" \
+		--file "${import_dir}/${collection}.json" --jsonArray
+done
+
+mongosh
+


### PR DESCRIPTION
Includes:
- A script to add JSON metrics to a JSON array in a format ready to be imported by [mongoimport](https://www.mongodb.com/developer/products/mongodb/mongoimport-guide/#import-many-json-documents).
- A script to query the existing metrics from a mongodb instance.
- Wiring in the Makefile to use the add metrics script to add metrics on a separate branch.

### All Submissions:

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
