### PR TITLE
CLOUDP-226369: Fix instance size updates when auto-scale ON

### DIFF
--- a/pkg/controller/atlasdeployment/region_configuration_test.go
+++ b/pkg/controller/atlasdeployment/region_configuration_test.go
@@ -348,7 +348,7 @@ func TestSyncComputeConfiguration(t *testing.T) {
 		assert.Equal(t, expected, advancedDeployment)
 	})
 
-	t.Run("should unset instance size for existing region with compute autoscaling enabled", func(t *testing.T) {
+	t.Run("should set Atlas instance sizes for existing region with compute autoscaling enabled", func(t *testing.T) {
 		advancedDeployment := &mdbv1.AdvancedDeploymentSpec{
 			DiskSizeGB: pointer.MakePtr(20),
 			ReplicationSpecs: []*mdbv1.AdvancedReplicationSpec{
@@ -379,6 +379,23 @@ func TestSyncComputeConfiguration(t *testing.T) {
 							},
 							Priority: pointer.MakePtr(7),
 						},
+						{
+							ProviderName: "AWS",
+							RegionName:   "EU_WEST1",
+							ElectableSpecs: &mdbv1.Specs{
+								InstanceSize: "M10",
+								NodeCount:    pointer.MakePtr(3),
+							},
+							AutoScaling: &mdbv1.AdvancedAutoScalingSpec{
+								Compute: &mdbv1.ComputeSpec{
+									Enabled:          pointer.MakePtr(true),
+									ScaleDownEnabled: pointer.MakePtr(true),
+									MinInstanceSize:  "M10",
+									MaxInstanceSize:  "M30",
+								},
+							},
+							Priority: pointer.MakePtr(6),
+						},
 					},
 				},
 			},
@@ -392,13 +409,16 @@ func TestSyncComputeConfiguration(t *testing.T) {
 							ProviderName: "AWS",
 							RegionName:   "EU_WEST2",
 							ElectableSpecs: &mdbv1.Specs{
-								NodeCount: pointer.MakePtr(3),
+								InstanceSize: "M30",
+								NodeCount:    pointer.MakePtr(3),
 							},
 							ReadOnlySpecs: &mdbv1.Specs{
-								NodeCount: pointer.MakePtr(1),
+								InstanceSize: "M30",
+								NodeCount:    pointer.MakePtr(1),
 							},
 							AnalyticsSpecs: &mdbv1.Specs{
-								NodeCount: pointer.MakePtr(1),
+								InstanceSize: "M30",
+								NodeCount:    pointer.MakePtr(1),
 							},
 							AutoScaling: &mdbv1.AdvancedAutoScalingSpec{
 								Compute: &mdbv1.ComputeSpec{
@@ -409,6 +429,23 @@ func TestSyncComputeConfiguration(t *testing.T) {
 								},
 							},
 							Priority: pointer.MakePtr(7),
+						},
+						{
+							ProviderName: "AWS",
+							RegionName:   "EU_WEST1",
+							ElectableSpecs: &mdbv1.Specs{
+								InstanceSize: "M30",
+								NodeCount:    pointer.MakePtr(3),
+							},
+							AutoScaling: &mdbv1.AdvancedAutoScalingSpec{
+								Compute: &mdbv1.ComputeSpec{
+									Enabled:          pointer.MakePtr(true),
+									ScaleDownEnabled: pointer.MakePtr(true),
+									MinInstanceSize:  "M10",
+									MaxInstanceSize:  "M30",
+								},
+							},
+							Priority: pointer.MakePtr(6),
 						},
 					},
 				},
@@ -422,15 +459,15 @@ func TestSyncComputeConfiguration(t *testing.T) {
 							ProviderName: "AWS",
 							RegionName:   "EU_WEST2",
 							ElectableSpecs: &mongodbatlas.Specs{
-								InstanceSize: "M10",
+								InstanceSize: "M30",
 								NodeCount:    pointer.MakePtr(3),
 							},
 							ReadOnlySpecs: &mongodbatlas.Specs{
-								InstanceSize: "M10",
+								InstanceSize: "M30",
 								NodeCount:    pointer.MakePtr(1),
 							},
 							AnalyticsSpecs: &mongodbatlas.Specs{
-								InstanceSize: "M10",
+								InstanceSize: "M30",
 								NodeCount:    pointer.MakePtr(1),
 							},
 							AutoScaling: &mongodbatlas.AdvancedAutoScaling{
@@ -442,6 +479,23 @@ func TestSyncComputeConfiguration(t *testing.T) {
 								},
 							},
 							Priority: pointer.MakePtr(7),
+						},
+						{
+							ProviderName: "AWS",
+							RegionName:   "EU_WEST1",
+							ElectableSpecs: &mongodbatlas.Specs{
+								InstanceSize: "M30",
+								NodeCount:    pointer.MakePtr(3),
+							},
+							AutoScaling: &mongodbatlas.AdvancedAutoScaling{
+								Compute: &mongodbatlas.Compute{
+									Enabled:          pointer.MakePtr(true),
+									ScaleDownEnabled: pointer.MakePtr(true),
+									MinInstanceSize:  "M10",
+									MaxInstanceSize:  "M30",
+								},
+							},
+							Priority: pointer.MakePtr(6),
 						},
 					},
 				},
@@ -535,8 +589,8 @@ func TestSyncComputeConfiguration(t *testing.T) {
 							},
 							AutoScaling: &mongodbatlas.AdvancedAutoScaling{
 								Compute: &mongodbatlas.Compute{
-									Enabled:          pointer.MakePtr(false),
-									ScaleDownEnabled: pointer.MakePtr(false),
+									Enabled:          pointer.MakePtr(true),
+									ScaleDownEnabled: pointer.MakePtr(true),
 									MinInstanceSize:  "M10",
 									MaxInstanceSize:  "M30",
 								},

--- a/test/int/deployment_test.go
+++ b/test/int/deployment_test.go
@@ -158,7 +158,7 @@ var _ = Describe("AtlasDeployment", Label("int", "AtlasDeployment", "deployment-
 			mergedDeployment, atlasDeployment, err := mergedAdvancedDeployment(*atlasDeploymentAsAtlas, *createdDeployment.Spec.DeploymentSpec)
 			Expect(err).ToNot(HaveOccurred())
 
-			_, diff := atlasdeployment.AdvancedDeploymentsEqual(zap.S(), mergedDeployment, atlasDeployment)
+			_, diff := atlasdeployment.AdvancedDeploymentsEqual(zap.S(), &mergedDeployment, &atlasDeployment)
 			Expect(diff).To(BeEmpty())
 
 			for _, check := range additionalChecks {
@@ -177,7 +177,7 @@ var _ = Describe("AtlasDeployment", Label("int", "AtlasDeployment", "deployment-
 			mergedDeployment, atlasDeployment, err := mergedAdvancedDeployment(*atlasDeploymentAsAtlas, *createdDeployment.Spec.DeploymentSpec)
 			Expect(err).ToNot(HaveOccurred())
 
-			_, diff := atlasdeployment.AdvancedDeploymentsEqual(zap.S(), mergedDeployment, atlasDeployment)
+			_, diff := atlasdeployment.AdvancedDeploymentsEqual(zap.S(), &mergedDeployment, &atlasDeployment)
 			Expect(diff).To(BeEmpty())
 
 			for _, check := range additionalChecks {
@@ -403,7 +403,7 @@ var _ = Describe("AtlasDeployment", Label("int", "AtlasDeployment", "deployment-
 		})
 	})
 
-	Describe("Create/Update the deployment (more complex scenario)", func() {
+	Describe("Create/Update the deployment (more complex scenario)", Label("int", "create-update-complex-deployment", "slow"), func() {
 		It("Should be created", func() {
 			createdDeployment = mdbv1.DefaultAWSDeployment(namespace.Name, createdProject.Name)
 			createdDeployment.Spec.DeploymentSpec.ClusterType = string(mdbv1.TypeReplicaSet)
@@ -688,7 +688,7 @@ var _ = Describe("AtlasDeployment", Label("int", "AtlasDeployment", "deployment-
 
 			By("Updating the Deployment backups settings", func() {
 				createdDeployment.Spec.DeploymentSpec.BackupEnabled = pointer.MakePtr(true)
-				// createdDeployment.Spec.DeploymentSpec.ProviderBackupEnabled = toptr.MakePtr(true)
+				// createdDeployment.Spec.DeploymentSpec.ProviderBackupEnabled = pointer.MakePtr(true)
 				performUpdate(30 * time.Minute)
 				doDeploymentStatusChecks()
 				checkAtlasState(func(c *admin.AdvancedClusterDescription) {


### PR DESCRIPTION
Atlas rejects updates with empty instance sizes with the following error:
> 400 (request "MISSING_ATTRIBUTE") The required attribute instanceSize was not specified.'

This forces us to select a value to be sent on updates even when we would want Atlas to ignore it and override it for us.

This fix does the following:

1. Instead of setting empty values when autoscaling is ON and something outside the region config was changed, the values from the Atlas side are set, when available and needed.
2. For comparing the region config or the cluster config we specifically ignore instance size differences between the Atlas status and the Kubernetes settings ONLY when autoscaling is ON for the region.

Unit tests have been modified to verify this new behavior.

### All Submissions:

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
