### PR TITLE
CLOUDP-220809: Fix v1.7.3 rebuilds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ e2e-openshift-upgrade:
 .PHONY: manager
 manager: generate fmt vet ## Build manager binary
 	@echo "Building operator with version $(VERSION)"
-	 GOOS=$(TARGET_OS) GOARCH=$(TARGET_ARCH) go build -o bin/manager -ldflags="-X github.com/mongodb/mongodb-atlas-kubernetes/pkg/version.Version=$(VERSION)" cmd/manager/main.go
+	CGO_ENABLED=0 GOOS=$(TARGET_OS) GOARCH=$(TARGET_ARCH) go build -o bin/manager -ldflags="-X github.com/mongodb/mongodb-atlas-kubernetes/pkg/version.Version=$(VERSION)" cmd/manager/main.go
 
 .PHONY: run
 run: generate fmt vet manifests ## Run against the configured Kubernetes cluster in ~/.kube/config


### PR DESCRIPTION
This is support fix for old version 1.7.3 which turned out to be broken when we bumped Go to 1.20 in the `Dockerfile` but the `Makefile` was still depending on the container image libc version, via CGO being enabled.

This same fix is already included in version `1.8.0` BTW. Once this is merged to the `v1.7.3-branch` we will update the `v1.7.3` tag and rebuild that version to fix consumers.

### All Submissions:

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
