### PR TITLE
CLOUDP-218306: Pass on context properly

### DIFF
--- a/pkg/api/v1/atlasdatabaseuser_types.go
+++ b/pkg/api/v1/atlasdatabaseuser_types.go
@@ -186,10 +186,10 @@ func (p *AtlasDatabaseUser) UpdateStatus(conditions []status.Condition, options 
 	}
 }
 
-func (p *AtlasDatabaseUser) ReadPassword(kubeClient client.Client) (string, error) {
+func (p *AtlasDatabaseUser) ReadPassword(ctx context.Context, kubeClient client.Client) (string, error) {
 	if p.Spec.PasswordSecret != nil {
 		secret := &corev1.Secret{}
-		if err := kubeClient.Get(context.Background(), *p.PasswordSecretObjectKey(), secret); err != nil {
+		if err := kubeClient.Get(ctx, *p.PasswordSecretObjectKey(), secret); err != nil {
 			return "", err
 		}
 		p, exist := secret.Data["password"]
@@ -206,8 +206,8 @@ func (p *AtlasDatabaseUser) ReadPassword(kubeClient client.Client) (string, erro
 }
 
 // ToAtlas converts the AtlasDatabaseUser to native Atlas client format. Reads the password from the Secret
-func (p AtlasDatabaseUser) ToAtlas(kubeClient client.Client) (*mongodbatlas.DatabaseUser, error) {
-	password, err := p.ReadPassword(kubeClient)
+func (p AtlasDatabaseUser) ToAtlas(ctx context.Context, kubeClient client.Client) (*mongodbatlas.DatabaseUser, error) {
+	password, err := p.ReadPassword(ctx, kubeClient)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/api/v1/common/common.go
+++ b/pkg/api/v1/common/common.go
@@ -51,10 +51,10 @@ func (rn *ResourceRefNamespaced) GetObject(parentNamespace string) *client.Objec
 	return &key
 }
 
-func (rn *ResourceRefNamespaced) ReadPassword(kubeClient client.Client, parentNamespace string) (string, error) {
+func (rn *ResourceRefNamespaced) ReadPassword(ctx context.Context, kubeClient client.Client, parentNamespace string) (string, error) {
 	if rn != nil {
 		secret := &v1.Secret{}
-		if err := kubeClient.Get(context.Background(), *rn.GetObject(parentNamespace), secret); err != nil {
+		if err := kubeClient.Get(ctx, *rn.GetObject(parentNamespace), secret); err != nil {
 			return "", err
 		}
 		p, exist := secret.Data["password"]

--- a/pkg/api/v1/project/integration.go
+++ b/pkg/api/v1/project/integration.go
@@ -1,6 +1,8 @@
 package project
 
 import (
+	"context"
+
 	"go.mongodb.org/atlas/mongodbatlas"
 
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/api/v1/common"
@@ -59,7 +61,7 @@ type Integration struct {
 	Enabled bool `json:"enabled,omitempty"`
 }
 
-func (i Integration) ToAtlas(c client.Client, defaultNS string) (result *mongodbatlas.ThirdPartyIntegration, err error) {
+func (i Integration) ToAtlas(ctx context.Context, c client.Client, defaultNS string) (result *mongodbatlas.ThirdPartyIntegration, err error) {
 	result = &mongodbatlas.ThirdPartyIntegration{
 		Type:                     i.Type,
 		AccountID:                i.AccountID,
@@ -82,7 +84,7 @@ func (i Integration) ToAtlas(c client.Client, defaultNS string) (result *mongodb
 			return
 		}
 
-		*target, err = passwordField.ReadPassword(c, defaultNS)
+		*target, err = passwordField.ReadPassword(ctx, c, defaultNS)
 		storeError(err, errors)
 	}
 

--- a/pkg/controller/atlas/ip_access_list.go
+++ b/pkg/controller/atlas/ip_access_list.go
@@ -17,13 +17,13 @@ func CustomIPAccessListStatus(client *mongodbatlas.Client) IPAccessListStatus {
 
 	return func(ctx context.Context, projectID, entryValue string) (string, error) {
 		urlStr := fmt.Sprintf("/api/atlas/v1.0/groups/%s/accessList/%s/status", projectID, entryValue)
-		req, err := client.NewRequest(context.Background(), http.MethodGet, urlStr, nil)
+		req, err := client.NewRequest(ctx, http.MethodGet, urlStr, nil)
 		if err != nil {
 			return "", err
 		}
 
 		status := ipAccessListStatus{}
-		_, err = client.Do(context.Background(), req, &status)
+		_, err = client.Do(ctx, req, &status)
 		if err != nil {
 			return "", err
 		}

--- a/pkg/controller/atlasdatafederation/datafederation.go
+++ b/pkg/controller/atlasdatafederation/datafederation.go
@@ -1,7 +1,6 @@
 package atlasdatafederation
 
 import (
-	"context"
 	"net/http"
 
 	"go.mongodb.org/atlas/mongodbatlas"
@@ -27,7 +26,7 @@ func (r *AtlasDataFederationReconciler) ensureDataFederation(ctx *workflow.Conte
 		return workflow.Terminate(workflow.Internal, "can not convert DataFederation (operator -> atlas)")
 	}
 
-	atlasSpec, resp, err := ctx.Client.DataFederation.Get(context.Background(), projectID, operatorSpec.Name)
+	atlasSpec, resp, err := ctx.Client.DataFederation.Get(ctx.Context, projectID, operatorSpec.Name)
 	if err != nil {
 		if resp == nil {
 			return workflow.Terminate(workflow.Internal, err.Error())
@@ -37,7 +36,7 @@ func (r *AtlasDataFederationReconciler) ensureDataFederation(ctx *workflow.Conte
 			return workflow.Terminate(workflow.DataFederationNotCreatedInAtlas, err.Error())
 		}
 
-		_, _, err = ctx.Client.DataFederation.Create(context.Background(), projectID, dataFederationToAtlas)
+		_, _, err = ctx.Client.DataFederation.Create(ctx.Context, projectID, dataFederationToAtlas)
 		if err != nil {
 			return workflow.Terminate(workflow.DataFederationNotCreatedInAtlas, err.Error())
 		}
@@ -54,7 +53,7 @@ func (r *AtlasDataFederationReconciler) ensureDataFederation(ctx *workflow.Conte
 		return workflow.OK()
 	}
 
-	_, _, err = ctx.Client.DataFederation.Update(context.Background(), projectID, dataFederation.Spec.Name, dataFederationToAtlas, nil)
+	_, _, err = ctx.Client.DataFederation.Update(ctx.Context, projectID, dataFederation.Spec.Name, dataFederationToAtlas, nil)
 	if err != nil {
 		return workflow.Terminate(workflow.DataFederationNotUpdatedInAtlas, err.Error())
 	}

--- a/pkg/controller/atlasdatafederation/private_endpoint.go
+++ b/pkg/controller/atlasdatafederation/private_endpoint.go
@@ -15,7 +15,7 @@ func (r *AtlasDataFederationReconciler) ensurePrivateEndpoints(ctx *workflow.Con
 	projectID := project.ID()
 	specPEs := dataFederation.Spec.PrivateEndpoints
 
-	atlasPEs, err := getAllDataFederationPEs(clientDF, projectID)
+	atlasPEs, err := getAllDataFederationPEs(ctx.Context, clientDF, projectID)
 	if err != nil {
 		ctx.Log.Debugw("getAllDataFederationPEs error", "err", err.Error())
 	}
@@ -34,7 +34,7 @@ func syncPrivateEndpointsWithAtlas(ctx *workflow.Context, clientDF *DataFederati
 	ctx.Log.Debugw("Data Federation PEs to Create", "endpoints", endpointsToCreate)
 	for _, e := range endpointsToCreate {
 		endpoint := e.(mdbv1.DataFederationPE)
-		if _, _, err := clientDF.CreateOnePrivateEndpoint(context.Background(), projectID, endpoint); err != nil {
+		if _, _, err := clientDF.CreateOnePrivateEndpoint(ctx.Context, projectID, endpoint); err != nil {
 			return workflow.Terminate(workflow.Internal, err.Error())
 		}
 	}
@@ -43,7 +43,7 @@ func syncPrivateEndpointsWithAtlas(ctx *workflow.Context, clientDF *DataFederati
 	ctx.Log.Debugw("Data Federation PEs to Delete", "endpoints", endpointsToDelete)
 	for _, item := range endpointsToDelete {
 		endpoint := item.(mdbv1.DataFederationPE)
-		if _, _, err := clientDF.DeleteOnePrivateEndpoint(context.Background(), projectID, endpoint.EndpointID); err != nil {
+		if _, _, err := clientDF.DeleteOnePrivateEndpoint(ctx.Context, projectID, endpoint.EndpointID); err != nil {
 			return workflow.Terminate(workflow.Internal, err.Error())
 		}
 	}
@@ -51,8 +51,8 @@ func syncPrivateEndpointsWithAtlas(ctx *workflow.Context, clientDF *DataFederati
 	return workflow.OK()
 }
 
-func getAllDataFederationPEs(client *DataFederationServiceOp, projectID string) (endpoints []mdbv1.DataFederationPE, err error) {
-	endpoints, _, err = client.GetAllPrivateEndpoints(context.Background(), projectID)
+func getAllDataFederationPEs(ctx context.Context, client *DataFederationServiceOp, projectID string) (endpoints []mdbv1.DataFederationPE, err error) {
+	endpoints, _, err = client.GetAllPrivateEndpoints(ctx, projectID)
 	if endpoints == nil {
 		endpoints = make([]mdbv1.DataFederationPE, 0)
 	}

--- a/pkg/controller/atlasdeployment/atlasdeployment_controller.go
+++ b/pkg/controller/atlasdeployment/atlasdeployment_controller.go
@@ -86,7 +86,7 @@ func (r *AtlasDeploymentReconciler) Reconcile(context context.Context, req ctrl.
 	log := r.Log.With("atlasdeployment", req.NamespacedName)
 
 	deployment := &mdbv1.AtlasDeployment{}
-	result := customresource.PrepareResource(r.Client, req, deployment, log)
+	result := customresource.PrepareResource(context, r.Client, req, deployment, log)
 	if !result.IsOk() {
 		return result.ReconcileResult(), nil
 	}
@@ -511,7 +511,7 @@ func (r *AtlasDeploymentReconciler) deleteConnectionStrings(
 	deployment *mdbv1.AtlasDeployment,
 ) error {
 	// We always remove the connection secrets even if the deployment is not removed from Atlas
-	secrets, err := connectionsecret.ListByDeploymentName(r.Client, "", project.ID(), deployment.GetDeploymentName())
+	secrets, err := connectionsecret.ListByDeploymentName(context, r.Client, "", project.ID(), deployment.GetDeploymentName())
 	if err != nil {
 		return fmt.Errorf("failed to find connection secrets for the user: %w", err)
 	}

--- a/pkg/controller/atlasdeployment/serverless_deployment.go
+++ b/pkg/controller/atlasdeployment/serverless_deployment.go
@@ -1,7 +1,6 @@
 package atlasdeployment
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 
@@ -18,7 +17,7 @@ func (r *AtlasDeploymentReconciler) ensureServerlessInstanceState(workflowCtx *w
 		return nil, workflow.Terminate(workflow.ServerlessPrivateEndpointReady, "deployment spec is empty")
 	}
 	serverlessSpec := deployment.Spec.ServerlessSpec
-	atlasDeployment, resp, err := workflowCtx.Client.ServerlessInstances.Get(context.Background(), project.Status.ID, serverlessSpec.Name)
+	atlasDeployment, resp, err := workflowCtx.Client.ServerlessInstances.Get(workflowCtx.Context, project.Status.ID, serverlessSpec.Name)
 	if err != nil {
 		if resp == nil {
 			return atlasDeployment, workflow.Terminate(workflow.Internal, err.Error())
@@ -33,7 +32,7 @@ func (r *AtlasDeploymentReconciler) ensureServerlessInstanceState(workflowCtx *w
 			return atlasDeployment, workflow.Terminate(workflow.Internal, err.Error())
 		}
 		workflowCtx.Log.Infof("Serverless Instance %s doesn't exist in Atlas - creating", serverlessSpec.Name)
-		atlasDeployment, _, err = workflowCtx.Client.ServerlessInstances.Create(context.Background(), project.Status.ID, &mongodbatlas.ServerlessCreateRequestParams{
+		atlasDeployment, _, err = workflowCtx.Client.ServerlessInstances.Create(workflowCtx.Context, project.Status.ID, &mongodbatlas.ServerlessCreateRequestParams{
 			Name: serverlessSpec.Name,
 			ProviderSettings: &mongodbatlas.ServerlessProviderSettings{
 				BackingProviderName: serverlessSpec.ProviderSettings.BackingProviderName,
@@ -57,7 +56,7 @@ func (r *AtlasDeploymentReconciler) ensureServerlessInstanceState(workflowCtx *w
 			convertedDeployment.Tags = &[]*mongodbatlas.Tag{}
 		}
 		if !isTagsEqual(*(atlasDeployment.Tags), *(convertedDeployment.Tags)) {
-			atlasDeployment, _, err = workflowCtx.Client.ServerlessInstances.Update(context.Background(), project.Status.ID, serverlessSpec.Name, &mongodbatlas.ServerlessUpdateRequestParams{
+			atlasDeployment, _, err = workflowCtx.Client.ServerlessInstances.Update(workflowCtx.Context, project.Status.ID, serverlessSpec.Name, &mongodbatlas.ServerlessUpdateRequestParams{
 				Tag: convertedDeployment.Tags,
 				ServerlessBackupOptions: &mongodbatlas.ServerlessBackupOptions{
 					ServerlessContinuousBackupEnabled: &serverlessSpec.BackupOptions.ServerlessContinuousBackupEnabled,

--- a/pkg/controller/atlasfederatedauth/atlasfederated_auth_controller.go
+++ b/pkg/controller/atlasfederatedauth/atlasfederated_auth_controller.go
@@ -51,7 +51,7 @@ func (r *AtlasFederatedAuthReconciler) Reconcile(ctx context.Context, req ctrl.R
 	log := r.Log.With("atlasfederatedauth", req.NamespacedName)
 
 	fedauth := &mdbv1.AtlasFederatedAuth{}
-	result := customresource.PrepareResource(r.Client, req, fedauth, log)
+	result := customresource.PrepareResource(ctx, r.Client, req, fedauth, log)
 	if !result.IsOk() {
 		return result.ReconcileResult(), nil
 	}
@@ -159,7 +159,7 @@ func managedByAtlas(ctx context.Context, atlasClient *mongodbatlas.Client, orgID
 			return false, err
 		}
 
-		projectlist, err := prepareProjectList(atlasClient)
+		projectlist, err := prepareProjectList(ctx, atlasClient)
 		if err != nil {
 			return false, err
 		}

--- a/pkg/controller/atlasproject/alert_configurations.go
+++ b/pkg/controller/atlasproject/alert_configurations.go
@@ -62,48 +62,48 @@ func (r *AtlasProjectReconciler) readAlertConfigurationsSecretsData(project *mdb
 			nf := &ac.Notifications[j]
 			switch {
 			case nf.APITokenRef.Name != "":
-				token, res, err := readNotificationSecret(r.Client, nf.APITokenRef, projectNs, "APIToken")
+				token, res, err := readNotificationSecret(service.Context, r.Client, nf.APITokenRef, projectNs, "APIToken")
 				resourcesToWatch = append(resourcesToWatch, *res)
 				if err != nil {
 					return err
 				}
 				nf.SetAPIToken(token)
 			case nf.DatadogAPIKeyRef.Name != "":
-				token, res, err := readNotificationSecret(r.Client, nf.DatadogAPIKeyRef, projectNs, "DatadogAPIKey")
+				token, res, err := readNotificationSecret(service.Context, r.Client, nf.DatadogAPIKeyRef, projectNs, "DatadogAPIKey")
 				resourcesToWatch = append(resourcesToWatch, *res)
 				if err != nil {
 					return err
 				}
 				nf.SetDatadogAPIKey(token)
 			case nf.FlowdockAPITokenRef.Name != "":
-				token, res, err := readNotificationSecret(r.Client, nf.FlowdockAPITokenRef, projectNs, "FlowdockAPIToken")
+				token, res, err := readNotificationSecret(service.Context, r.Client, nf.FlowdockAPITokenRef, projectNs, "FlowdockAPIToken")
 				resourcesToWatch = append(resourcesToWatch, *res)
 				if err != nil {
 					return err
 				}
 				nf.SetFlowdockAPIToken(token)
 			case nf.OpsGenieAPIKeyRef.Name != "":
-				token, res, err := readNotificationSecret(r.Client, nf.OpsGenieAPIKeyRef, projectNs, "OpsGenieAPIKey")
+				token, res, err := readNotificationSecret(service.Context, r.Client, nf.OpsGenieAPIKeyRef, projectNs, "OpsGenieAPIKey")
 				resourcesToWatch = append(resourcesToWatch, *res)
 				if err != nil {
 					return err
 				}
 				nf.SetOpsGenieAPIKey(token)
 			case nf.ServiceKeyRef.Name != "":
-				token, res, err := readNotificationSecret(r.Client, nf.ServiceKeyRef, projectNs, "ServiceKey")
+				token, res, err := readNotificationSecret(service.Context, r.Client, nf.ServiceKeyRef, projectNs, "ServiceKey")
 				resourcesToWatch = append(resourcesToWatch, *res)
 				if err != nil {
 					return err
 				}
 				nf.SetServiceKey(token)
 			case nf.VictorOpsSecretRef.Name != "":
-				token, res, err := readNotificationSecret(r.Client, nf.VictorOpsSecretRef, projectNs, "VictorOpsAPIKey")
+				token, res, err := readNotificationSecret(service.Context, r.Client, nf.VictorOpsSecretRef, projectNs, "VictorOpsAPIKey")
 				resourcesToWatch = append(resourcesToWatch, *res)
 				if err != nil {
 					return err
 				}
 				nf.SetVictorOpsAPIKey(token)
-				token, res, err = readNotificationSecret(r.Client, nf.VictorOpsSecretRef, projectNs, "VictorOpsRoutingKey")
+				token, res, err = readNotificationSecret(service.Context, r.Client, nf.VictorOpsSecretRef, projectNs, "VictorOpsRoutingKey")
 				resourcesToWatch = append(resourcesToWatch, *res)
 				if err != nil {
 					return err
@@ -115,7 +115,7 @@ func (r *AtlasProjectReconciler) readAlertConfigurationsSecretsData(project *mdb
 	return nil
 }
 
-func readNotificationSecret(kubeClient client.Client, res common.ResourceRefNamespaced, parentNamespace string, fieldName string) (string, *watch.WatchedObject, error) {
+func readNotificationSecret(ctx context.Context, kubeClient client.Client, res common.ResourceRefNamespaced, parentNamespace string, fieldName string) (string, *watch.WatchedObject, error) {
 	secret := &v1.Secret{}
 	var ns string
 	if res.Namespace == "" {
@@ -127,7 +127,7 @@ func readNotificationSecret(kubeClient client.Client, res common.ResourceRefName
 	secretObj := client.ObjectKey{Name: res.Name, Namespace: ns}
 	obj := &watch.WatchedObject{ResourceKind: "Secret", Resource: secretObj}
 
-	if err := kubeClient.Get(context.Background(), secretObj, secret); err != nil {
+	if err := kubeClient.Get(ctx, secretObj, secret); err != nil {
 		return "", obj, err
 	}
 	val, exists := secret.Data[fieldName]

--- a/pkg/controller/atlasproject/atlasproject_controller.go
+++ b/pkg/controller/atlasproject/atlasproject_controller.go
@@ -80,7 +80,7 @@ func (r *AtlasProjectReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	log := r.Log.With("atlasproject", req.NamespacedName)
 
 	project := &mdbv1.AtlasProject{}
-	result := customresource.PrepareResource(r.Client, req, project, log)
+	result := customresource.PrepareResource(ctx, r.Client, req, project, log)
 	if !result.IsOk() {
 		return result.ReconcileResult(), nil
 	}

--- a/pkg/controller/atlasproject/auditing.go
+++ b/pkg/controller/atlasproject/auditing.go
@@ -1,7 +1,6 @@
 package atlasproject
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -111,12 +110,12 @@ func removeConfigurationType(atlas *mongodbatlas.Auditing) {
 }
 
 func fetchAuditing(ctx *workflow.Context, projectID string) (*mongodbatlas.Auditing, error) {
-	res, _, err := ctx.Client.Auditing.Get(context.Background(), projectID)
+	res, _, err := ctx.Client.Auditing.Get(ctx.Context, projectID)
 	return res, err
 }
 
 func patchAuditing(ctx *workflow.Context, projectID string, auditing *mongodbatlas.Auditing) error {
-	_, _, err := ctx.Client.Auditing.Configure(context.Background(), projectID, auditing)
+	_, _, err := ctx.Client.Auditing.Configure(ctx.Context, projectID, auditing)
 	return err
 }
 

--- a/pkg/controller/atlasproject/custom_roles.go
+++ b/pkg/controller/atlasproject/custom_roles.go
@@ -1,7 +1,6 @@
 package atlasproject
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -65,7 +64,7 @@ func ensureCustomRoles(workflowCtx *workflow.Context, project *v1.AtlasProject, 
 }
 
 func fetchCustomRoles(ctx *workflow.Context, projectID string) ([]v1.CustomRole, error) {
-	data, _, err := ctx.Client.CustomDBRoles.List(context.Background(), projectID, nil)
+	data, _, err := ctx.Client.CustomDBRoles.List(ctx.Context, projectID, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve custom roles from atlas: %w", err)
 	}
@@ -126,7 +125,7 @@ func deleteCustomRoles(ctx *workflow.Context, projectID string, toDelete map[str
 
 	statuses := map[string]status.CustomRole{}
 	for _, customRole := range toDelete {
-		_, err := ctx.Client.CustomDBRoles.Delete(context.Background(), projectID, customRole.Name)
+		_, err := ctx.Client.CustomDBRoles.Delete(ctx.Context, projectID, customRole.Name)
 
 		opStatus, errorMsg := evaluateOperation(err)
 		statuses[customRole.Name] = status.CustomRole{
@@ -153,7 +152,7 @@ func updateCustomRoles(ctx *workflow.Context, projectID string, toUpdate map[str
 		data := customRole.ToAtlas()
 		// Patch fails when sending the role name in the body, needs clarification with cloud team
 		data.RoleName = ""
-		_, _, err := ctx.Client.CustomDBRoles.Update(context.Background(), projectID, customRole.Name, data)
+		_, _, err := ctx.Client.CustomDBRoles.Update(ctx.Context, projectID, customRole.Name, data)
 
 		opStatus, errorMsg := evaluateOperation(err)
 
@@ -178,7 +177,7 @@ func createCustomRoles(ctx *workflow.Context, projectID string, toCreate map[str
 
 	statuses := map[string]status.CustomRole{}
 	for _, customRole := range toCreate {
-		_, _, err := ctx.Client.CustomDBRoles.Create(context.Background(), projectID, customRole.ToAtlas())
+		_, _, err := ctx.Client.CustomDBRoles.Create(ctx.Context, projectID, customRole.ToAtlas())
 
 		opStatus, errorMsg := evaluateOperation(err)
 

--- a/pkg/controller/atlasproject/private_endpoint_test.go
+++ b/pkg/controller/atlasproject/private_endpoint_test.go
@@ -1,6 +1,7 @@
 package atlasproject
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -85,7 +86,7 @@ func TestGetEndpointsNotInSpec(t *testing.T) {
 
 func TestCanPrivateEndpointReconcile(t *testing.T) {
 	t.Run("should return true when subResourceDeletionProtection is disabled", func(t *testing.T) {
-		result, err := canPrivateEndpointReconcile(&mongodbatlas.Client{}, false, &mdbv1.AtlasProject{})
+		result, err := canPrivateEndpointReconcile(context.Background(), &mongodbatlas.Client{}, false, &mdbv1.AtlasProject{})
 		require.NoError(t, err)
 		require.True(t, result)
 	})
@@ -93,7 +94,7 @@ func TestCanPrivateEndpointReconcile(t *testing.T) {
 	t.Run("should return error when unable to deserialize last applied configuration", func(t *testing.T) {
 		akoProject := &mdbv1.AtlasProject{}
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{wrong}"})
-		result, err := canPrivateEndpointReconcile(&mongodbatlas.Client{}, true, akoProject)
+		result, err := canPrivateEndpointReconcile(context.Background(), &mongodbatlas.Client{}, true, akoProject)
 		require.EqualError(t, err, "invalid character 'w' looking for beginning of object key string")
 		require.False(t, result)
 	})
@@ -108,7 +109,7 @@ func TestCanPrivateEndpointReconcile(t *testing.T) {
 		}
 		akoProject := &mdbv1.AtlasProject{}
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{}"})
-		result, err := canPrivateEndpointReconcile(&atlasClient, true, akoProject)
+		result, err := canPrivateEndpointReconcile(context.Background(), &atlasClient, true, akoProject)
 
 		require.EqualError(t, err, "failed to retrieve data")
 		require.False(t, result)
@@ -124,7 +125,7 @@ func TestCanPrivateEndpointReconcile(t *testing.T) {
 		}
 		akoProject := &mdbv1.AtlasProject{}
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{}"})
-		result, err := canPrivateEndpointReconcile(&atlasClient, true, akoProject)
+		result, err := canPrivateEndpointReconcile(context.Background(), &atlasClient, true, akoProject)
 
 		require.NoError(t, err)
 		require.True(t, result)
@@ -164,7 +165,7 @@ func TestCanPrivateEndpointReconcile(t *testing.T) {
 			},
 		}
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{\"privateEndpoints\":[{\"provider\":\"AWS\",\"region\":\"eu-west-2\"}]}"})
-		result, err := canPrivateEndpointReconcile(&atlasClient, true, akoProject)
+		result, err := canPrivateEndpointReconcile(context.Background(), &atlasClient, true, akoProject)
 
 		require.NoError(t, err)
 		require.True(t, result)
@@ -209,7 +210,7 @@ func TestCanPrivateEndpointReconcile(t *testing.T) {
 			},
 		}
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{\"privateEndpoints\":[{\"provider\":\"AWS\",\"region\":\"eu-west-2\"}]}"})
-		result, err := canPrivateEndpointReconcile(&atlasClient, true, akoProject)
+		result, err := canPrivateEndpointReconcile(context.Background(), &atlasClient, true, akoProject)
 
 		require.NoError(t, err)
 		require.True(t, result)
@@ -254,7 +255,7 @@ func TestCanPrivateEndpointReconcile(t *testing.T) {
 			},
 		}
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{\"privateEndpoints\":[{\"provider\":\"AWS\",\"region\":\"eu-west-2\"}]}"})
-		result, err := canPrivateEndpointReconcile(&atlasClient, true, akoProject)
+		result, err := canPrivateEndpointReconcile(context.Background(), &atlasClient, true, akoProject)
 
 		require.NoError(t, err)
 		require.False(t, result)

--- a/pkg/controller/atlasproject/project.go
+++ b/pkg/controller/atlasproject/project.go
@@ -1,7 +1,6 @@
 package atlasproject
 
 import (
-	"context"
 	"errors"
 
 	"go.mongodb.org/atlas/mongodbatlas"
@@ -14,7 +13,7 @@ import (
 // ensureProjectExists creates the project if it doesn't exist yet. Returns the project ID
 func (r *AtlasProjectReconciler) ensureProjectExists(ctx *workflow.Context, project *mdbv1.AtlasProject) (string, workflow.Result) {
 	// Try to find the project
-	p, _, err := ctx.Client.Projects.GetOneProjectByName(context.Background(), project.Spec.Name)
+	p, _, err := ctx.Client.Projects.GetOneProjectByName(ctx.Context, project.Spec.Name)
 	if err != nil {
 		ctx.Log.Infow("Error", "err", err.Error())
 		var apiError *mongodbatlas.ErrorResponse

--- a/pkg/controller/atlasproject/project_settings.go
+++ b/pkg/controller/atlasproject/project_settings.go
@@ -1,7 +1,6 @@
 package atlasproject
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -77,12 +76,12 @@ func patchSettings(ctx *workflow.Context, projectID string, spec *v1.ProjectSett
 		return err
 	}
 
-	_, _, err = ctx.Client.Projects.UpdateProjectSettings(context.Background(), projectID, specAsAtlas)
+	_, _, err = ctx.Client.Projects.UpdateProjectSettings(ctx.Context, projectID, specAsAtlas)
 	return err
 }
 
 func fetchSettings(ctx *workflow.Context, projectID string) (*v1.ProjectSettings, error) {
-	data, _, err := ctx.Client.Projects.GetProjectSettings(context.Background(), projectID)
+	data, _, err := ctx.Client.Projects.GetProjectSettings(ctx.Context, projectID)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/atlasproject/team_reconciler.go
+++ b/pkg/controller/atlasproject/team_reconciler.go
@@ -30,7 +30,7 @@ func (r *AtlasProjectReconciler) teamReconcile(
 	return func(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
 		log := r.Log.With("atlasteam", req.NamespacedName)
 
-		result := customresource.PrepareResource(r.Client, req, team, log)
+		result := customresource.PrepareResource(ctx, r.Client, req, team, log)
 		if !result.IsOk() {
 			return result.ReconcileResult(), nil
 		}

--- a/pkg/controller/atlasproject/x509_auth.go
+++ b/pkg/controller/atlasproject/x509_auth.go
@@ -24,7 +24,7 @@ func (r *AtlasProjectReconciler) ensureX509(ctx *workflow.Context, projectID str
 	var err error
 	authModes := project.Status.AuthModes
 	if key := project.X509SecretObjectKey(); key != nil {
-		specCert, err = readX509CertFromSecret(r.Client, *key, log)
+		specCert, err = readX509CertFromSecret(ctx.Context, r.Client, *key, log)
 		if err != nil {
 			return authModes, workflow.Terminate(workflow.Internal, err.Error())
 		}
@@ -32,7 +32,7 @@ func (r *AtlasProjectReconciler) ensureX509(ctx *workflow.Context, projectID str
 
 	if authModes.CheckAuthMode(authmode.X509) && specCert == "" {
 		log.Infow("Disable x509 auth", "projectID", projectID)
-		_, err := ctx.Client.X509AuthDBUsers.DisableCustomerX509(context.Background(), projectID)
+		_, err := ctx.Client.X509AuthDBUsers.DisableCustomerX509(ctx.Context, projectID)
 		if err != nil {
 			return authModes, workflow.Terminate(workflow.Internal, err.Error())
 		}
@@ -40,7 +40,7 @@ func (r *AtlasProjectReconciler) ensureX509(ctx *workflow.Context, projectID str
 		return authModes, workflow.OK()
 	}
 
-	customer, _, err := ctx.Client.X509AuthDBUsers.GetCurrentX509Conf(context.Background(), projectID)
+	customer, _, err := ctx.Client.X509AuthDBUsers.GetCurrentX509Conf(ctx.Context, projectID)
 	if err != nil {
 		return authModes, workflow.Terminate(workflow.Internal, err.Error())
 	}
@@ -52,7 +52,7 @@ func (r *AtlasProjectReconciler) ensureX509(ctx *workflow.Context, projectID str
 		log.Infow("Saving new x509 cert", "projectID", projectID)
 		log.Debugw("New customer", "conf", conf)
 
-		_, _, err := ctx.Client.X509AuthDBUsers.SaveConfiguration(context.Background(), projectID, &conf)
+		_, _, err := ctx.Client.X509AuthDBUsers.SaveConfiguration(ctx.Context, projectID, &conf)
 		if err != nil {
 			return authModes, workflow.Terminate(workflow.Internal, err.Error())
 		}
@@ -66,10 +66,10 @@ func (r *AtlasProjectReconciler) ensureX509(ctx *workflow.Context, projectID str
 	return authModes, workflow.OK()
 }
 
-func readX509CertFromSecret(kubeClient client.Client, secretRef client.ObjectKey, log *zap.SugaredLogger) (string, error) {
+func readX509CertFromSecret(ctx context.Context, kubeClient client.Client, secretRef client.ObjectKey, log *zap.SugaredLogger) (string, error) {
 	secret := &corev1.Secret{}
 	log.Debugw("reading X.509 certificate from the secret", "secretRef", secretRef)
-	if err := kubeClient.Get(context.Background(), secretRef, secret); err != nil {
+	if err := kubeClient.Get(ctx, secretRef, secret); err != nil {
 		return "", err
 	}
 

--- a/pkg/controller/connectionsecret/ensuresecret.go
+++ b/pkg/controller/connectionsecret/ensuresecret.go
@@ -44,13 +44,13 @@ type PrivateLinkConnURLs struct {
 
 // Ensure creates or updates the connection Secret for the specific cluster and db user. Returns the name of the Secret
 // created.
-func Ensure(client client.Client, namespace, projectName, projectID, clusterName string, data ConnectionData) (string, error) {
+func Ensure(ctx context.Context, client client.Client, namespace, projectName, projectID, clusterName string, data ConnectionData) (string, error) {
 	var getError error
 	s := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
 		Name:      formatSecretName(projectName, clusterName, data.DBUserName),
 		Namespace: namespace,
 	}}
-	if getError = client.Get(context.Background(), kube.ObjectKeyFromObject(s), s); getError != nil && !apiErrors.IsNotFound(getError) {
+	if getError = client.Get(ctx, kube.ObjectKeyFromObject(s), s); getError != nil && !apiErrors.IsNotFound(getError) {
 		return "", getError
 	}
 	if err := fillSecret(s, projectID, clusterName, data); err != nil {
@@ -58,10 +58,10 @@ func Ensure(client client.Client, namespace, projectName, projectID, clusterName
 	}
 	if getError != nil {
 		// Creating
-		return s.Name, client.Create(context.Background(), s)
+		return s.Name, client.Create(ctx, s)
 	}
 
-	return s.Name, client.Update(context.Background(), s)
+	return s.Name, client.Update(ctx, s)
 }
 
 func fillSecret(secret *corev1.Secret, projectID string, clusterName string, data ConnectionData) error {

--- a/pkg/controller/connectionsecret/ensuresecret_test.go
+++ b/pkg/controller/connectionsecret/ensuresecret_test.go
@@ -39,7 +39,7 @@ func TestEnsure(t *testing.T) {
 	t.Run("Create/Update", func(t *testing.T) {
 		data := dataForSecret()
 		// Create
-		_, err := Ensure(fakeClient, "testNs", "project1", "603e7bf38a94956835659ae5", "cluster1", data)
+		_, err := Ensure(context.Background(), fakeClient, "testNs", "project1", "603e7bf38a94956835659ae5", "cluster1", data)
 		assert.NoError(t, err)
 		validateSecret(t, fakeClient, "testNs", "project1", "603e7bf38a94956835659ae5", "cluster1", data)
 
@@ -47,7 +47,7 @@ func TestEnsure(t *testing.T) {
 		data.Password = "new$!"
 		data.SrvConnURL = "mongodb+srv://mongodb10.example.com:27017/?authSource=admin&tls=true"
 		data.ConnURL = "mongodb://mongodb10.example.com:27017,mongodb1.example.com:27017/?authSource=admin&tls=true"
-		_, err = Ensure(fakeClient, "testNs", "project1", "603e7bf38a94956835659ae5", "cluster1", data)
+		_, err = Ensure(context.Background(), fakeClient, "testNs", "project1", "603e7bf38a94956835659ae5", "cluster1", data)
 		assert.NoError(t, err)
 		validateSecret(t, fakeClient, "testNs", "project1", "603e7bf38a94956835659ae5", "cluster1", data)
 	})
@@ -55,12 +55,12 @@ func TestEnsure(t *testing.T) {
 	t.Run("Create two different secrets", func(t *testing.T) {
 		data := dataForSecret()
 		// First secret
-		_, err := Ensure(fakeClient, "testNs", "project1", "603e7bf38a94956835659ae5", "cluster1", data)
+		_, err := Ensure(context.Background(), fakeClient, "testNs", "project1", "603e7bf38a94956835659ae5", "cluster1", data)
 		assert.NoError(t, err)
 		validateSecret(t, fakeClient, "testNs", "project1", "603e7bf38a94956835659ae5", "cluster1", data)
 
 		// The second secret (the same cluster and user name but different projects)
-		_, err = Ensure(fakeClient, "testNs", "project2", "903e7bf38a94256835659ae5", "cluster1", data)
+		_, err = Ensure(context.Background(), fakeClient, "testNs", "project2", "903e7bf38a94256835659ae5", "cluster1", data)
 		assert.NoError(t, err)
 		validateSecret(t, fakeClient, "testNs", "project2", "903e7bf38a94256835659ae5", "cluster1", data)
 	})
@@ -70,7 +70,7 @@ func TestEnsure(t *testing.T) {
 		data.DBUserName = "#simple@user_for.test"
 
 		// Unfortunately, fake client doesn't validate object names, so this doesn't cover the validness of the produced name :(
-		_, err := Ensure(fakeClient, "otherNs", "my@project", "603e7bf38a94956835659ae5", "some cluster!", data)
+		_, err := Ensure(context.Background(), fakeClient, "otherNs", "my@project", "603e7bf38a94956835659ae5", "some cluster!", data)
 		assert.NoError(t, err)
 		s := validateSecret(t, fakeClient, "otherNs", "my-project", "603e7bf38a94956835659ae5", "some-cluster", data)
 		assert.Equal(t, "my-project-some-cluster-simple-user-for.test", s.Name)

--- a/pkg/controller/connectionsecret/listsecrets.go
+++ b/pkg/controller/connectionsecret/listsecrets.go
@@ -12,16 +12,16 @@ import (
 )
 
 // ListByDeploymentName returns all secrets in the specified namespace that have labels for 'projectID' and 'clusterName'
-func ListByDeploymentName(k8sClient client.Client, namespace, projectID, clusterName string) ([]corev1.Secret, error) {
-	return list(k8sClient, namespace, projectID, clusterName, "")
+func ListByDeploymentName(ctx context.Context, k8sClient client.Client, namespace, projectID, clusterName string) ([]corev1.Secret, error) {
+	return list(ctx, k8sClient, namespace, projectID, clusterName, "")
 }
 
 // ListByUserName returns all secrets in the specified namespace that have label for 'projectID' and data for 'userName'
-func ListByUserName(k8sClient client.Client, namespace, projectID, userName string) ([]corev1.Secret, error) {
-	return list(k8sClient, namespace, projectID, "", userName)
+func ListByUserName(ctx context.Context, k8sClient client.Client, namespace, projectID, userName string) ([]corev1.Secret, error) {
+	return list(ctx, k8sClient, namespace, projectID, "", userName)
 }
 
-func list(k8sClient client.Client, namespace, projectID, clusterName, dbUserName string) ([]corev1.Secret, error) {
+func list(ctx context.Context, k8sClient client.Client, namespace, projectID, clusterName, dbUserName string) ([]corev1.Secret, error) {
 	secrets := corev1.SecretList{}
 	var result []corev1.Secret
 	opts := &client.ListOptions{
@@ -34,7 +34,7 @@ func list(k8sClient client.Client, namespace, projectID, clusterName, dbUserName
 		opts.Namespace = namespace
 	}
 
-	if err := k8sClient.List(context.Background(), &secrets, opts); err != nil {
+	if err := k8sClient.List(ctx, &secrets, opts); err != nil {
 		return nil, err
 	}
 

--- a/pkg/controller/connectionsecret/listsecrets_test.go
+++ b/pkg/controller/connectionsecret/listsecrets_test.go
@@ -1,6 +1,7 @@
 package connectionsecret
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -23,54 +24,54 @@ func TestListConnectionSecrets(t *testing.T) {
 		// c1, user1
 		data := dataForSecret()
 		data.DBUserName = "user1"
-		_, err := Ensure(fakeClient, "testNs", "p1", "603e7bf38a94956835659ae5", "c1", data)
+		_, err := Ensure(context.Background(), fakeClient, "testNs", "p1", "603e7bf38a94956835659ae5", "c1", data)
 		assert.NoError(t, err)
 
 		// c1, user2
 		data = dataForSecret()
 		data.DBUserName = "user2"
-		_, err = Ensure(fakeClient, "testNs", "p1", "603e7bf38a94956835659ae5", "c1", data)
+		_, err = Ensure(context.Background(), fakeClient, "testNs", "p1", "603e7bf38a94956835659ae5", "c1", data)
 		assert.NoError(t, err)
 
 		// c2, user1
 		data = dataForSecret()
 		data.DBUserName = "user1"
-		_, err = Ensure(fakeClient, "testNs", "p1", "603e7bf38a94956835659ae5", "c2", data)
+		_, err = Ensure(context.Background(), fakeClient, "testNs", "p1", "603e7bf38a94956835659ae5", "c2", data)
 		assert.NoError(t, err)
 
 		// c1, user1 but different project (p2)
 		data = dataForSecret()
 		data.DBUserName = "user1"
-		_, err = Ensure(fakeClient, "testNs", "p2", "some-other-project-id", "c1", data)
+		_, err = Ensure(context.Background(), fakeClient, "testNs", "p2", "some-other-project-id", "c1", data)
 		assert.NoError(t, err)
 
 		// c1, user1 but different namespace
 		data = dataForSecret()
 		data.DBUserName = "user1"
-		_, err = Ensure(fakeClient, "otherNs", "p1", "603e7bf38a94956835659ae5", "c1", data)
+		_, err = Ensure(context.Background(), fakeClient, "otherNs", "p1", "603e7bf38a94956835659ae5", "c1", data)
 		assert.NoError(t, err)
 
-		secrets, err := ListByDeploymentName(fakeClient, "testNs", "603e7bf38a94956835659ae5", "c1")
+		secrets, err := ListByDeploymentName(context.Background(), fakeClient, "testNs", "603e7bf38a94956835659ae5", "c1")
 		assert.NoError(t, err)
 		assert.Equal(t, []string{"p1-c1-user1", "p1-c1-user2"}, getSecretsNames(secrets))
 
-		secrets, err = ListByDeploymentName(fakeClient, "testNs", "603e7bf38a94956835659ae5", "c2")
+		secrets, err = ListByDeploymentName(context.Background(), fakeClient, "testNs", "603e7bf38a94956835659ae5", "c2")
 		assert.NoError(t, err)
 		assert.Equal(t, []string{"p1-c2-user1"}, getSecretsNames(secrets))
 
-		secrets, err = ListByDeploymentName(fakeClient, "testNs", "603e7bf38a94956835659ae5", "c3")
+		secrets, err = ListByDeploymentName(context.Background(), fakeClient, "testNs", "603e7bf38a94956835659ae5", "c3")
 		assert.NoError(t, err)
 		assert.Len(t, getSecretsNames(secrets), 0)
 
-		secrets, err = ListByDeploymentName(fakeClient, "testNs", "non-existent-project-id", "c1")
+		secrets, err = ListByDeploymentName(context.Background(), fakeClient, "testNs", "non-existent-project-id", "c1")
 		assert.NoError(t, err)
 		assert.Len(t, getSecretsNames(secrets), 0)
 
-		secrets, err = ListByUserName(fakeClient, "testNs", "603e7bf38a94956835659ae5", "user1")
+		secrets, err = ListByUserName(context.Background(), fakeClient, "testNs", "603e7bf38a94956835659ae5", "user1")
 		assert.NoError(t, err)
 		assert.Equal(t, []string{"p1-c1-user1", "p1-c2-user1"}, getSecretsNames(secrets))
 
-		secrets, err = ListByUserName(fakeClient, "testNs", "603e7bf38a94956835659ae5", "user2")
+		secrets, err = ListByUserName(context.Background(), fakeClient, "testNs", "603e7bf38a94956835659ae5", "user2")
 		assert.NoError(t, err)
 		assert.Equal(t, []string{"p1-c1-user2"}, getSecretsNames(secrets))
 	})
@@ -83,10 +84,10 @@ func TestListConnectionSecrets(t *testing.T) {
 
 		data := dataForSecret()
 		data.DBUserName = "user1"
-		_, err := Ensure(fakeClient, "testNs", "#nice project!", "603e7bf38a94956835659ae5", "the cluster@thecompany.com/", data)
+		_, err := Ensure(context.Background(), fakeClient, "testNs", "#nice project!", "603e7bf38a94956835659ae5", "the cluster@thecompany.com/", data)
 		assert.NoError(t, err)
 
-		secrets, err := ListByDeploymentName(fakeClient, "testNs", "603e7bf38a94956835659ae5", "the cluster@thecompany.com/")
+		secrets, err := ListByDeploymentName(context.Background(), fakeClient, "testNs", "603e7bf38a94956835659ae5", "the cluster@thecompany.com/")
 		assert.NoError(t, err)
 		assert.Equal(t, []string{"nice-project-the-cluster-thecompany.com-user1"}, getSecretsNames(secrets))
 	})

--- a/pkg/controller/customresource/customresource.go
+++ b/pkg/controller/customresource/customresource.go
@@ -30,8 +30,8 @@ const (
 )
 
 // PrepareResource queries the Custom Resource 'request.NamespacedName' and populates the 'resource' pointer.
-func PrepareResource(client client.Client, request reconcile.Request, resource mdbv1.AtlasCustomResource, log *zap.SugaredLogger) workflow.Result {
-	err := client.Get(context.Background(), request.NamespacedName, resource)
+func PrepareResource(ctx context.Context, client client.Client, request reconcile.Request, resource mdbv1.AtlasCustomResource, log *zap.SugaredLogger) workflow.Result {
+	err := client.Get(ctx, request.NamespacedName, resource)
 	if err != nil {
 		if apiErrors.IsNotFound(err) {
 			// Request object not found, could have been deleted after reconcile request.

--- a/pkg/controller/statushandler/handler.go
+++ b/pkg/controller/statushandler/handler.go
@@ -19,7 +19,7 @@ func Update(ctx *workflow.Context, kubeClient client.Client, eventRecorder recor
 
 	resource.UpdateStatus(ctx.Conditions(), ctx.StatusOptions()...)
 
-	if err := patchUpdateStatus(kubeClient, resource); err != nil {
+	if err := patchUpdateStatus(ctx.Context, kubeClient, resource); err != nil {
 		if apiErrors.IsNotFound(err) {
 			ctx.Log.Infof("The resource %s no longer exists, not updating the status", kube.ObjectKey(resource.GetNamespace(), resource.GetName()))
 			return

--- a/pkg/controller/statushandler/patch.go
+++ b/pkg/controller/statushandler/patch.go
@@ -18,11 +18,11 @@ type patchValue struct {
 
 // patchUpdateStatus performs the JSONPatch patch update to the Atlas Custom Resource.
 // The "jsonPatch" merge allows to update only status field so is more
-func patchUpdateStatus(kubeClient client.Client, resource mdbv1.AtlasCustomResource) error {
-	return doPatch(kubeClient, resource, resource.GetStatus())
+func patchUpdateStatus(ctx context.Context, kubeClient client.Client, resource mdbv1.AtlasCustomResource) error {
+	return doPatch(ctx, kubeClient, resource, resource.GetStatus())
 }
 
-func doPatch(kubeClient client.Client, resource client.Object, statusValue interface{}) error {
+func doPatch(ctx context.Context, kubeClient client.Client, resource client.Object, statusValue interface{}) error {
 	payload := []patchValue{{
 		Op:    "replace",
 		Path:  "/status",
@@ -35,5 +35,5 @@ func doPatch(kubeClient client.Client, resource client.Object, statusValue inter
 	}
 
 	patch := client.RawPatch(types.JSONPatchType, data)
-	return kubeClient.Status().Patch(context.Background(), resource, patch)
+	return kubeClient.Status().Patch(ctx, resource, patch)
 }

--- a/pkg/controller/statushandler/patch_test.go
+++ b/pkg/controller/statushandler/patch_test.go
@@ -41,7 +41,7 @@ func Test_PatchUpdateStatus(t *testing.T) {
 	updatedProject := existingProject.DeepCopy()
 	updatedProject.Status.Common.Conditions[0].Status = corev1.ConditionTrue
 	updatedProject.Status.ID = "theId"
-	assert.NoError(t, patchUpdateStatus(fakeClient, updatedProject))
+	assert.NoError(t, patchUpdateStatus(context.Background(), fakeClient, updatedProject))
 
 	projectAfterPatch := &mdbv1.AtlasProject{}
 	assert.NoError(t, fakeClient.Get(context.Background(), kube.ObjectKeyFromObject(updatedProject), projectAfterPatch))

--- a/pkg/controller/watch/event_handler.go
+++ b/pkg/controller/watch/event_handler.go
@@ -17,15 +17,15 @@ import (
 type EventHandlerWithDelete struct {
 	handler.EnqueueRequestForObject
 	Controller interface {
-		Delete(e event.DeleteEvent) error
+		Delete(ctx context.Context, e event.DeleteEvent) error
 	}
 }
 
-func (d *EventHandlerWithDelete) Delete(_ context.Context, e event.DeleteEvent, _ workqueue.RateLimitingInterface) {
+func (d *EventHandlerWithDelete) Delete(ctx context.Context, e event.DeleteEvent, _ workqueue.RateLimitingInterface) {
 	objectKey := kube.ObjectKeyFromObject(e.Object)
 	log := zap.S().With("resource", objectKey)
 
-	if err := d.Controller.Delete(e); err != nil && k8serrors.IsNotFound(err) {
+	if err := d.Controller.Delete(ctx, e); err != nil && k8serrors.IsNotFound(err) {
 		log.Errorf("Object (%s) removed from Kubernetes, but controller could not delete it: %s", e.Object.GetObjectKind(), err)
 	}
 }

--- a/pkg/util/testutil/atlas.go
+++ b/pkg/util/testutil/atlas.go
@@ -1,3 +1,4 @@
+// TODO: move away from pkg, this code is only usable from tests
 package testutil
 
 import (
@@ -15,7 +16,7 @@ func WaitForAtlasDeploymentStateToNotBeReached(ctx context.Context, atlasClient 
 		case <-ctx.Done():
 			return true
 		default:
-			atlasDeployment, _, err := atlasClient.AdvancedClusters.Get(context.Background(), projectName, deploymentName)
+			atlasDeployment, _, err := atlasClient.AdvancedClusters.Get(ctx, projectName, deploymentName)
 			if err != nil {
 				return false
 			}
@@ -42,7 +43,7 @@ func WaitForAtlasDatabaseUserStateToNotBeReached(ctx context.Context, atlasClien
 		case <-ctx.Done():
 			return true
 		default:
-			atlasDatabaseUser, _, err := atlasClient.DatabaseUsers.Get(context.Background(), authDb, groupId, userName)
+			atlasDatabaseUser, _, err := atlasClient.DatabaseUsers.Get(ctx, authDb, groupId, userName)
 			if err != nil {
 				return false
 			}
@@ -69,7 +70,7 @@ func WaitForAtlasProjectStateToNotBeReached(ctx context.Context, atlasClient *mo
 		case <-ctx.Done():
 			return true
 		default:
-			project, _, err := atlasClient.Projects.GetOneProjectByName(context.Background(), projectName)
+			project, _, err := atlasClient.Projects.GetOneProjectByName(ctx, projectName)
 			if err != nil {
 				return false
 			}

--- a/pkg/util/testutil/conditions.go
+++ b/pkg/util/testutil/conditions.go
@@ -1,3 +1,4 @@
+// TODO: move away from pkg, this code is only usable from tests
 package testutil
 
 import (

--- a/pkg/util/testutil/customresources.go
+++ b/pkg/util/testutil/customresources.go
@@ -1,3 +1,4 @@
+// TODO: move away from pkg, this code is only usable from tests
 package testutil
 
 import (
@@ -14,7 +15,8 @@ import (
 )
 
 func CheckCondition(k8sClient client.Client, createdResource mdbv1.AtlasCustomResource, expectedCondition status.Condition, checksIfFail ...func(mdbv1.AtlasCustomResource)) bool {
-	if ok := ReadAtlasResource(k8sClient, createdResource); !ok {
+	// This is only used from test code
+	if ok := ReadAtlasResource(context.Background(), k8sClient, createdResource); !ok {
 		return false
 	}
 	// Atlas Operator hasn't started working yet
@@ -34,8 +36,8 @@ func CheckCondition(k8sClient client.Client, createdResource mdbv1.AtlasCustomRe
 	return true
 }
 
-func ReadAtlasResource(k8sClient client.Client, createdResource mdbv1.AtlasCustomResource) bool {
-	if err := k8sClient.Get(context.Background(), kube.ObjectKeyFromObject(createdResource), createdResource); err != nil {
+func ReadAtlasResource(ctx context.Context, k8sClient client.Client, createdResource mdbv1.AtlasCustomResource) bool {
+	if err := k8sClient.Get(ctx, kube.ObjectKeyFromObject(createdResource), createdResource); err != nil {
 		// The only error we tolerate is "not found"
 		gomega.Expect(apiErrors.IsNotFound(err)).To(gomega.BeTrue(), fmt.Sprintf("Unexpected error: %s", err))
 		return false

--- a/pkg/util/testutil/events.go
+++ b/pkg/util/testutil/events.go
@@ -1,3 +1,4 @@
+// TODO: move away from pkg, this code is only usable from tests
 package testutil
 
 import (

--- a/pkg/util/testutil/ipaccesslist_matcher.go
+++ b/pkg/util/testutil/ipaccesslist_matcher.go
@@ -1,3 +1,4 @@
+// TODO: move away from pkg, this code is only usable from tests
 package testutil
 
 import (

--- a/pkg/util/testutil/maintenancewindow_matcher.go
+++ b/pkg/util/testutil/maintenancewindow_matcher.go
@@ -1,3 +1,4 @@
+// TODO: move away from pkg, this code is only usable from tests
 package testutil
 
 import (

--- a/test/e2e/db_users_test.go
+++ b/test/e2e/db_users_test.go
@@ -26,7 +26,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var _ = Describe("Operator watch all namespace should create connection secrets for database users in any namaspace", Label("deployment-ns"), func() {
+var _ = Describe("Operator watch all namespace should create connection secrets for database users in any namespace", Label("deployment-ns"), func() {
 	var testData *model.TestDataProvider
 	secondNamespace := "second-namespace"
 

--- a/test/int/project_test.go
+++ b/test/int/project_test.go
@@ -356,7 +356,7 @@ var _ = Describe("AtlasProject", Label("int", "AtlasProject"), func() {
 				return testutil.CheckCondition(k8sClient, createdProject, status.TrueCondition(status.ReadyType))
 			}).WithTimeout(ProjectCreationTimeout).WithPolling(interval).Should(BeTrue())
 
-			Expect(testutil.ReadAtlasResource(k8sClient, createdProject)).To(BeTrue())
+			Expect(testutil.ReadAtlasResource(context.Background(), k8sClient, createdProject)).To(BeTrue())
 			Expect(createdProject.Status.Conditions).To(ContainElement(testutil.MatchCondition(status.TrueCondition(status.ProjectReadyType))))
 
 			// Atlas


### PR DESCRIPTION
Make sure all contexts are **properly propagated on production code paths**:
- Replace `context.Background()`(or `context.TODO()`) in production code with the pre-exiting context.
- Propagate the pre-existing context down one or more times to where it is needed.
- Add a timeout context on invocations from commands, currently only at `post-install` I believe.
- Fix all calling sites affected by parameter signature changes when adding the context being passed down. This includes test code invocations, using `context.TODO()` as the argument on those cases.

### All Submissions:

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
