### PR TITLE
Avoid e2e test changing tracked files

### DIFF
--- a/.github/actions/gen-install-scripts/entrypoint.sh
+++ b/.github/actions/gen-install-scripts/entrypoint.sh
@@ -2,7 +2,29 @@
 
 set -xeou pipefail
 
+subdir=${1:-}
+
 target_dir="deploy"
+bundle_dir="bundle"
+config_dir="config"
+
+function cleanup() {
+  # Restore original bundle.Dockerfile as needed
+  cp bundle.Dockerfile "${bundle_dir}/bundle.Dockerfile"
+  mv bundle.Dockerfile.backup bundle.Dockerfile
+}
+
+if [ "${subdir}" != "" ]; then
+  target_dir+="/${subdir}"
+  bundle_dir+="/${subdir}"
+  config_dir+="/${subdir}"
+  mkdir -p "${target_dir}" "${bundle_dir}"
+  cp -R config/release "${config_dir}"
+  cp -R bundle/manifests bundle/metadata "${bundle_dir}/manifests"
+  cp bundle.Dockerfile bundle.Dockerfile.backup
+  trap cleanup EXIT
+fi
+
 clusterwide_dir="${target_dir}/clusterwide"
 namespaced_dir="${target_dir}/namespaced"
 crds_dir="${target_dir}/crds"
@@ -14,59 +36,59 @@ mkdir -p "${crds_dir}"
 mkdir -p "${openshift}"
 
 # Generate configuration and save it to `all-in-one`
-controller-gen crd:crdVersions=v1,ignoreUnexportedFields=true rbac:roleName=manager-role webhook paths="./pkg/api/..." output:crd:artifacts:config=config/crd/bases
-cd config/manager && kustomize edit set image controller="${INPUT_IMAGE_URL}"
+controller-gen crd:crdVersions=v1,ignoreUnexportedFields=true rbac:roleName=manager-role webhook paths="./pkg/api/..." output:crd:artifacts:config="${config_dir}/crd/bases"
+cd "${config_dir}/manager" && kustomize edit set image controller="${INPUT_IMAGE_URL}"
 cd -
-./scripts/split_roles_yaml.sh
+./scripts/split_roles_yaml.sh "${subdir}"
 
 which kustomize
 kustomize version
 
 # all-in-one
-kustomize build --load-restrictor LoadRestrictionsNone "config/release/${INPUT_ENV}/allinone" > "${target_dir}/all-in-one.yaml"
+kustomize build --load-restrictor LoadRestrictionsNone "${config_dir}/release/${INPUT_ENV}/allinone" > "${target_dir}/all-in-one.yaml"
 echo "Created all-in-one config"
 
 # clusterwide
-kustomize build --load-restrictor LoadRestrictionsNone "config/release/${INPUT_ENV}/clusterwide" > "${clusterwide_dir}/clusterwide-config.yaml"
-kustomize build "config/crd" > "${clusterwide_dir}/crds.yaml"
+kustomize build --load-restrictor LoadRestrictionsNone "${config_dir}/release/${INPUT_ENV}/clusterwide" > "${clusterwide_dir}/clusterwide-config.yaml"
+kustomize build "${config_dir}/crd" > "${clusterwide_dir}/crds.yaml"
 echo "Created clusterwide config"
 
 # base-openshift-namespace-scoped
-kustomize build --load-restrictor LoadRestrictionsNone "config/release/${INPUT_ENV}/openshift" > "${openshift}/openshift.yaml"
-kustomize build "config/crd" > "${openshift}/crds.yaml"
+kustomize build --load-restrictor LoadRestrictionsNone "${config_dir}/release/${INPUT_ENV}/openshift" > "${openshift}/openshift.yaml"
+kustomize build "${config_dir}/crd" > "${openshift}/crds.yaml"
 echo "Created openshift namespaced config"
 
 # namespaced
-kustomize build --load-restrictor LoadRestrictionsNone "config/release/${INPUT_ENV}/namespaced" > "${namespaced_dir}/namespaced-config.yaml"
-kustomize build "config/crd" > "${namespaced_dir}/crds.yaml"
+kustomize build --load-restrictor LoadRestrictionsNone "${config_dir}/release/${INPUT_ENV}/namespaced" > "${namespaced_dir}/namespaced-config.yaml"
+kustomize build "${config_dir}/crd" > "${namespaced_dir}/crds.yaml"
 echo "Created namespaced config"
 
 # crds
-cp config/crd/bases/* "${crds_dir}"
+cp "${config_dir}/crd/bases"/* "${crds_dir}"
 
 # CSV bundle
 operator-sdk generate kustomize manifests -q --apis-dir=pkg/api
 # get the current version so we could put it into the "replaces:"
-current_version="$(yq e '.metadata.name' bundle/manifests/mongodb-atlas-kubernetes.clusterserviceversion.yaml)"
+current_version=$(yq e '.metadata.name' "${bundle_dir}/manifests/mongodb-atlas-kubernetes.clusterserviceversion.yaml")
 
 # We pass the version only for non-dev deployments (it's ok to have "0.0.0" for dev)
 channel="stable"
 if [[ "${INPUT_ENV}" == "dev" ]]; then
   echo "build dev purpose"
-  kustomize build --load-restrictor LoadRestrictionsNone config/manifests |
-    operator-sdk generate bundle -q --overwrite --default-channel="${channel}" --channels="${channel}"
+  kustomize build --load-restrictor LoadRestrictionsNone "${config_dir}/manifests" |
+    operator-sdk generate bundle -q --overwrite --default-channel="${channel}" --channels="${channel}" --output-dir "${bundle_dir}"
 else
   echo "build release version"
   echo  "${INPUT_IMAGE_URL}"
-  kustomize build --load-restrictor LoadRestrictionsNone config/manifests |
-    operator-sdk generate bundle -q --overwrite --version "${INPUT_VERSION}" --default-channel="${channel}" --channels="${channel}"
+  kustomize build --load-restrictor LoadRestrictionsNone "${config_dir}/manifests" |
+    operator-sdk generate bundle -q --overwrite --version "${INPUT_VERSION}" --default-channel="${channel}" --channels="${channel}" --output-dir "${bundle_dir}"
   # add replaces
-  awk '!/replaces:/' bundle/manifests/mongodb-atlas-kubernetes.clusterserviceversion.yaml > tmp && mv tmp bundle/manifests/mongodb-atlas-kubernetes.clusterserviceversion.yaml
-  echo "  replaces: $current_version" >> bundle/manifests/mongodb-atlas-kubernetes.clusterserviceversion.yaml
+  awk '!/replaces:/' "${bundle_dir}/manifests/mongodb-atlas-kubernetes.clusterserviceversion.yaml" > tmp && mv tmp "${bundle_dir}/manifests/mongodb-atlas-kubernetes.clusterserviceversion.yaml"
+  echo "  replaces: $current_version" >> "${bundle_dir}/manifests/mongodb-atlas-kubernetes.clusterserviceversion.yaml"
   # Add WATCH_NAMESPACE env parameter
-  value="metadata.annotations['olm.targetNamespaces']" yq e -i '.spec.install.spec.deployments[0].spec.template.spec.containers[0].env[2] |= {"name": "WATCH_NAMESPACE", "valueFrom": {"fieldRef": {"fieldPath": env(value)}}}' bundle/manifests/mongodb-atlas-kubernetes.clusterserviceversion.yaml
-  # Add containerImage to bundle/manifests/ csv. containerImage - The full location (registry, repository, name and tag) of the operator image
-  yq e -i ".metadata.annotations.containerImage=\"${INPUT_IMAGE_URL}\"" bundle/manifests/mongodb-atlas-kubernetes.clusterserviceversion.yaml
+  value="metadata.annotations['olm.targetNamespaces']" yq e -i '.spec.install.spec.deployments[0].spec.template.spec.containers[0].env[2] |= {"name": "WATCH_NAMESPACE", "valueFrom": {"fieldRef": {"fieldPath": env(value)}}}' "${bundle_dir}/manifests/mongodb-atlas-kubernetes.clusterserviceversion.yaml"
+  # Add containerImage to "${bundle_dir}/manifests/" csv. containerImage - The full location (registry, repository, name and tag) of the operator image
+  yq e -i ".metadata.annotations.containerImage=\"${INPUT_IMAGE_URL}\"" "${bundle_dir}/manifests/mongodb-atlas-kubernetes.clusterserviceversion.yaml"
 fi
 
 # add additional LABELs to bundle.Docker file

--- a/.gitignore
+++ b/.gitignore
@@ -41,7 +41,11 @@ node_modules
 tmp/
 
 # ready to work samples
-deploy/
+deploy
+
+# e2e work files
+config/e2e
+bundle/e2e
 
 # ignore tool binaries
 tools/clean/clean

--- a/scripts/e2e_local.sh
+++ b/scripts/e2e_local.sh
@@ -22,18 +22,18 @@ export INPUT_IMAGE_URL="${image}"
 export INPUT_ENV=dev
 
 if [[ "${build}" == "true" ]]; then
-    ./.github/actions/gen-install-scripts/entrypoint.sh
-    awk '{gsub(/cloud.mongodb.com/, "cloud-qa.mongodb.com", $0); print}' bundle/manifests/mongodb-atlas-kubernetes.clusterserviceversion.yaml > tmp && mv tmp bundle/manifests/mongodb-atlas-kubernetes.clusterserviceversion.yaml
+    ./.github/actions/gen-install-scripts/entrypoint.sh e2e
+    awk '{gsub(/cloud.mongodb.com/, "cloud-qa.mongodb.com", $0); print}' bundle/e2e/manifests/mongodb-atlas-kubernetes.clusterserviceversion.yaml > tmp && mv tmp bundle/e2e/manifests/mongodb-atlas-kubernetes.clusterserviceversion.yaml
 
     docker build -t "${image}" .
     docker push "${image}"
 
     #bundles
-    docker build -f bundle.Dockerfile -t "${bundle_image}" .
+    docker build -f bundle/e2e/bundle.Dockerfile -t "${bundle_image}" .
     docker push "${bundle_image}"
 fi
 
-kubectl apply -f deploy/crds
+kubectl apply -f deploy/e2e/crds
 
 export MCLI_OPS_MANAGER_URL="https://cloud-qa.mongodb.com/"
 export MCLI_PUBLIC_API_KEY="${public_key}"

--- a/scripts/split_roles_yaml.sh
+++ b/scripts/split_roles_yaml.sh
@@ -2,13 +2,20 @@
 
 set -eou pipefail
 
+subdir=${1:-}
+
+config_dir="config"
+if [ "${subdir}" != "" ]; then
+  config_dir+="/${subdir}"
+fi
+
 # This is the script that allows to avoid the restrictions from the controller-gen tool that puts both Role and ClusterRole
 # to the same role.yaml file (and kustomize doesn't provide an easy way to use only a single resource from file as a base)
-# So we simply split the 'config/rbac/roles.yaml' file into two new files
-if [[ -f config/rbac/role.yaml ]]; then
-	awk '/---/{f="xx0"int(++i);} {if(NF!=0)print > f};' config/rbac/role.yaml
-	# csplit config/rbac/role.yaml '/---/' '{*}' &> /dev/null - infinite repetition '{*}' is not working on BSD/OSx
-	mv xx01 config/rbac/clusterwide/role.yaml
-	mv xx02 config/rbac/namespaced/role.yaml
-	rm config/rbac/role.yaml
+# So we simply split the '"${config_dir}rbac/roles.yaml' file into two new files
+if [[ -f "${config_dir}/rbac/role.yaml" ]]; then
+	awk '/---/{f="xx0"int(++i);} {if(NF!=0)print > f};' "${config_dir}/rbac/role.yaml"
+	# csplit "${config_dir}/rbac/role.yaml" '/---/' '{*}' &> /dev/null - infinite repetition '{*}' is not working on BSD/OSx
+	mv xx01 "${config_dir}/rbac/clusterwide/role.yaml"
+	mv xx02 "${config_dir}/rbac/namespaced/role.yaml"
+	rm "${config_dir}/rbac/role.yaml"
 fi

--- a/test/helper/e2e/config/config.go
+++ b/test/helper/e2e/config/config.go
@@ -3,11 +3,11 @@ package config
 const (
 
 	// Kubernetes configuration samples for users in deploy directory
-	DefaultDeployConfig              = "../../deploy/" // Released generated files
-	DefaultClusterWideCRDConfig      = "../../deploy/clusterwide/crds.yaml"
-	DefaultClusterWideOperatorConfig = "../../deploy/clusterwide/clusterwide-config.yaml"
-	DefaultNamespacedCRDConfig       = "../../deploy/namespaced/crds.yaml"
-	DefaultNamespacedOperatorConfig  = "../../deploy/namespaced/namespaced-config.yaml"
+	DefaultDeployConfig              = "../../deploy/e2e/" // Released generated files
+	DefaultClusterWideCRDConfig      = "../../deploy/e2e/clusterwide/crds.yaml"
+	DefaultClusterWideOperatorConfig = "../../deploy/e2e/clusterwide/clusterwide-config.yaml"
+	DefaultNamespacedCRDConfig       = "../../deploy/e2e/namespaced/crds.yaml"
+	DefaultNamespacedOperatorConfig  = "../../deploy/e2e/namespaced/namespaced-config.yaml"
 
 	// Default names/path for tests coordinates
 	DataGenFolder            = "data/gen" // for generated configs
@@ -41,5 +41,5 @@ const (
 	AzureRegionEU = "northeurope"
 
 	// GCP
-	FileNameSAGCP = "gcp_service_account.json"
+	FileNameSAGCP = "../../output/gcp_service_account.json"
 )


### PR DESCRIPTION
This change puts `e2e` testing support file on a separate directory so they do not stomp on tracked repo files for releases. That way, local runs of `e2e` tests should no longer create spurious changes that are not to be committed.

### All Submissions:

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
