### PR TITLE
CLOUDP-218740: Only run test-app push test on main

### DIFF
--- a/.github/workflows/build-test-app.yml
+++ b/.github/workflows/build-test-app.yml
@@ -5,6 +5,8 @@ on:
     paths:
       - 'test/app/**'
       - '!test/app/helm/**'
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
This should avoid **dependabot** changes such as #1290 trying to run a push event which requires credential access that **dependabot** should not have and writing to a registry that it should not be doing.

### All Submissions:

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
