### PR TITLE
CLOUDP-222442: Run all test in merge queue

### DIFF
--- a/.github/workflows/cloud-tests.yml
+++ b/.github/workflows/cloud-tests.yml
@@ -18,6 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'merge_group' ||
       github.ref == 'refs/heads/main' ||
       (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]') ||
       contains(github.event.pull_request.labels.*.name, 'safe-to-test')
@@ -59,6 +60,13 @@ jobs:
     secrets: inherit
     with:
       forked:  ${{ inputs.forked }}
+
+  test-e2e-gov:
+    needs:
+      - allowed
+    if: github.event_name == 'merge_group'
+    uses: ./.github/workflows/test-e2e-gov.yml
+    secrets: inherit
 
   openshift-upgrade-test:
     needs: allowed

--- a/.github/workflows/test-e2e-gov.yml
+++ b/.github/workflows/test-e2e-gov.yml
@@ -1,9 +1,6 @@
 name: E2E Gov tests
 
 on:
-  pull_request:
-   types:
-      - closed
   workflow_call:
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,7 @@ on:
     types: [labeled]
     paths-ignore:
       - 'docs/**'
+  merge_group:
   workflow_dispatch:
 
 concurrency:
@@ -45,7 +46,7 @@ jobs:
       - validate-manifests
       - check-licenses
       - cloud-tests-filter
-    if: (needs.cloud-tests-filter.outputs.run-cloud-tests == 'true')
+    if: (github.event_name == 'merge_group' || needs.cloud-tests-filter.outputs.run-cloud-tests == 'true')
     uses: ./.github/workflows/cloud-tests.yml
     secrets: inherit
     with:


### PR DESCRIPTION
The idea is to force ALL tests to run at merge time within the merge queue, which triggers with event [`merge_group`](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#merge_group).

- The event `merge_group` triggers the overall `test.yml`.
- The event `merge_group` is sufficient to trigger cloud tests, run filters will not stop it.
- The `cloud-tests.yml` `Allowed` check is always true on `merge_group`.
- The `cloud-tests.yml` triggers the `e2e-test-gov.yml` only on `merge_group`.
- The `e2e-test-gov.yml` workflow is no longer self triggered by closed PR.

### All Submissions:

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
