### PR TITLE
CLOUDP-221636: Consolidate on context.Background

### DIFF
--- a/pkg/controller/atlas/provider_test.go
+++ b/pkg/controller/atlas/provider_test.go
@@ -46,7 +46,7 @@ func TestProvider_Client(t *testing.T) {
 	t.Run("should return Atlas API client and organization id using global secret", func(t *testing.T) {
 		p := NewProductionProvider("https://cloud.mongodb.com/", client.ObjectKey{Name: "api-secret", Namespace: "default"}, k8sClient)
 
-		c, id, err := p.Client(context.TODO(), nil, zaptest.NewLogger(t).Sugar())
+		c, id, err := p.Client(context.Background(), nil, zaptest.NewLogger(t).Sugar())
 		assert.NoError(t, err)
 		assert.Equal(t, "1234567890", id)
 		assert.NotNil(t, c)
@@ -55,7 +55,7 @@ func TestProvider_Client(t *testing.T) {
 	t.Run("should return Atlas API client and organization id using connection secret", func(t *testing.T) {
 		p := NewProductionProvider("https://cloud.mongodb.com/", client.ObjectKey{Name: "global-secret", Namespace: "default"}, k8sClient)
 
-		c, id, err := p.Client(context.TODO(), &client.ObjectKey{Name: "api-secret", Namespace: "default"}, zaptest.NewLogger(t).Sugar())
+		c, id, err := p.Client(context.Background(), &client.ObjectKey{Name: "api-secret", Namespace: "default"}, zaptest.NewLogger(t).Sugar())
 		assert.NoError(t, err)
 		assert.Equal(t, "1234567890", id)
 		assert.NotNil(t, c)

--- a/pkg/controller/atlasproject/auditing_test.go
+++ b/pkg/controller/atlasproject/auditing_test.go
@@ -326,5 +326,5 @@ func TestAuditingInSync(t *testing.T) {
 }
 
 func testWorkFlowContext(client mongodbatlas.Client) *workflow.Context {
-	return &workflow.Context{Client: &client, Context: context.TODO()}
+	return &workflow.Context{Client: &client, Context: context.Background()}
 }

--- a/pkg/controller/atlasproject/cloud_provider_integration_test.go
+++ b/pkg/controller/atlasproject/cloud_provider_integration_test.go
@@ -27,7 +27,7 @@ func TestSyncCloudProviderIntegration(t *testing.T) {
 		}
 		workflowCtx := &workflow.Context{
 			Client:  &atlasClient,
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 		result, err := syncCloudProviderIntegration(workflowCtx, "projectID", []mdbv1.CloudProviderIntegration{})
 		assert.EqualError(t, err, "unable to fetch cloud provider access from Atlas: service unavailable")
@@ -104,7 +104,7 @@ func TestSyncCloudProviderIntegration(t *testing.T) {
 		}
 		workflowCtx := &workflow.Context{
 			Client:  &atlasClient,
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 
 		result, err := syncCloudProviderIntegration(workflowCtx, "projectID", cpas)
@@ -159,7 +159,7 @@ func TestSyncCloudProviderIntegration(t *testing.T) {
 		}
 		workflowCtx := &workflow.Context{
 			Client:  &atlasClient,
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 
 		result, err := syncCloudProviderIntegration(workflowCtx, "projectID", cpas)
@@ -212,7 +212,7 @@ func TestSyncCloudProviderIntegration(t *testing.T) {
 		workflowCtx := &workflow.Context{
 			Client:  &atlasClient,
 			Log:     zaptest.NewLogger(t).Sugar(),
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 
 		result, err := syncCloudProviderIntegration(workflowCtx, "projectID", cpas)
@@ -776,7 +776,7 @@ func TestCreateCloudProviderIntegration(t *testing.T) {
 		}
 		workflowCtx := &workflow.Context{
 			Client:  &atlasClient,
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 
 		assert.Equal(t, expected, createCloudProviderAccess(workflowCtx, "projectID", cpa))
@@ -804,7 +804,7 @@ func TestCreateCloudProviderIntegration(t *testing.T) {
 		workflowCtx := &workflow.Context{
 			Client:  &atlasClient,
 			Log:     zaptest.NewLogger(t).Sugar(),
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 
 		assert.Equal(t, expected, createCloudProviderAccess(workflowCtx, "projectID", cpa))
@@ -849,7 +849,7 @@ func TestAuthorizeCloudProviderIntegration(t *testing.T) {
 		}
 		workflowCtx := &workflow.Context{
 			Client:  &atlasClient,
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 
 		assert.Equal(t, expected, authorizeCloudProviderAccess(workflowCtx, "projectID", cpa))
@@ -885,7 +885,7 @@ func TestAuthorizeCloudProviderIntegration(t *testing.T) {
 		workflowCtx := &workflow.Context{
 			Client:  &atlasClient,
 			Log:     zaptest.NewLogger(t).Sugar(),
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 
 		assert.Equal(t, expected, authorizeCloudProviderAccess(workflowCtx, "projectID", cpa))
@@ -914,7 +914,7 @@ func TestDeleteCloudProviderIntegration(t *testing.T) {
 		}
 		workflowCtx := &workflow.Context{
 			Client:  &atlasClient,
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 
 		deleteCloudProviderAccess(workflowCtx, "projectID", cpa)
@@ -941,7 +941,7 @@ func TestDeleteCloudProviderIntegration(t *testing.T) {
 		workflowCtx := &workflow.Context{
 			Client:  &atlasClient,
 			Log:     zaptest.NewLogger(t).Sugar(),
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 
 		deleteCloudProviderAccess(workflowCtx, "projectID", cpa)
@@ -953,7 +953,7 @@ func TestCanCloudProviderIntegrationReconcile(t *testing.T) {
 	t.Run("should return true when subResourceDeletionProtection is disabled", func(t *testing.T) {
 		workflowCtx := &workflow.Context{
 			Client:  &mongodbatlas.Client{},
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 		result, err := canCloudProviderIntegrationReconcile(workflowCtx, false, &mdbv1.AtlasProject{})
 		assert.NoError(t, err)
@@ -964,7 +964,7 @@ func TestCanCloudProviderIntegrationReconcile(t *testing.T) {
 		akoProject := &mdbv1.AtlasProject{}
 		workflowCtx := &workflow.Context{
 			Client:  &mongodbatlas.Client{},
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{wrong}"})
 		result, err := canCloudProviderIntegrationReconcile(workflowCtx, true, akoProject)
@@ -984,7 +984,7 @@ func TestCanCloudProviderIntegrationReconcile(t *testing.T) {
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{}"})
 		workflowCtx := &workflow.Context{
 			Client:  &atlasClient,
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 		result, err := canCloudProviderIntegrationReconcile(workflowCtx, true, akoProject)
 
@@ -1006,7 +1006,7 @@ func TestCanCloudProviderIntegrationReconcile(t *testing.T) {
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{}"})
 		workflowCtx := &workflow.Context{
 			Client:  &atlasClient,
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 		result, err := canCloudProviderIntegrationReconcile(workflowCtx, true, akoProject)
 
@@ -1042,7 +1042,7 @@ func TestCanCloudProviderIntegrationReconcile(t *testing.T) {
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{\"cloudProviderIntegrations\":[{\"providerName\":\"AWS\",\"iamAssumedRoleArn\":\"arn1\"}]}"})
 		workflowCtx := &workflow.Context{
 			Client:  &atlasClient,
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 		result, err := canCloudProviderIntegrationReconcile(workflowCtx, true, akoProject)
 
@@ -1086,7 +1086,7 @@ func TestCanCloudProviderIntegrationReconcile(t *testing.T) {
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{\"cloudProviderIntegrations\":[{\"providerName\":\"AWS\",\"iamAssumedRoleArn\":\"arn1\"}]}"})
 		workflowCtx := &workflow.Context{
 			Client:  &atlasClient,
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 		result, err := canCloudProviderIntegrationReconcile(workflowCtx, true, akoProject)
 
@@ -1121,7 +1121,7 @@ func TestCanCloudProviderIntegrationReconcile(t *testing.T) {
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{\"cloudProviderIntegrations\":[{\"providerName\":\"AWS\",\"iamAssumedRoleArn\":\"arn1\"}]}"})
 		workflowCtx := &workflow.Context{
 			Client:  &atlasClient,
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 		result, err := canCloudProviderIntegrationReconcile(workflowCtx, true, akoProject)
 
@@ -1165,7 +1165,7 @@ func TestCanCloudProviderIntegrationReconcile(t *testing.T) {
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{\"cloudProviderIntegrations\":[{\"providerName\":\"AWS\",\"iamAssumedRoleArn\":\"arn1\"}]}"})
 		workflowCtx := &workflow.Context{
 			Client:  &atlasClient,
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 		result, err := canCloudProviderIntegrationReconcile(workflowCtx, true, akoProject)
 
@@ -1209,7 +1209,7 @@ func TestCanCloudProviderIntegrationReconcile(t *testing.T) {
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{\"cloudProviderAccessRoles\":[{\"providerName\":\"AWS\",\"iamAssumedRoleArn\":\"arn1\"}]}"})
 		workflowCtx := &workflow.Context{
 			Client:  &atlasClient,
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 		result, err := canCloudProviderIntegrationReconcile(workflowCtx, true, akoProject)
 
@@ -1231,7 +1231,7 @@ func TestEnsureCloudProviderIntegration(t *testing.T) {
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{}"})
 		workflowCtx := &workflow.Context{
 			Client:  &atlasClient,
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 		result := ensureCloudProviderIntegration(workflowCtx, akoProject, true)
 
@@ -1274,7 +1274,7 @@ func TestEnsureCloudProviderIntegration(t *testing.T) {
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{\"cloudProviderIntegrations\":[{\"providerName\":\"AWS\",\"iamAssumedRoleArn\":\"arn1\"}]}"})
 		workflowCtx := &workflow.Context{
 			Client:  &atlasClient,
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 		result := ensureCloudProviderIntegration(workflowCtx, akoProject, true)
 
@@ -1290,7 +1290,7 @@ func TestEnsureCloudProviderIntegration(t *testing.T) {
 
 	t.Run("should return earlier when there are not items to operate", func(t *testing.T) {
 		akoProject := &mdbv1.AtlasProject{}
-		workflowCtx := &workflow.Context{Context: context.TODO()}
+		workflowCtx := &workflow.Context{Context: context.Background()}
 		result := ensureCloudProviderIntegration(workflowCtx, akoProject, false)
 		assert.Equal(
 			t,
@@ -1323,7 +1323,7 @@ func TestEnsureCloudProviderIntegration(t *testing.T) {
 		}
 		workflowCtx := &workflow.Context{
 			Client:  &atlasClient,
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 		result := ensureCloudProviderIntegration(workflowCtx, akoProject, false)
 		assert.Equal(
@@ -1407,7 +1407,7 @@ func TestEnsureCloudProviderIntegration(t *testing.T) {
 		}
 		workflowCtx := &workflow.Context{
 			Client:  &atlasClient,
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 		result := ensureCloudProviderIntegration(workflowCtx, akoProject, false)
 		assert.Equal(
@@ -1468,7 +1468,7 @@ func TestEnsureCloudProviderIntegration(t *testing.T) {
 		}
 		workflowCtx := &workflow.Context{
 			Client:  &atlasClient,
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 		result := ensureCloudProviderIntegration(workflowCtx, akoProject, false)
 		assert.Equal(
@@ -1533,7 +1533,7 @@ func TestEnsureCloudProviderIntegration(t *testing.T) {
 		}
 		workflowCtx := workflow.Context{
 			Client:  &atlasClient,
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 		result := ensureCloudProviderIntegration(&workflowCtx, akoProject, false)
 		assert.Equal(

--- a/pkg/controller/atlasproject/custom_roles_test.go
+++ b/pkg/controller/atlasproject/custom_roles_test.go
@@ -219,7 +219,7 @@ func TestCanCustomRolesReconcile(t *testing.T) {
 	t.Run("should return true when subResourceDeletionProtection is disabled", func(t *testing.T) {
 		workflowCtx := workflow.Context{
 			Client:  &mongodbatlas.Client{},
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 		result, err := canCustomRolesReconcile(&workflowCtx, false, &mdbv1.AtlasProject{})
 		assert.NoError(t, err)
@@ -231,7 +231,7 @@ func TestCanCustomRolesReconcile(t *testing.T) {
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{wrong}"})
 		workflowCtx := &workflow.Context{
 			Client:  &mongodbatlas.Client{},
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 		result, err := canCustomRolesReconcile(workflowCtx, true, akoProject)
 		assert.EqualError(t, err, "invalid character 'w' looking for beginning of object key string")
@@ -250,7 +250,7 @@ func TestCanCustomRolesReconcile(t *testing.T) {
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{}"})
 		workflowCtx := &workflow.Context{
 			Client:  &atlasClient,
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 		result, err := canCustomRolesReconcile(workflowCtx, true, akoProject)
 
@@ -270,7 +270,7 @@ func TestCanCustomRolesReconcile(t *testing.T) {
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{}"})
 		workflowCtx := &workflow.Context{
 			Client:  &atlasClient,
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 		result, err := canCustomRolesReconcile(workflowCtx, true, akoProject)
 
@@ -290,7 +290,7 @@ func TestCanCustomRolesReconcile(t *testing.T) {
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{}"})
 		workflowCtx := &workflow.Context{
 			Client:  &atlasClient,
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 		result, err := canCustomRolesReconcile(workflowCtx, true, akoProject)
 
@@ -346,7 +346,7 @@ func TestCanCustomRolesReconcile(t *testing.T) {
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: `{"customRoles":[{"name":"testRole1","actions":[{"name":"INSERT","resources":[{"database":"testDB","collection":"testCollection"}]}]}]}`})
 		workflowCtx := &workflow.Context{
 			Client:  &atlasClient,
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 		result, err := canCustomRolesReconcile(workflowCtx, true, akoProject)
 
@@ -402,7 +402,7 @@ func TestCanCustomRolesReconcile(t *testing.T) {
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: `{"customRoles":[{"name":"testRole1","actions":[{"name":"INSERT","resources":[{"database":"testDB","collection":"testCollection"}]}]}]}`})
 		workflowCtx := &workflow.Context{
 			Client:  &atlasClient,
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 		result, err := canCustomRolesReconcile(workflowCtx, true, akoProject)
 
@@ -460,7 +460,7 @@ func TestCanCustomRolesReconcile(t *testing.T) {
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: `{"customRoles":[{"name":"testRole1","actions":[{"name":"INSERT","resources":[{"cluster":false,"database":"testDB","collection":"testCollection"}]}]}]}`})
 		workflowCtx := &workflow.Context{
 			Client:  &atlasClient,
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 		result, err := canCustomRolesReconcile(workflowCtx, true, akoProject)
 
@@ -482,7 +482,7 @@ func TestEnsureCustomRoles(t *testing.T) {
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{}"})
 		workflowCtx := &workflow.Context{
 			Client:  &atlasClient,
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 		result := ensureCustomRoles(workflowCtx, akoProject, true)
 
@@ -539,7 +539,7 @@ func TestEnsureCustomRoles(t *testing.T) {
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: `{"customRoles":[{"name":"testRole1","actions":[{"name":"INSERT","resources":[{"cluster":false,"database":"testDB","collection":"testCollection"}]}]}]}`})
 		workflowCtx := &workflow.Context{
 			Client:  &atlasClient,
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 		result := ensureCustomRoles(workflowCtx, akoProject, true)
 

--- a/pkg/controller/atlasproject/encryption_at_rest_test.go
+++ b/pkg/controller/atlasproject/encryption_at_rest_test.go
@@ -25,7 +25,7 @@ func TestCanEncryptionAtRestReconcile(t *testing.T) {
 	t.Run("should return true when subResourceDeletionProtection is disabled", func(t *testing.T) {
 		workflowCtx := &workflow.Context{
 			Client:  &mongodbatlas.Client{},
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 		result, err := canEncryptionAtRestReconcile(workflowCtx, false, &mdbv1.AtlasProject{})
 		require.NoError(t, err)
@@ -37,7 +37,7 @@ func TestCanEncryptionAtRestReconcile(t *testing.T) {
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{wrong}"})
 		workflowCtx := &workflow.Context{
 			Client:  &mongodbatlas.Client{},
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 		result, err := canEncryptionAtRestReconcile(workflowCtx, true, akoProject)
 		require.EqualError(t, err, "invalid character 'w' looking for beginning of object key string")
@@ -56,7 +56,7 @@ func TestCanEncryptionAtRestReconcile(t *testing.T) {
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{}"})
 		workflowCtx := &workflow.Context{
 			Client:  &atlasClient,
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 		result, err := canEncryptionAtRestReconcile(workflowCtx, true, akoProject)
 
@@ -86,7 +86,7 @@ func TestCanEncryptionAtRestReconcile(t *testing.T) {
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{}"})
 		workflowCtx := &workflow.Context{
 			Client:  &atlasClient,
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 		result, err := canEncryptionAtRestReconcile(workflowCtx, true, akoProject)
 
@@ -138,7 +138,7 @@ func TestCanEncryptionAtRestReconcile(t *testing.T) {
 		)
 		workflowCtx := &workflow.Context{
 			Client:  &atlasClient,
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 		result, err := canEncryptionAtRestReconcile(workflowCtx, true, akoProject)
 
@@ -191,7 +191,7 @@ func TestCanEncryptionAtRestReconcile(t *testing.T) {
 		)
 		workflowCtx := &workflow.Context{
 			Client:  &atlasClient,
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 		result, err := canEncryptionAtRestReconcile(workflowCtx, true, akoProject)
 
@@ -244,7 +244,7 @@ func TestCanEncryptionAtRestReconcile(t *testing.T) {
 		)
 		workflowCtx := &workflow.Context{
 			Client:  &atlasClient,
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 		result, err := canEncryptionAtRestReconcile(workflowCtx, true, akoProject)
 
@@ -266,7 +266,7 @@ func TestEnsureEncryptionAtRest(t *testing.T) {
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{}"})
 		workflowCtx := &workflow.Context{
 			Client:  &atlasClient,
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 		reconciler := &AtlasProjectReconciler{
 			SubObjectDeletionProtection: true,
@@ -320,7 +320,7 @@ func TestEnsureEncryptionAtRest(t *testing.T) {
 		)
 		workflowCtx := &workflow.Context{
 			Client:  &atlasClient,
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 		secretData := map[string][]byte{
 			"AccessKeyID":         []byte("testAccessKeyID"),

--- a/pkg/controller/atlasproject/integrations_test.go
+++ b/pkg/controller/atlasproject/integrations_test.go
@@ -53,7 +53,7 @@ func TestCanIntegrationsReconcile(t *testing.T) {
 	t.Run("should return true when subResourceDeletionProtection is disabled", func(t *testing.T) {
 		workflowCtx := &workflow.Context{
 			Client:  &mongodbatlas.Client{},
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 		result, err := canIntegrationsReconcile(workflowCtx, false, &mdbv1.AtlasProject{})
 		require.NoError(t, err)
@@ -65,7 +65,7 @@ func TestCanIntegrationsReconcile(t *testing.T) {
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{wrong}"})
 		workflowCtx := &workflow.Context{
 			Client:  &mongodbatlas.Client{},
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 		result, err := canIntegrationsReconcile(workflowCtx, true, akoProject)
 		require.EqualError(t, err, "invalid character 'w' looking for beginning of object key string")
@@ -84,7 +84,7 @@ func TestCanIntegrationsReconcile(t *testing.T) {
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{}"})
 		workflowCtx := &workflow.Context{
 			Client:  &atlasClient,
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 		result, err := canIntegrationsReconcile(workflowCtx, true, akoProject)
 
@@ -104,7 +104,7 @@ func TestCanIntegrationsReconcile(t *testing.T) {
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{}"})
 		workflowCtx := &workflow.Context{
 			Client:  &atlasClient,
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 		result, err := canIntegrationsReconcile(workflowCtx, true, akoProject)
 
@@ -150,7 +150,7 @@ func TestCanIntegrationsReconcile(t *testing.T) {
 		)
 		workflowCtx := &workflow.Context{
 			Client:  &atlasClient,
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 		result, err := canIntegrationsReconcile(workflowCtx, true, akoProject)
 
@@ -196,7 +196,7 @@ func TestCanIntegrationsReconcile(t *testing.T) {
 		)
 		workflowCtx := &workflow.Context{
 			Client:  &atlasClient,
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 		result, err := canIntegrationsReconcile(workflowCtx, true, akoProject)
 
@@ -242,7 +242,7 @@ func TestCanIntegrationsReconcile(t *testing.T) {
 		)
 		workflowCtx := &workflow.Context{
 			Client:  &atlasClient,
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 		result, err := canIntegrationsReconcile(workflowCtx, true, akoProject)
 

--- a/pkg/controller/atlasproject/ipaccess_list_test.go
+++ b/pkg/controller/atlasproject/ipaccess_list_test.go
@@ -41,7 +41,7 @@ func TestFilterActiveIPAccessLists(t *testing.T) {
 
 func TestCanIPAccessListReconcile(t *testing.T) {
 	t.Run("should return true when subResourceDeletionProtection is disabled", func(t *testing.T) {
-		result, err := canIPAccessListReconcile(context.TODO(), &mongodbatlas.Client{}, false, &mdbv1.AtlasProject{})
+		result, err := canIPAccessListReconcile(context.Background(), &mongodbatlas.Client{}, false, &mdbv1.AtlasProject{})
 		require.NoError(t, err)
 		require.True(t, result)
 	})
@@ -49,7 +49,7 @@ func TestCanIPAccessListReconcile(t *testing.T) {
 	t.Run("should return error when unable to deserialize last applied configuration", func(t *testing.T) {
 		akoProject := &mdbv1.AtlasProject{}
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{wrong}"})
-		result, err := canIPAccessListReconcile(context.TODO(), &mongodbatlas.Client{}, true, akoProject)
+		result, err := canIPAccessListReconcile(context.Background(), &mongodbatlas.Client{}, true, akoProject)
 		require.EqualError(t, err, "invalid character 'w' looking for beginning of object key string")
 		require.False(t, result)
 	})
@@ -64,7 +64,7 @@ func TestCanIPAccessListReconcile(t *testing.T) {
 		}
 		akoProject := &mdbv1.AtlasProject{}
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{}"})
-		result, err := canIPAccessListReconcile(context.TODO(), &atlasClient, true, akoProject)
+		result, err := canIPAccessListReconcile(context.Background(), &atlasClient, true, akoProject)
 
 		require.EqualError(t, err, "failed to retrieve data")
 		require.False(t, result)
@@ -80,7 +80,7 @@ func TestCanIPAccessListReconcile(t *testing.T) {
 		}
 		akoProject := &mdbv1.AtlasProject{}
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{}"})
-		result, err := canIPAccessListReconcile(context.TODO(), &atlasClient, true, akoProject)
+		result, err := canIPAccessListReconcile(context.Background(), &atlasClient, true, akoProject)
 
 		require.NoError(t, err)
 		require.True(t, result)
@@ -115,7 +115,7 @@ func TestCanIPAccessListReconcile(t *testing.T) {
 			},
 		}
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{\"projectIpAccessList\":[{\"cidrBlock\":\"192.168.0.0/24\"}]}"})
-		result, err := canIPAccessListReconcile(context.TODO(), &atlasClient, true, akoProject)
+		result, err := canIPAccessListReconcile(context.Background(), &atlasClient, true, akoProject)
 
 		require.NoError(t, err)
 		require.True(t, result)
@@ -154,7 +154,7 @@ func TestCanIPAccessListReconcile(t *testing.T) {
 			},
 		}
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{\"projectIpAccessList\":[{\"cidrBlock\":\"192.168.0.0/24\"}]}"})
-		result, err := canIPAccessListReconcile(context.TODO(), &atlasClient, true, akoProject)
+		result, err := canIPAccessListReconcile(context.Background(), &atlasClient, true, akoProject)
 
 		require.NoError(t, err)
 		require.True(t, result)
@@ -193,7 +193,7 @@ func TestCanIPAccessListReconcile(t *testing.T) {
 			},
 		}
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{\"projectIpAccessList\":[{\"cidrBlock\":\"192.168.0.0/24\"}]}"})
-		result, err := canIPAccessListReconcile(context.TODO(), &atlasClient, true, akoProject)
+		result, err := canIPAccessListReconcile(context.Background(), &atlasClient, true, akoProject)
 
 		require.NoError(t, err)
 		require.False(t, result)
@@ -213,7 +213,7 @@ func TestEnsureIPAccessList(t *testing.T) {
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{}"})
 		workflowCtx := &workflow.Context{
 			Client:  &atlasClient,
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 		result := ensureIPAccessList(workflowCtx, atlas.CustomIPAccessListStatus(&atlasClient), akoProject, true)
 
@@ -255,7 +255,7 @@ func TestEnsureIPAccessList(t *testing.T) {
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{\"projectIpAccessList\":[{\"cidrBlock\":\"192.168.0.0/24\"}]}"})
 		workflowCtx := &workflow.Context{
 			Client:  &atlasClient,
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 		result := ensureIPAccessList(workflowCtx, atlas.CustomIPAccessListStatus(&atlasClient), akoProject, true)
 
@@ -313,7 +313,7 @@ func TestEnsureIPAccessList(t *testing.T) {
 		}
 		workflowCtx := &workflow.Context{
 			Client:  &atlasClient,
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 		result := ensureIPAccessList(
 			workflowCtx,
@@ -349,7 +349,7 @@ func TestSyncIPAccessList(t *testing.T) {
 		}
 		workflowCtx := &workflow.Context{
 			Client:  &atlasClient,
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 
 		assert.ErrorContains(t, syncIPAccessList(workflowCtx, "projectID", current, desired), "failed")
@@ -378,7 +378,7 @@ func TestSyncIPAccessList(t *testing.T) {
 		}
 		workflowCtx := &workflow.Context{
 			Client:  &atlasClient,
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 
 		assert.ErrorContains(t, syncIPAccessList(workflowCtx, "projectID", current, desired), "failed")
@@ -398,7 +398,7 @@ func TestSyncIPAccessList(t *testing.T) {
 		atlasClient := mongodbatlas.Client{}
 		workflowCtx := &workflow.Context{
 			Client:  &atlasClient,
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 
 		assert.NoError(t, syncIPAccessList(workflowCtx, "projectID", current, desired))

--- a/pkg/controller/atlasproject/maintenancewindow_test.go
+++ b/pkg/controller/atlasproject/maintenancewindow_test.go
@@ -135,7 +135,7 @@ func TestCanMaintenanceWindowReconcile(t *testing.T) {
 	t.Run("should return true when subResourceDeletionProtection is disabled", func(t *testing.T) {
 		workflowCtx := &workflow.Context{
 			Client:  &mongodbatlas.Client{},
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 		result, err := canMaintenanceWindowReconcile(workflowCtx, false, &mdbv1.AtlasProject{})
 		require.NoError(t, err)
@@ -147,7 +147,7 @@ func TestCanMaintenanceWindowReconcile(t *testing.T) {
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{wrong}"})
 		workflowCtx := &workflow.Context{
 			Client:  &mongodbatlas.Client{},
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 		result, err := canMaintenanceWindowReconcile(workflowCtx, true, akoProject)
 		require.EqualError(t, err, "invalid character 'w' looking for beginning of object key string")
@@ -166,7 +166,7 @@ func TestCanMaintenanceWindowReconcile(t *testing.T) {
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{}"})
 		workflowCtx := &workflow.Context{
 			Client:  &atlasClient,
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 		result, err := canMaintenanceWindowReconcile(workflowCtx, true, akoProject)
 
@@ -186,7 +186,7 @@ func TestCanMaintenanceWindowReconcile(t *testing.T) {
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{}"})
 		workflowCtx := &workflow.Context{
 			Client:  &atlasClient,
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 		result, err := canMaintenanceWindowReconcile(workflowCtx, true, akoProject)
 
@@ -216,7 +216,7 @@ func TestCanMaintenanceWindowReconcile(t *testing.T) {
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{\"maintenanceWindow\":{\"dayOfWeek\":1,\"hourOfDay\":1}}"})
 		workflowCtx := &workflow.Context{
 			Client:  &atlasClient,
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 		result, err := canMaintenanceWindowReconcile(workflowCtx, true, akoProject)
 
@@ -246,7 +246,7 @@ func TestCanMaintenanceWindowReconcile(t *testing.T) {
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{\"maintenanceWindow\":{\"dayOfWeek\":7,\"hourOfDay\":20}}"})
 		workflowCtx := &workflow.Context{
 			Client:  &atlasClient,
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 		result, err := canMaintenanceWindowReconcile(workflowCtx, true, akoProject)
 
@@ -277,7 +277,7 @@ func TestCanMaintenanceWindowReconcile(t *testing.T) {
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{\"maintenanceWindow\":{\"dayOfWeek\":1,\"hourOfDay\":1}}"})
 		workflowCtx := &workflow.Context{
 			Client:  &atlasClient,
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 		result, err := canMaintenanceWindowReconcile(workflowCtx, true, akoProject)
 
@@ -299,7 +299,7 @@ func TestEnsureMaintenanceWindow(t *testing.T) {
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{}"})
 		workflowCtx := &workflow.Context{
 			Client:  &atlasClient,
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 		result := ensureMaintenanceWindow(workflowCtx, akoProject, true)
 
@@ -331,7 +331,7 @@ func TestEnsureMaintenanceWindow(t *testing.T) {
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{\"maintenanceWindow\":{\"dayOfWeek\":1,\"hourOfDay\":20,\"startASAP\":true,\"autoDefer\":true}}"})
 		workflowCtx := &workflow.Context{
 			Client:  &atlasClient,
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 		result := ensureMaintenanceWindow(workflowCtx, akoProject, true)
 

--- a/pkg/controller/atlasproject/network_peering_test.go
+++ b/pkg/controller/atlasproject/network_peering_test.go
@@ -19,7 +19,7 @@ func TestCanNetworkPeeringReconcile(t *testing.T) {
 	t.Run("should return true when subResourceDeletionProtection is disabled", func(t *testing.T) {
 		workflowCtx := &workflow.Context{
 			Client:  &mongodbatlas.Client{},
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 		result, err := canNetworkPeeringReconcile(workflowCtx, false, &mdbv1.AtlasProject{})
 		require.NoError(t, err)
@@ -31,7 +31,7 @@ func TestCanNetworkPeeringReconcile(t *testing.T) {
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{wrong}"})
 		workflowCtx := &workflow.Context{
 			Client:  &mongodbatlas.Client{},
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 		result, err := canNetworkPeeringReconcile(workflowCtx, true, akoProject)
 		require.EqualError(t, err, "invalid character 'w' looking for beginning of object key string")
@@ -50,7 +50,7 @@ func TestCanNetworkPeeringReconcile(t *testing.T) {
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{}"})
 		workflowCtx := &workflow.Context{
 			Client:  &atlasClient,
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 		result, err := canNetworkPeeringReconcile(workflowCtx, true, akoProject)
 
@@ -75,7 +75,7 @@ func TestCanNetworkPeeringReconcile(t *testing.T) {
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{}"})
 		workflowCtx := &workflow.Context{
 			Client:  &atlasClient,
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 		result, err := canNetworkPeeringReconcile(workflowCtx, true, akoProject)
 
@@ -100,7 +100,7 @@ func TestCanNetworkPeeringReconcile(t *testing.T) {
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{\"networkPeers\":[{\"providerName\":\"AWS\",\"accepterRegionName\":\"eu-west-1\",\"atlasCidrBlock\":\"192.168.0.0/24\"}]}"})
 		workflowCtx := &workflow.Context{
 			Client:  &atlasClient,
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 		result, err := canNetworkPeeringReconcile(workflowCtx, true, akoProject)
 
@@ -157,7 +157,7 @@ func TestCanNetworkPeeringReconcile(t *testing.T) {
 			)
 			workflowCtx := &workflow.Context{
 				Client:  &atlasClient,
-				Context: context.TODO(),
+				Context: context.Background(),
 			}
 			result, err := canNetworkPeeringReconcile(workflowCtx, true, akoProject)
 
@@ -210,7 +210,7 @@ func TestCanNetworkPeeringReconcile(t *testing.T) {
 			)
 			workflowCtx := &workflow.Context{
 				Client:  &atlasClient,
-				Context: context.TODO(),
+				Context: context.Background(),
 			}
 			result, err := canNetworkPeeringReconcile(workflowCtx, true, akoProject)
 
@@ -268,7 +268,7 @@ func TestCanNetworkPeeringReconcile(t *testing.T) {
 			)
 			workflowCtx := &workflow.Context{
 				Client:  &atlasClient,
-				Context: context.TODO(),
+				Context: context.Background(),
 			}
 			result, err := canNetworkPeeringReconcile(workflowCtx, true, akoProject)
 
@@ -326,7 +326,7 @@ func TestCanNetworkPeeringReconcile(t *testing.T) {
 			)
 			workflowCtx := &workflow.Context{
 				Client:  &atlasClient,
-				Context: context.TODO(),
+				Context: context.Background(),
 			}
 			result, err := canNetworkPeeringReconcile(workflowCtx, true, akoProject)
 
@@ -379,7 +379,7 @@ func TestCanNetworkPeeringReconcile(t *testing.T) {
 			)
 			workflowCtx := &workflow.Context{
 				Client:  &atlasClient,
-				Context: context.TODO(),
+				Context: context.Background(),
 			}
 			result, err := canNetworkPeeringReconcile(workflowCtx, true, akoProject)
 
@@ -437,7 +437,7 @@ func TestCanNetworkPeeringReconcile(t *testing.T) {
 			)
 			workflowCtx := &workflow.Context{
 				Client:  &atlasClient,
-				Context: context.TODO(),
+				Context: context.Background(),
 			}
 			result, err := canNetworkPeeringReconcile(workflowCtx, true, akoProject)
 
@@ -495,7 +495,7 @@ func TestCanNetworkPeeringReconcile(t *testing.T) {
 			)
 			workflowCtx := &workflow.Context{
 				Client:  &atlasClient,
-				Context: context.TODO(),
+				Context: context.Background(),
 			}
 			result, err := canNetworkPeeringReconcile(workflowCtx, true, akoProject)
 
@@ -547,7 +547,7 @@ func TestCanNetworkPeeringReconcile(t *testing.T) {
 			)
 			workflowCtx := &workflow.Context{
 				Client:  &atlasClient,
-				Context: context.TODO(),
+				Context: context.Background(),
 			}
 			result, err := canNetworkPeeringReconcile(workflowCtx, true, akoProject)
 
@@ -605,7 +605,7 @@ func TestCanNetworkPeeringReconcile(t *testing.T) {
 			)
 			workflowCtx := &workflow.Context{
 				Client:  &atlasClient,
-				Context: context.TODO(),
+				Context: context.Background(),
 			}
 			result, err := canNetworkPeeringReconcile(workflowCtx, true, akoProject)
 
@@ -628,7 +628,7 @@ func TestEnsureNetworkPeers(t *testing.T) {
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{}"})
 		workflowCtx := &workflow.Context{
 			Client:  &atlasClient,
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 		result := ensureNetworkPeers(workflowCtx, akoProject, true)
 
@@ -683,7 +683,7 @@ func TestEnsureNetworkPeers(t *testing.T) {
 		)
 		workflowCtx := &workflow.Context{
 			Client:  &atlasClient,
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 		result := ensureNetworkPeers(workflowCtx, akoProject, true)
 

--- a/pkg/controller/atlasproject/project_settings_test.go
+++ b/pkg/controller/atlasproject/project_settings_test.go
@@ -20,7 +20,7 @@ func TestProjectSettingsReconcile(t *testing.T) {
 	t.Run("should return true when subResourceDeletionProtection is disabled", func(t *testing.T) {
 		workflowCtx := &workflow.Context{
 			Client:  &mongodbatlas.Client{},
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 		result, err := canProjectSettingsReconcile(workflowCtx, false, &mdbv1.AtlasProject{})
 		require.NoError(t, err)
@@ -32,7 +32,7 @@ func TestProjectSettingsReconcile(t *testing.T) {
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{wrong}"})
 		workflowCtx := &workflow.Context{
 			Client:  &mongodbatlas.Client{},
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 		result, err := canProjectSettingsReconcile(workflowCtx, true, akoProject)
 		require.EqualError(t, err, "invalid character 'w' looking for beginning of object key string")
@@ -51,7 +51,7 @@ func TestProjectSettingsReconcile(t *testing.T) {
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{}"})
 		workflowCtx := &workflow.Context{
 			Client:  &atlasClient,
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 		result, err := canProjectSettingsReconcile(workflowCtx, true, akoProject)
 
@@ -71,7 +71,7 @@ func TestProjectSettingsReconcile(t *testing.T) {
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{}"})
 		workflowCtx := &workflow.Context{
 			Client:  &atlasClient,
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 		result, err := canProjectSettingsReconcile(workflowCtx, true, akoProject)
 
@@ -120,7 +120,7 @@ func TestProjectSettingsReconcile(t *testing.T) {
 		)
 		workflowCtx := &workflow.Context{
 			Client:  &atlasClient,
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 		result, err := canProjectSettingsReconcile(workflowCtx, true, akoProject)
 
@@ -170,7 +170,7 @@ func TestProjectSettingsReconcile(t *testing.T) {
 		)
 		workflowCtx := &workflow.Context{
 			Client:  &atlasClient,
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 		result, err := canProjectSettingsReconcile(workflowCtx, true, akoProject)
 
@@ -220,7 +220,7 @@ func TestProjectSettingsReconcile(t *testing.T) {
 		)
 		workflowCtx := &workflow.Context{
 			Client:  &atlasClient,
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 		result, err := canProjectSettingsReconcile(workflowCtx, true, akoProject)
 
@@ -242,7 +242,7 @@ func TestEnsureProjectSettings(t *testing.T) {
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{}"})
 		workflowCtx := &workflow.Context{
 			Client:  &atlasClient,
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 		result := ensureProjectSettings(workflowCtx, akoProject, true)
 
@@ -291,7 +291,7 @@ func TestEnsureProjectSettings(t *testing.T) {
 		)
 		workflowCtx := &workflow.Context{
 			Client:  &atlasClient,
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 		result := ensureProjectSettings(workflowCtx, akoProject, true)
 

--- a/pkg/controller/atlasproject/team_reconciler_test.go
+++ b/pkg/controller/atlasproject/team_reconciler_test.go
@@ -20,7 +20,7 @@ func TestTeamManagedByAtlas(t *testing.T) {
 		workflowCtx := &workflow.Context{
 			OrgID:   "orgID",
 			Client:  &mongodbatlas.Client{},
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 		checker := teamsManagedByAtlas(workflowCtx)
 		result, err := checker(&v1.AtlasProject{})
@@ -32,7 +32,7 @@ func TestTeamManagedByAtlas(t *testing.T) {
 		workflowCtx := &workflow.Context{
 			OrgID:   "orgID",
 			Client:  &mongodbatlas.Client{},
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 		checker := teamsManagedByAtlas(workflowCtx)
 		result, err := checker(&v1.AtlasTeam{})
@@ -56,7 +56,7 @@ func TestTeamManagedByAtlas(t *testing.T) {
 		workflowCtx := &workflow.Context{
 			OrgID:   "orgID",
 			Client:  &atlasClient,
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 		checker := teamsManagedByAtlas(workflowCtx)
 		result, err := checker(team)
@@ -80,7 +80,7 @@ func TestTeamManagedByAtlas(t *testing.T) {
 		workflowCtx := &workflow.Context{
 			OrgID:   "orgID",
 			Client:  &atlasClient,
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 		checker := teamsManagedByAtlas(workflowCtx)
 		result, err := checker(team)
@@ -112,7 +112,7 @@ func TestTeamManagedByAtlas(t *testing.T) {
 		workflowCtx := &workflow.Context{
 			OrgID:   "orgID-1",
 			Client:  &atlasClient,
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 		checker := teamsManagedByAtlas(workflowCtx)
 		result, err := checker(team)
@@ -144,7 +144,7 @@ func TestTeamManagedByAtlas(t *testing.T) {
 		workflowCtx := &workflow.Context{
 			OrgID:   "orgID-1",
 			Client:  &atlasClient,
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 		checker := teamsManagedByAtlas(workflowCtx)
 		result, err := checker(team)

--- a/pkg/controller/atlasproject/teams_test.go
+++ b/pkg/controller/atlasproject/teams_test.go
@@ -57,7 +57,7 @@ func TestCanAssignedTeamsReconcile(t *testing.T) {
 	t.Run("should return true when subResourceDeletionProtection is disabled", func(t *testing.T) {
 		workflowCtx := &workflow.Context{
 			Client:  &mongodbatlas.Client{},
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 		result, err := canAssignedTeamsReconcile(workflowCtx, k8sClient, false, &mdbv1.AtlasProject{})
 		assert.NoError(t, err)
@@ -69,7 +69,7 @@ func TestCanAssignedTeamsReconcile(t *testing.T) {
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{wrong}"})
 		workflowCtx := &workflow.Context{
 			Client:  &mongodbatlas.Client{},
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 		result, err := canAssignedTeamsReconcile(workflowCtx, k8sClient, true, akoProject)
 		assert.EqualError(t, err, "invalid character 'w' looking for beginning of object key string")
@@ -88,7 +88,7 @@ func TestCanAssignedTeamsReconcile(t *testing.T) {
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{}"})
 		workflowCtx := &workflow.Context{
 			Client:  &atlasClient,
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 		result, err := canAssignedTeamsReconcile(workflowCtx, k8sClient, true, akoProject)
 
@@ -108,7 +108,7 @@ func TestCanAssignedTeamsReconcile(t *testing.T) {
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{}"})
 		workflowCtx := &workflow.Context{
 			Client:  &atlasClient,
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 		result, err := canAssignedTeamsReconcile(workflowCtx, k8sClient, true, akoProject)
 
@@ -128,7 +128,7 @@ func TestCanAssignedTeamsReconcile(t *testing.T) {
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{}"})
 		workflowCtx := &workflow.Context{
 			Client:  &atlasClient,
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 		result, err := canAssignedTeamsReconcile(workflowCtx, k8sClient, true, akoProject)
 
@@ -168,7 +168,7 @@ func TestCanAssignedTeamsReconcile(t *testing.T) {
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: `{"teams":[{"teamRef":{"name":"team1","namespace":"default"},"roles":["GROUP_OWNER"]}]}`})
 		workflowCtx := &workflow.Context{
 			Client:  &atlasClient,
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 		result, err := canAssignedTeamsReconcile(workflowCtx, k8sClient, true, akoProject)
 
@@ -208,7 +208,7 @@ func TestCanAssignedTeamsReconcile(t *testing.T) {
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: `{"teams":[{"teamRef":{"name":"team1","namespace":"default"},"roles":["GROUP_OWNER"]}]}`})
 		workflowCtx := &workflow.Context{
 			Client:  &atlasClient,
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 		result, err := canAssignedTeamsReconcile(workflowCtx, k8sClient, true, akoProject)
 
@@ -248,7 +248,7 @@ func TestCanAssignedTeamsReconcile(t *testing.T) {
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: `{"teams":[{"teamRef":{"name":"team1","namespace":"default"},"roles":["GROUP_OWNER"]}]}`})
 		workflowCtx := &workflow.Context{
 			Client:  &atlasClient,
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 		result, err := canAssignedTeamsReconcile(workflowCtx, k8sClient, true, akoProject)
 
@@ -272,7 +272,7 @@ func TestEnsureAssignedTeams(t *testing.T) {
 		workflowCtx := &workflow.Context{
 			Client:  &atlasClient,
 			Log:     logger,
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 		reconciler := &AtlasProjectReconciler{
 			Log: logger,
@@ -343,7 +343,7 @@ func TestEnsureAssignedTeams(t *testing.T) {
 		workflowCtx := &workflow.Context{
 			Client:  &atlasClient,
 			Log:     logger,
-			Context: context.TODO(),
+			Context: context.Background(),
 		}
 		reconciler := &AtlasProjectReconciler{
 			Client: k8sClient,
@@ -366,7 +366,7 @@ func TestUpdateTeamState(t *testing.T) {
 	t.Run("should not duplicate projects listed", func(t *testing.T) {
 		logger := zaptest.NewLogger(t).Sugar()
 		workflowCtx := &workflow.Context{
-			Context: context.TODO(),
+			Context: context.Background(),
 			Log:     logger,
 		}
 		testScheme := runtime.NewScheme()
@@ -434,7 +434,7 @@ func TestUpdateTeamState(t *testing.T) {
 		// "reconcile" the team state and check we still have 1 project in status
 		err := reconciler.updateTeamState(workflowCtx, project, teamRef, false)
 		assert.NoError(t, err)
-		k8sClient.Get(context.TODO(), types.NamespacedName{Name: team.ObjectMeta.Name, Namespace: team.ObjectMeta.Namespace}, team)
+		k8sClient.Get(context.Background(), types.NamespacedName{Name: team.ObjectMeta.Name, Namespace: team.ObjectMeta.Namespace}, team)
 		assert.Equal(t, 1, len(team.Status.Projects))
 	})
 }

--- a/pkg/controller/watch/watched_resource_handler_test.go
+++ b/pkg/controller/watch/watched_resource_handler_test.go
@@ -23,7 +23,7 @@ func TestHandleCreate(t *testing.T) {
 		createEvent := event.CreateEvent{Object: secret}
 		queue := controllertest.Queue{Interface: workqueue.New()}
 
-		handler.Create(context.TODO(), createEvent, &queue)
+		handler.Create(context.Background(), createEvent, &queue)
 		assert.Zero(t, queue.Len())
 	})
 	t.Run("Create event is handled", func(t *testing.T) {
@@ -34,7 +34,7 @@ func TestHandleCreate(t *testing.T) {
 		createEvent := event.CreateEvent{Object: secret}
 		queue := controllertest.Queue{Interface: workqueue.New()}
 
-		handler.Create(context.TODO(), createEvent, &queue)
+		handler.Create(context.Background(), createEvent, &queue)
 		assert.Equal(t, queue.Len(), 1)
 
 		enqueued, _ := queue.Get()
@@ -57,7 +57,7 @@ func TestHandleUpdate(t *testing.T) {
 		updateEvent := event.UpdateEvent{ObjectOld: oldSecret, ObjectNew: newSecret}
 		queue := controllertest.Queue{Interface: workqueue.New()}
 
-		handler.Update(context.TODO(), updateEvent, &queue)
+		handler.Update(context.Background(), updateEvent, &queue)
 		assert.Zero(t, queue.Len())
 	})
 	t.Run("Update event is handled", func(t *testing.T) {
@@ -73,7 +73,7 @@ func TestHandleUpdate(t *testing.T) {
 		updateEvent := event.UpdateEvent{ObjectOld: oldSecret, ObjectNew: newSecret}
 		queue := controllertest.Queue{Interface: workqueue.New()}
 
-		handler.Update(context.TODO(), updateEvent, &queue)
+		handler.Update(context.Background(), updateEvent, &queue)
 		assert.Equal(t, queue.Len(), 1)
 
 		enqueued, _ := queue.Get()

--- a/test/app/main.go
+++ b/test/app/main.go
@@ -22,7 +22,7 @@ import (
 
 var (
 	collection *mongo.Collection
-	ctx        = context.TODO()
+	ctx        = context.Background()
 
 	// related to DB
 	dbName         = "Ships"

--- a/test/e2e/project_deletion_protection_test.go
+++ b/test/e2e/project_deletion_protection_test.go
@@ -470,15 +470,15 @@ var _ = Describe("Project Deletion Protection", Label("project", "deletion-prote
 						WithMessageRegexp("unable to reconcile Assigned Teams due to deletion protection being enabled. see https://dochub.mongodb.org/core/ako-deletion-protection for further information"),
 				)
 
-				g.Expect(testData.K8SClient.Get(context.TODO(), client.ObjectKeyFromObject(testData.Project), testData.Project)).To(Succeed())
+				g.Expect(testData.K8SClient.Get(context.Background(), client.ObjectKeyFromObject(testData.Project), testData.Project)).To(Succeed())
 				g.Expect(testData.Project.Status.Conditions).To(ContainElements(expectedConditions))
 			}).WithTimeout(time.Minute * 5).WithPolling(time.Second * 20).Should(Succeed())
 		})
 
 		By("IP Access List is ready after configured properly", func() {
-			Expect(testData.K8SClient.Get(context.TODO(), client.ObjectKeyFromObject(testData.Project), testData.Project)).To(Succeed())
+			Expect(testData.K8SClient.Get(context.Background(), client.ObjectKeyFromObject(testData.Project), testData.Project)).To(Succeed())
 			testData.Project.Spec.ProjectIPAccessList[0].CIDRBlock = "192.168.0.0/24"
-			Expect(testData.K8SClient.Update(context.TODO(), testData.Project)).To(Succeed())
+			Expect(testData.K8SClient.Update(context.Background(), testData.Project)).To(Succeed())
 
 			Eventually(func(g Gomega) {
 				expectedConditions := conditions.MatchConditions(
@@ -515,18 +515,18 @@ var _ = Describe("Project Deletion Protection", Label("project", "deletion-prote
 						WithMessageRegexp("unable to reconcile Assigned Teams due to deletion protection being enabled. see https://dochub.mongodb.org/core/ako-deletion-protection for further information"),
 				)
 
-				g.Expect(testData.K8SClient.Get(context.TODO(), client.ObjectKeyFromObject(testData.Project), testData.Project)).To(Succeed())
+				g.Expect(testData.K8SClient.Get(context.Background(), client.ObjectKeyFromObject(testData.Project), testData.Project)).To(Succeed())
 				g.Expect(testData.Project.Status.Conditions).To(ContainElements(expectedConditions))
 			}).WithTimeout(time.Minute * 5).WithPolling(time.Second * 20).Should(Succeed())
 		})
 
 		By("Cloud Provider Integration is ready after configured properly", func() {
-			Expect(testData.K8SClient.Get(context.TODO(), client.ObjectKeyFromObject(testData.Project), testData.Project)).To(Succeed())
+			Expect(testData.K8SClient.Get(context.Background(), client.ObjectKeyFromObject(testData.Project), testData.Project)).To(Succeed())
 			testData.Project.Spec.CloudProviderIntegrations[0].IamAssumedRoleArn = awsRoleARN
-			Expect(testData.K8SClient.Update(context.TODO(), testData.Project)).To(Succeed())
+			Expect(testData.K8SClient.Update(context.Background(), testData.Project)).To(Succeed())
 
 			Eventually(func(g Gomega) {
-				g.Expect(testData.K8SClient.Get(context.TODO(), client.ObjectKeyFromObject(testData.Project), testData.Project)).To(Succeed())
+				g.Expect(testData.K8SClient.Get(context.Background(), client.ObjectKeyFromObject(testData.Project), testData.Project)).To(Succeed())
 
 				g.Expect(testData.Project.Status.CloudProviderIntegrations).ToNot(HaveLen(0))
 				g.Expect(testData.Project.Status.CloudProviderIntegrations[0].Status).To(Equal("AUTHORIZED"))
@@ -573,18 +573,18 @@ var _ = Describe("Project Deletion Protection", Label("project", "deletion-prote
 						WithMessageRegexp("unable to reconcile Assigned Teams due to deletion protection being enabled. see https://dochub.mongodb.org/core/ako-deletion-protection for further information"),
 				)
 
-				g.Expect(testData.K8SClient.Get(context.TODO(), client.ObjectKeyFromObject(testData.Project), testData.Project)).To(Succeed())
+				g.Expect(testData.K8SClient.Get(context.Background(), client.ObjectKeyFromObject(testData.Project), testData.Project)).To(Succeed())
 				g.Expect(testData.Project.Status.Conditions).To(ContainElements(expectedConditions))
 			}).WithTimeout(time.Minute * 5).WithPolling(time.Second * 20).Should(Succeed())
 		})
 
 		By("Network Peering is ready after configured properly", func() {
-			Expect(testData.K8SClient.Get(context.TODO(), client.ObjectKeyFromObject(testData.Project), testData.Project)).To(Succeed())
+			Expect(testData.K8SClient.Get(context.Background(), client.ObjectKeyFromObject(testData.Project), testData.Project)).To(Succeed())
 			testData.Project.Spec.NetworkPeers[0].VpcID = AwsVpcID
-			Expect(testData.K8SClient.Update(context.TODO(), testData.Project)).To(Succeed())
+			Expect(testData.K8SClient.Update(context.Background(), testData.Project)).To(Succeed())
 
 			Eventually(func(g Gomega) {
-				g.Expect(testData.K8SClient.Get(context.TODO(), client.ObjectKeyFromObject(testData.Project), testData.Project)).To(Succeed())
+				g.Expect(testData.K8SClient.Get(context.Background(), client.ObjectKeyFromObject(testData.Project), testData.Project)).To(Succeed())
 
 				g.Expect(testData.Project.Status.NetworkPeers).ToNot(HaveLen(0))
 				g.Expect(testData.Project.Status.NetworkPeers[0].StatusName).To(Equal("AVAILABLE"))
@@ -621,7 +621,7 @@ var _ = Describe("Project Deletion Protection", Label("project", "deletion-prote
 						WithMessageRegexp("unable to reconcile Assigned Teams due to deletion protection being enabled. see https://dochub.mongodb.org/core/ako-deletion-protection for further information"),
 				)
 
-				g.Expect(testData.K8SClient.Get(context.TODO(), client.ObjectKeyFromObject(testData.Project), testData.Project)).To(Succeed())
+				g.Expect(testData.K8SClient.Get(context.Background(), client.ObjectKeyFromObject(testData.Project), testData.Project)).To(Succeed())
 				g.Expect(testData.Project.Status.Conditions).To(ContainElements(expectedConditions))
 			}).WithTimeout(time.Minute * 5).WithPolling(time.Second * 20).Should(Succeed())
 		})
@@ -639,9 +639,9 @@ var _ = Describe("Project Deletion Protection", Label("project", "deletion-prote
 			}
 			Expect(testData.K8SClient.Create(ctx, secret)).To(Succeed())
 
-			Expect(testData.K8SClient.Get(context.TODO(), client.ObjectKeyFromObject(testData.Project), testData.Project)).To(Succeed())
+			Expect(testData.K8SClient.Get(context.Background(), client.ObjectKeyFromObject(testData.Project), testData.Project)).To(Succeed())
 			testData.Project.Spec.Integrations[0].Type = "PAGER_DUTY"
-			Expect(testData.K8SClient.Update(context.TODO(), testData.Project)).To(Succeed())
+			Expect(testData.K8SClient.Update(context.Background(), testData.Project)).To(Succeed())
 
 			Eventually(func(g Gomega) {
 				expectedConditions := conditions.MatchConditions(
@@ -672,15 +672,15 @@ var _ = Describe("Project Deletion Protection", Label("project", "deletion-prote
 						WithMessageRegexp("unable to reconcile Assigned Teams due to deletion protection being enabled. see https://dochub.mongodb.org/core/ako-deletion-protection for further information"),
 				)
 
-				g.Expect(testData.K8SClient.Get(context.TODO(), client.ObjectKeyFromObject(testData.Project), testData.Project)).To(Succeed())
+				g.Expect(testData.K8SClient.Get(context.Background(), client.ObjectKeyFromObject(testData.Project), testData.Project)).To(Succeed())
 				g.Expect(testData.Project.Status.Conditions).To(ContainElements(expectedConditions))
 			}).WithTimeout(time.Minute * 5).WithPolling(time.Second * 20).Should(Succeed())
 		})
 
 		By("Maintenance Window is ready after configured properly", func() {
-			Expect(testData.K8SClient.Get(context.TODO(), client.ObjectKeyFromObject(testData.Project), testData.Project)).To(Succeed())
+			Expect(testData.K8SClient.Get(context.Background(), client.ObjectKeyFromObject(testData.Project), testData.Project)).To(Succeed())
 			testData.Project.Spec.MaintenanceWindow.DayOfWeek = 7
-			Expect(testData.K8SClient.Update(context.TODO(), testData.Project)).To(Succeed())
+			Expect(testData.K8SClient.Update(context.Background(), testData.Project)).To(Succeed())
 
 			Eventually(func(g Gomega) {
 				expectedConditions := conditions.MatchConditions(
@@ -709,15 +709,15 @@ var _ = Describe("Project Deletion Protection", Label("project", "deletion-prote
 						WithMessageRegexp("unable to reconcile Assigned Teams due to deletion protection being enabled. see https://dochub.mongodb.org/core/ako-deletion-protection for further information"),
 				)
 
-				g.Expect(testData.K8SClient.Get(context.TODO(), client.ObjectKeyFromObject(testData.Project), testData.Project)).To(Succeed())
+				g.Expect(testData.K8SClient.Get(context.Background(), client.ObjectKeyFromObject(testData.Project), testData.Project)).To(Succeed())
 				g.Expect(testData.Project.Status.Conditions).To(ContainElements(expectedConditions))
 			}).WithTimeout(time.Minute * 5).WithPolling(time.Second * 20).Should(Succeed())
 		})
 
 		By("Auditing is ready after configured properly", func() {
-			Expect(testData.K8SClient.Get(context.TODO(), client.ObjectKeyFromObject(testData.Project), testData.Project)).To(Succeed())
+			Expect(testData.K8SClient.Get(context.Background(), client.ObjectKeyFromObject(testData.Project), testData.Project)).To(Succeed())
 			testData.Project.Spec.Auditing.AuditFilter = `{"atype":"authenticate","param":{"user":"auditReadOnly","db":"admin","mechanism":"SCRAM-SHA-1"}}`
-			Expect(testData.K8SClient.Update(context.TODO(), testData.Project)).To(Succeed())
+			Expect(testData.K8SClient.Update(context.Background(), testData.Project)).To(Succeed())
 
 			Eventually(func(g Gomega) {
 				expectedConditions := conditions.MatchConditions(
@@ -744,15 +744,15 @@ var _ = Describe("Project Deletion Protection", Label("project", "deletion-prote
 						WithMessageRegexp("unable to reconcile Assigned Teams due to deletion protection being enabled. see https://dochub.mongodb.org/core/ako-deletion-protection for further information"),
 				)
 
-				g.Expect(testData.K8SClient.Get(context.TODO(), client.ObjectKeyFromObject(testData.Project), testData.Project)).To(Succeed())
+				g.Expect(testData.K8SClient.Get(context.Background(), client.ObjectKeyFromObject(testData.Project), testData.Project)).To(Succeed())
 				g.Expect(testData.Project.Status.Conditions).To(ContainElements(expectedConditions))
 			}).WithTimeout(time.Minute * 5).WithPolling(time.Second * 20).Should(Succeed())
 		})
 
 		By("Maintenance Window is ready after configured properly", func() {
-			Expect(testData.K8SClient.Get(context.TODO(), client.ObjectKeyFromObject(testData.Project), testData.Project)).To(Succeed())
+			Expect(testData.K8SClient.Get(context.Background(), client.ObjectKeyFromObject(testData.Project), testData.Project)).To(Succeed())
 			testData.Project.Spec.Settings.IsDataExplorerEnabled = toptr.MakePtr(true)
-			Expect(testData.K8SClient.Update(context.TODO(), testData.Project)).To(Succeed())
+			Expect(testData.K8SClient.Update(context.Background(), testData.Project)).To(Succeed())
 
 			Eventually(func(g Gomega) {
 				expectedConditions := conditions.MatchConditions(
@@ -777,15 +777,15 @@ var _ = Describe("Project Deletion Protection", Label("project", "deletion-prote
 						WithMessageRegexp("unable to reconcile Assigned Teams due to deletion protection being enabled. see https://dochub.mongodb.org/core/ako-deletion-protection for further information"),
 				)
 
-				g.Expect(testData.K8SClient.Get(context.TODO(), client.ObjectKeyFromObject(testData.Project), testData.Project)).To(Succeed())
+				g.Expect(testData.K8SClient.Get(context.Background(), client.ObjectKeyFromObject(testData.Project), testData.Project)).To(Succeed())
 				g.Expect(testData.Project.Status.Conditions).To(ContainElements(expectedConditions))
 			}).WithTimeout(time.Minute * 5).WithPolling(time.Second * 20).Should(Succeed())
 		})
 
 		By("Encryption At Rest is ready after configured properly", func() {
-			Expect(testData.K8SClient.Get(context.TODO(), client.ObjectKeyFromObject(testData.Project), testData.Project)).To(Succeed())
+			Expect(testData.K8SClient.Get(context.Background(), client.ObjectKeyFromObject(testData.Project), testData.Project)).To(Succeed())
 			testData.Project.Spec.EncryptionAtRest.AwsKms.Region = "EU_WEST_2"
-			Expect(testData.K8SClient.Update(context.TODO(), testData.Project)).To(Succeed())
+			Expect(testData.K8SClient.Update(context.Background(), testData.Project)).To(Succeed())
 
 			Eventually(func(g Gomega) {
 				expectedConditions := conditions.MatchConditions(
@@ -808,15 +808,15 @@ var _ = Describe("Project Deletion Protection", Label("project", "deletion-prote
 						WithMessageRegexp("unable to reconcile Assigned Teams due to deletion protection being enabled. see https://dochub.mongodb.org/core/ako-deletion-protection for further information"),
 				)
 
-				g.Expect(testData.K8SClient.Get(context.TODO(), client.ObjectKeyFromObject(testData.Project), testData.Project)).To(Succeed())
+				g.Expect(testData.K8SClient.Get(context.Background(), client.ObjectKeyFromObject(testData.Project), testData.Project)).To(Succeed())
 				g.Expect(testData.Project.Status.Conditions).To(ContainElements(expectedConditions))
 			}).WithTimeout(time.Minute * 5).WithPolling(time.Second * 20).Should(Succeed())
 		})
 
 		By("Custom Roles is ready after configured properly", func() {
-			Expect(testData.K8SClient.Get(context.TODO(), client.ObjectKeyFromObject(testData.Project), testData.Project)).To(Succeed())
+			Expect(testData.K8SClient.Get(context.Background(), client.ObjectKeyFromObject(testData.Project), testData.Project)).To(Succeed())
 			testData.Project.Spec.CustomRoles[0].Actions[0].Resources[0].Database = toptr.MakePtr("testDB")
-			Expect(testData.K8SClient.Update(context.TODO(), testData.Project)).To(Succeed())
+			Expect(testData.K8SClient.Update(context.Background(), testData.Project)).To(Succeed())
 
 			Eventually(func(g Gomega) {
 				expectedConditions := conditions.MatchConditions(
@@ -837,29 +837,29 @@ var _ = Describe("Project Deletion Protection", Label("project", "deletion-prote
 						WithMessageRegexp("unable to reconcile Assigned Teams due to deletion protection being enabled. see https://dochub.mongodb.org/core/ako-deletion-protection for further information"),
 				)
 
-				g.Expect(testData.K8SClient.Get(context.TODO(), client.ObjectKeyFromObject(testData.Project), testData.Project)).To(Succeed())
+				g.Expect(testData.K8SClient.Get(context.Background(), client.ObjectKeyFromObject(testData.Project), testData.Project)).To(Succeed())
 				g.Expect(testData.Project.Status.Conditions).To(ContainElements(expectedConditions))
 			}).WithTimeout(time.Minute * 5).WithPolling(time.Second * 20).Should(Succeed())
 		})
 
 		By("Team is ready after configured properly", func() {
-			Expect(testData.K8SClient.Get(context.TODO(), client.ObjectKeyFromObject(testData.Teams[0]), testData.Teams[0])).To(Succeed())
+			Expect(testData.K8SClient.Get(context.Background(), client.ObjectKeyFromObject(testData.Teams[0]), testData.Teams[0])).To(Succeed())
 			testData.Teams[0].Spec.Usernames = make([]mdbv1.TeamUser, 0, len(usernames))
 			for _, username := range usernames {
 				testData.Teams[0].Spec.Usernames = append(testData.Teams[0].Spec.Usernames, mdbv1.TeamUser(username))
 			}
-			Expect(testData.K8SClient.Update(context.TODO(), testData.Teams[0])).To(Succeed())
+			Expect(testData.K8SClient.Update(context.Background(), testData.Teams[0])).To(Succeed())
 
 			Eventually(func(g Gomega) {
-				g.Expect(testData.K8SClient.Get(context.TODO(), client.ObjectKeyFromObject(testData.Teams[0]), testData.Teams[0])).To(Succeed())
+				g.Expect(testData.K8SClient.Get(context.Background(), client.ObjectKeyFromObject(testData.Teams[0]), testData.Teams[0])).To(Succeed())
 				g.Expect(testData.Teams[0].Status.Conditions).To(ContainElements(conditions.MatchCondition(status.TrueCondition(status.ReadyType))))
 			}).WithTimeout(time.Minute * 1).WithPolling(time.Second * 20).Should(Succeed())
 		})
 
 		By("Assigned Teams is ready after configured properly", func() {
-			Expect(testData.K8SClient.Get(context.TODO(), client.ObjectKeyFromObject(testData.Project), testData.Project)).To(Succeed())
+			Expect(testData.K8SClient.Get(context.Background(), client.ObjectKeyFromObject(testData.Project), testData.Project)).To(Succeed())
 			testData.Project.Spec.Teams[0].Roles[0] = "GROUP_OWNER"
-			Expect(testData.K8SClient.Update(context.TODO(), testData.Project)).To(Succeed())
+			Expect(testData.K8SClient.Update(context.Background(), testData.Project)).To(Succeed())
 
 			Eventually(func(g Gomega) {
 				expectedConditions := conditions.MatchConditions(
@@ -878,7 +878,7 @@ var _ = Describe("Project Deletion Protection", Label("project", "deletion-prote
 					status.TrueCondition(status.ProjectTeamsReadyType),
 				)
 
-				g.Expect(testData.K8SClient.Get(context.TODO(), client.ObjectKeyFromObject(testData.Project), testData.Project)).To(Succeed())
+				g.Expect(testData.K8SClient.Get(context.Background(), client.ObjectKeyFromObject(testData.Project), testData.Project)).To(Succeed())
 				g.Expect(testData.Project.Status.Conditions).To(ContainElements(expectedConditions))
 			}).WithTimeout(time.Minute * 5).WithPolling(time.Second * 20).Should(Succeed())
 		})

--- a/test/int/backup_protected_test.go
+++ b/test/int/backup_protected_test.go
@@ -50,7 +50,7 @@ var _ = Describe("AtlasBackupSchedule Deletion Protected",
 					customresource.ResourcePolicyAnnotation,
 					customresource.ResourcePolicyDelete,
 				)
-				Expect(k8sClient.Create(context.TODO(), testProject, &client.CreateOptions{})).To(Succeed())
+				Expect(k8sClient.Create(context.Background(), testProject, &client.CreateOptions{})).To(Succeed())
 
 				Eventually(func() bool {
 					return resources.CheckCondition(k8sClient, testProject, status.TrueCondition(status.ReadyType))
@@ -69,7 +69,7 @@ var _ = Describe("AtlasBackupSchedule Deletion Protected",
 				Expect(k8sClient.Delete(context.Background(), testDeployment)).To(Succeed())
 			})
 			By("Deleting project from k8s and atlas", func() {
-				Expect(k8sClient.Delete(context.TODO(), testProject, &client.DeleteOptions{})).To(Succeed())
+				Expect(k8sClient.Delete(context.Background(), testProject, &client.DeleteOptions{})).To(Succeed())
 				Eventually(
 					checkAtlasProjectRemoved(testProject.Status.ID),
 				).WithTimeout(20 * time.Minute).WithPolling(PollingInterval).Should(BeTrue())

--- a/test/int/deployment_protected_test.go
+++ b/test/int/deployment_protected_test.go
@@ -48,7 +48,7 @@ var _ = Describe("AtlasDeployment Deletion Protected",
 					customresource.ResourcePolicyAnnotation,
 					customresource.ResourcePolicyDelete,
 				)
-				Expect(k8sClient.Create(context.TODO(), testProject, &client.CreateOptions{})).To(Succeed())
+				Expect(k8sClient.Create(context.Background(), testProject, &client.CreateOptions{})).To(Succeed())
 
 				Eventually(func() bool {
 					return resources.CheckCondition(k8sClient, testProject, status.TrueCondition(status.ReadyType))
@@ -58,7 +58,7 @@ var _ = Describe("AtlasDeployment Deletion Protected",
 
 		AfterAll(func() {
 			By("Deleting project from k8s and atlas", func() {
-				Expect(k8sClient.Delete(context.TODO(), testProject, &client.DeleteOptions{})).To(Succeed())
+				Expect(k8sClient.Delete(context.Background(), testProject, &client.DeleteOptions{})).To(Succeed())
 				Eventually(
 					checkAtlasProjectRemoved(testProject.Status.ID),
 				).WithTimeout(3 * time.Minute).WithPolling(PollingInterval).Should(BeTrue())
@@ -95,7 +95,7 @@ var _ = Describe("AtlasDeployment Deletion Protected",
 
 func preserveDeploymentFlow(ns string, testProject *mdbv1.AtlasProject, testDeployment *mdbv1.AtlasDeployment) {
 	By("Creating deployment in Kubernetes", func() {
-		Expect(k8sClient.Create(context.TODO(), testDeployment, &client.CreateOptions{})).To(Succeed())
+		Expect(k8sClient.Create(context.Background(), testDeployment, &client.CreateOptions{})).To(Succeed())
 	})
 
 	By("Waiting the deployment to settle in Kubernetes", func() {
@@ -105,10 +105,10 @@ func preserveDeploymentFlow(ns string, testProject *mdbv1.AtlasProject, testDepl
 	})
 
 	By("Deleting the deployment from Kubernetes", func() {
-		Expect(k8sClient.Delete(context.TODO(), testDeployment, &client.DeleteOptions{})).To(Succeed())
+		Expect(k8sClient.Delete(context.Background(), testDeployment, &client.DeleteOptions{})).To(Succeed())
 		Eventually(func() bool {
 			deployment := mdbv1.AtlasDeployment{}
-			err := k8sClient.Get(context.TODO(), kube.ObjectKey(ns, testDeployment.Name), &deployment, &client.GetOptions{})
+			err := k8sClient.Get(context.Background(), kube.ObjectKey(ns, testDeployment.Name), &deployment, &client.GetOptions{})
 			return k8serrors.IsNotFound(err)
 		}).WithTimeout(5 * time.Minute).WithPolling(PollingInterval).Should(BeTrue())
 	})

--- a/test/int/deployment_unprotected_test.go
+++ b/test/int/deployment_unprotected_test.go
@@ -41,7 +41,7 @@ var _ = Describe("AtlasDeployment Deletion Unprotected",
 
 			By("Creating a project", func() {
 				testProject = mdbv1.DefaultProject(testNamespace.Name, connectionSecret.Name).WithIPAccessList(project.NewIPAccessList().WithCIDR("0.0.0.0/0"))
-				Expect(k8sClient.Create(context.TODO(), testProject, &client.CreateOptions{})).To(Succeed())
+				Expect(k8sClient.Create(context.Background(), testProject, &client.CreateOptions{})).To(Succeed())
 
 				Eventually(func() bool {
 					return resources.CheckCondition(k8sClient, testProject, status.TrueCondition(status.ReadyType))
@@ -51,7 +51,7 @@ var _ = Describe("AtlasDeployment Deletion Unprotected",
 
 		AfterAll(func() {
 			By("Deleting project from k8s and atlas", func() {
-				Expect(k8sClient.Delete(context.TODO(), testProject, &client.DeleteOptions{})).To(Succeed())
+				Expect(k8sClient.Delete(context.Background(), testProject, &client.DeleteOptions{})).To(Succeed())
 				Eventually(
 					checkAtlasProjectRemoved(testProject.Status.ID),
 				).WithTimeout(3 * time.Minute).WithPolling(PollingInterval).Should(BeTrue())
@@ -89,7 +89,7 @@ var _ = Describe("AtlasDeployment Deletion Unprotected",
 func wipeDeploymentFlow(ns string, testProject *mdbv1.AtlasProject, testDeployment *mdbv1.AtlasDeployment) {
 	By("Creating a deployment in the cluster with annotation set to delete", func() {
 		testDeployment = mdbv1.DefaultAWSDeployment(ns, testProject.Name).Lightweight()
-		Expect(k8sClient.Create(context.TODO(), testDeployment, &client.CreateOptions{})).To(Succeed())
+		Expect(k8sClient.Create(context.Background(), testDeployment, &client.CreateOptions{})).To(Succeed())
 	})
 
 	By("Waiting the deployment to settle in kubernetes", func() {
@@ -99,10 +99,10 @@ func wipeDeploymentFlow(ns string, testProject *mdbv1.AtlasProject, testDeployme
 	})
 
 	By("Deleting the deployment from Kubernetes", func() {
-		Expect(k8sClient.Delete(context.TODO(), testDeployment, &client.DeleteOptions{})).To(Succeed())
+		Expect(k8sClient.Delete(context.Background(), testDeployment, &client.DeleteOptions{})).To(Succeed())
 		Eventually(func() bool {
 			deployment := mdbv1.AtlasDeployment{}
-			err := k8sClient.Get(context.TODO(), kube.ObjectKey(ns, testDeployment.Name), &deployment, &client.GetOptions{})
+			err := k8sClient.Get(context.Background(), kube.ObjectKey(ns, testDeployment.Name), &deployment, &client.GetOptions{})
 			return k8serrors.IsNotFound(err)
 		}).WithTimeout(2 * time.Minute).WithPolling(PollingInterval).Should(BeTrue())
 	})

--- a/test/int/project_protect_test.go
+++ b/test/int/project_protect_test.go
@@ -48,7 +48,7 @@ var _ = Describe("AtlasProject", Label("int", "AtlasProject", "protection-enable
 			By("Creating a project in the cluster", func() {
 				testProject = mdbv1.NewProject(testNamespace.Name, projectName, projectName).
 					WithConnectionSecret(connectionSecret.Name)
-				Expect(k8sClient.Create(context.TODO(), testProject, &client.CreateOptions{})).To(Succeed())
+				Expect(k8sClient.Create(context.Background(), testProject, &client.CreateOptions{})).To(Succeed())
 
 				Eventually(func() bool {
 					return resources.CheckCondition(k8sClient, testProject, status.TrueCondition(status.ReadyType))
@@ -58,17 +58,17 @@ var _ = Describe("AtlasProject", Label("int", "AtlasProject", "protection-enable
 			// nolint:dupl
 			By("Deleting project in cluster doesn't delete from Atlas", func() {
 				projectID := testProject.ID()
-				Expect(k8sClient.Delete(context.TODO(), testProject, &client.DeleteOptions{})).To(Succeed())
+				Expect(k8sClient.Delete(context.Background(), testProject, &client.DeleteOptions{})).To(Succeed())
 
 				Eventually(func(g Gomega) {
-					g.Expect(k8sClient.Get(context.TODO(), client.ObjectKeyFromObject(testProject), testProject, &client.GetOptions{})).ToNot(Succeed())
+					g.Expect(k8sClient.Get(context.Background(), client.ObjectKeyFromObject(testProject), testProject, &client.GetOptions{})).ToNot(Succeed())
 
-					atlasProject, _, err := atlasClient.Projects.GetOneProjectByName(context.TODO(), projectName)
+					atlasProject, _, err := atlasClient.Projects.GetOneProjectByName(context.Background(), projectName)
 					g.Expect(err).To(BeNil())
 					g.Expect(atlasProject).ToNot(BeNil())
 				}).WithTimeout(5 * time.Minute).WithPolling(PollingInterval).Should(Succeed())
 
-				_, err := atlasClient.Projects.Delete(context.TODO(), projectID)
+				_, err := atlasClient.Projects.Delete(context.Background(), projectID)
 				Expect(err).To(BeNil())
 			})
 		})
@@ -83,14 +83,14 @@ var _ = Describe("AtlasProject", Label("int", "AtlasProject", "protection-enable
 					Name:                      projectName,
 					WithDefaultAlertsSettings: toptr.MakePtr(true),
 				}
-				_, _, err := atlasClient.Projects.Create(context.TODO(), &atlasProject, &mongodbatlas.CreateProjectOptions{})
+				_, _, err := atlasClient.Projects.Create(context.Background(), &atlasProject, &mongodbatlas.CreateProjectOptions{})
 				Expect(err).To(BeNil())
 			})
 
 			By("Creating a project in the cluster", func() {
 				testProject = mdbv1.NewProject(testNamespace.Name, projectName, projectName).
 					WithConnectionSecret(connectionSecret.Name)
-				Expect(k8sClient.Create(context.TODO(), testProject, &client.CreateOptions{})).To(Succeed())
+				Expect(k8sClient.Create(context.Background(), testProject, &client.CreateOptions{})).To(Succeed())
 
 				Eventually(func() bool {
 					return resources.CheckCondition(k8sClient, testProject, status.TrueCondition(status.ReadyType))
@@ -100,17 +100,17 @@ var _ = Describe("AtlasProject", Label("int", "AtlasProject", "protection-enable
 			// nolint:dupl
 			By("Deleting project in cluster doesn't delete from Atlas", func() {
 				projectID := testProject.ID()
-				Expect(k8sClient.Delete(context.TODO(), testProject, &client.DeleteOptions{})).To(Succeed())
+				Expect(k8sClient.Delete(context.Background(), testProject, &client.DeleteOptions{})).To(Succeed())
 
 				Eventually(func(g Gomega) {
-					g.Expect(k8sClient.Get(context.TODO(), client.ObjectKeyFromObject(testProject), testProject, &client.GetOptions{})).ToNot(Succeed())
+					g.Expect(k8sClient.Get(context.Background(), client.ObjectKeyFromObject(testProject), testProject, &client.GetOptions{})).ToNot(Succeed())
 
-					atlasProject, _, err := atlasClient.Projects.GetOneProjectByName(context.TODO(), projectName)
+					atlasProject, _, err := atlasClient.Projects.GetOneProjectByName(context.Background(), projectName)
 					g.Expect(err).To(BeNil())
 					g.Expect(atlasProject).ToNot(BeNil())
 				}).WithTimeout(5 * time.Minute).WithPolling(PollingInterval).Should(Succeed())
 
-				_, err := atlasClient.Projects.Delete(context.TODO(), projectID)
+				_, err := atlasClient.Projects.Delete(context.Background(), projectID)
 				Expect(err).To(BeNil())
 			})
 		})
@@ -123,7 +123,7 @@ var _ = Describe("AtlasProject", Label("int", "AtlasProject", "protection-enable
 				testProject = mdbv1.NewProject(testNamespace.Name, projectName, projectName).
 					WithAnnotations(map[string]string{customresource.ResourcePolicyAnnotation: customresource.ResourcePolicyDelete}).
 					WithConnectionSecret(connectionSecret.Name)
-				Expect(k8sClient.Create(context.TODO(), testProject, &client.CreateOptions{})).To(Succeed())
+				Expect(k8sClient.Create(context.Background(), testProject, &client.CreateOptions{})).To(Succeed())
 
 				Eventually(func() bool {
 					return resources.CheckCondition(k8sClient, testProject, status.TrueCondition(status.ReadyType))
@@ -133,10 +133,10 @@ var _ = Describe("AtlasProject", Label("int", "AtlasProject", "protection-enable
 			// nolint:dupl
 			By("Deleting project in cluster should delete it from Atlas", func() {
 				projectID := testProject.ID()
-				Expect(k8sClient.Delete(context.TODO(), testProject, &client.DeleteOptions{})).To(Succeed())
+				Expect(k8sClient.Delete(context.Background(), testProject, &client.DeleteOptions{})).To(Succeed())
 
 				Eventually(func(g Gomega) {
-					_, r, err := atlasClient.Projects.GetOneProject(context.TODO(), projectID)
+					_, r, err := atlasClient.Projects.GetOneProject(context.Background(), projectID)
 					g.Expect(err).ToNot(BeNil())
 					g.Expect(r).ToNot(BeNil())
 					g.Expect(r.StatusCode).To(Equal(http.StatusNotFound))


### PR DESCRIPTION
We should use `context.Background()` everywhere. TODO() is only for cases where code is still work in progress:
https://pkg.go.dev/context#TODO
> Code should use context.TODO when it's unclear which Context to use or it is not yet available (because the surrounding function has not yet been extended to accept a Context parameter).

### All Submissions:

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
