### PR TITLE
CLOUDP-229520: Log diff results

### DIFF
--- a/pkg/controller/atlasdatabaseuser/databaseuser.go
+++ b/pkg/controller/atlasdatabaseuser/databaseuser.go
@@ -262,7 +262,7 @@ func userMatchesSpec(log *zap.SugaredLogger, atlasSpec *mongodbatlas.DatabaseUse
 	}
 	d := cmp.Diff(*atlasSpec, userMerged, cmpopts.EquateEmpty())
 	if d != "" {
-		log.Debugf("Users differs from spec: %s", d)
+		log.Infof("Users differs from spec: %s", d)
 	}
 
 	return d == "", nil

--- a/pkg/controller/atlasdatafederation/datafederation.go
+++ b/pkg/controller/atlasdatafederation/datafederation.go
@@ -76,7 +76,7 @@ func dataFederationEqual(atlasSpec, operatorSpec mdbv1.DataFederationSpec, log *
 
 	d := cmp.Diff(atlasSpec, mergedSpec, cmpopts.EquateEmpty())
 	if d != "" {
-		log.Infof("Data Federation diff: \n%s", d)
+		log.Infof("Data Federation differs from spec: \n%s", d)
 	}
 
 	return d == "", d

--- a/pkg/controller/atlasdatafederation/datafederation.go
+++ b/pkg/controller/atlasdatafederation/datafederation.go
@@ -76,7 +76,7 @@ func dataFederationEqual(atlasSpec, operatorSpec mdbv1.DataFederationSpec, log *
 
 	d := cmp.Diff(atlasSpec, mergedSpec, cmpopts.EquateEmpty())
 	if d != "" {
-		log.Debugf("Data Federation diff: \n%s", d)
+		log.Infof("Data Federation diff: \n%s", d)
 	}
 
 	return d == "", d

--- a/pkg/controller/atlasdeployment/advanced_deployment.go
+++ b/pkg/controller/atlasdeployment/advanced_deployment.go
@@ -208,7 +208,7 @@ func AdvancedDeploymentsEqual(log *zap.SugaredLogger, deploymentOperator *mdbv1.
 	}
 	d := cmp.Diff(actualCleaned, expected, cmpopts.EquateEmpty(), cmpopts.SortSlices(mdbv1.LessAD))
 	if d != "" {
-		log.Debugf("Deployments are different: %s", d)
+		log.Infof("Deployments are different: %s", d)
 	}
 
 	return d == "", d

--- a/pkg/controller/atlasdeployment/advanced_deployment.go
+++ b/pkg/controller/atlasdeployment/advanced_deployment.go
@@ -100,7 +100,7 @@ func advancedDeploymentIdle(ctx *workflow.Context, project *mdbv1.AtlasProject, 
 		}
 	}
 
-	syncRegionConfiguration(&specDeployment, atlasDeploymentAsAtlas)
+	syncRegionConfiguration(ctx.Log, &specDeployment, atlasDeploymentAsAtlas)
 
 	deploymentAsAtlas, err := specDeployment.ToAtlas()
 	if err != nil {
@@ -208,7 +208,7 @@ func AdvancedDeploymentsEqual(log *zap.SugaredLogger, deploymentOperator *mdbv1.
 	}
 	d := cmp.Diff(actualCleaned, expected, cmpopts.EquateEmpty(), cmpopts.SortSlices(mdbv1.LessAD))
 	if d != "" {
-		log.Infof("Deployments are different: %s", d)
+		log.Infof("Deployment differs from spec: %s", d)
 	}
 
 	return d == "", d

--- a/pkg/controller/atlasdeployment/atlasdeployment_controller.go
+++ b/pkg/controller/atlasdeployment/atlasdeployment_controller.go
@@ -671,7 +671,7 @@ func serverlessDeploymentMatchesSpec(log *zap.SugaredLogger, atlasSpec *mongodba
 
 	d := cmp.Diff(atlasSpec, &clusterMerged, cmpopts.EquateEmpty())
 	if d != "" {
-		log.Debugf("Serverless deployment differs from spec: %s", d)
+		log.Infof("Serverless deployment differs from spec: %s", d)
 	}
 
 	return d == "", nil
@@ -689,7 +689,7 @@ func advancedDeploymentMatchesSpec(log *zap.SugaredLogger, atlasSpec *mongodbatl
 
 	d := cmp.Diff(atlasSpec, &clusterMerged, cmpopts.EquateEmpty())
 	if d != "" {
-		log.Debugf("Advanced deployment differs from spec: %s", d)
+		log.Infof("Advanced deployment differs from spec: %s", d)
 	}
 
 	return d == "", nil

--- a/pkg/controller/atlasdeployment/backup.go
+++ b/pkg/controller/atlasdeployment/backup.go
@@ -5,8 +5,9 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/controller/validate"
 	"go.uber.org/zap"
+
+	"github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/controller/validate"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"

--- a/pkg/controller/atlasdeployment/region_configuration_test.go
+++ b/pkg/controller/atlasdeployment/region_configuration_test.go
@@ -5,12 +5,15 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"go.mongodb.org/atlas/mongodbatlas"
+	"go.uber.org/zap/zaptest"
 
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/pointer"
 	mdbv1 "github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/api/v1"
 )
 
 func TestSyncComputeConfiguration(t *testing.T) {
+	logger := zaptest.NewLogger(t).Sugar()
+
 	t.Run("should not modify new region when there's no cluster in Atlas", func(t *testing.T) {
 		advancedDeployment := &mdbv1.AdvancedDeploymentSpec{
 			DiskSizeGB: pointer.MakePtr(20),
@@ -64,8 +67,7 @@ func TestSyncComputeConfiguration(t *testing.T) {
 				},
 			},
 		}
-
-		syncRegionConfiguration(advancedDeployment, nil)
+		syncRegionConfiguration(logger, advancedDeployment, nil)
 		assert.Equal(t, expected, advancedDeployment)
 	})
 
@@ -134,7 +136,7 @@ func TestSyncComputeConfiguration(t *testing.T) {
 			},
 		}
 
-		syncRegionConfiguration(advancedDeployment, atlasCluster)
+		syncRegionConfiguration(logger, advancedDeployment, atlasCluster)
 		assert.Equal(t, expected, advancedDeployment)
 	})
 
@@ -203,7 +205,7 @@ func TestSyncComputeConfiguration(t *testing.T) {
 			},
 		}
 
-		syncRegionConfiguration(advancedDeployment, atlasCluster)
+		syncRegionConfiguration(logger, advancedDeployment, atlasCluster)
 		assert.Equal(t, expected, advancedDeployment)
 	})
 
@@ -275,7 +277,7 @@ func TestSyncComputeConfiguration(t *testing.T) {
 			},
 		}
 
-		syncRegionConfiguration(advancedDeployment, atlasCluster)
+		syncRegionConfiguration(logger, advancedDeployment, atlasCluster)
 		assert.Equal(t, expected, advancedDeployment)
 	})
 
@@ -344,7 +346,7 @@ func TestSyncComputeConfiguration(t *testing.T) {
 			},
 		}
 
-		syncRegionConfiguration(advancedDeployment, atlasCluster)
+		syncRegionConfiguration(logger, advancedDeployment, atlasCluster)
 		assert.Equal(t, expected, advancedDeployment)
 	})
 
@@ -502,7 +504,7 @@ func TestSyncComputeConfiguration(t *testing.T) {
 			},
 		}
 
-		syncRegionConfiguration(advancedDeployment, atlasCluster)
+		syncRegionConfiguration(logger, advancedDeployment, atlasCluster)
 		assert.Equal(t, expected, advancedDeployment)
 	})
 
@@ -602,7 +604,7 @@ func TestSyncComputeConfiguration(t *testing.T) {
 			},
 		}
 
-		syncRegionConfiguration(advancedDeployment, atlasCluster)
+		syncRegionConfiguration(logger, advancedDeployment, atlasCluster)
 		assert.Equal(t, expected, advancedDeployment)
 	})
 
@@ -712,7 +714,7 @@ func TestSyncComputeConfiguration(t *testing.T) {
 			},
 		}
 
-		syncRegionConfiguration(advancedDeployment, atlasCluster)
+		syncRegionConfiguration(logger, advancedDeployment, atlasCluster)
 		assert.Equal(t, expected, advancedDeployment)
 	})
 
@@ -823,7 +825,7 @@ func TestSyncComputeConfiguration(t *testing.T) {
 			},
 		}
 
-		syncRegionConfiguration(advancedDeployment, atlasCluster)
+		syncRegionConfiguration(logger, advancedDeployment, atlasCluster)
 		assert.Equal(t, expected, advancedDeployment)
 	})
 }

--- a/pkg/controller/atlasfederatedauth/atlasfederated_auth_controller.go
+++ b/pkg/controller/atlasfederatedauth/atlasfederated_auth_controller.go
@@ -93,7 +93,7 @@ func (r *AtlasFederatedAuthReconciler) Reconcile(ctx context.Context, req ctrl.R
 	workflowCtx.OrgID = orgID
 
 	// Setting protection flag to static false because ownership detection is disabled.
-	owner, err := customresource.IsOwner(fedauth, false, customresource.IsResourceManagedByOperator, managedByAtlas(ctx, atlasClient, orgID))
+	owner, err := customresource.IsOwner(fedauth, false, customresource.IsResourceManagedByOperator, managedByAtlas(ctx, log, atlasClient, orgID))
 	if err != nil {
 		result = workflow.Terminate(workflow.Internal, fmt.Sprintf("unable to resolve ownership for deletion protection: %s", err))
 		workflowCtx.SetConditionFromResult(status.FederatedAuthReadyType, result)
@@ -139,7 +139,7 @@ func logIfWarning(ctx *workflow.Context, result workflow.Result) {
 	}
 }
 
-func managedByAtlas(ctx context.Context, atlasClient *admin.APIClient, orgID string) customresource.AtlasChecker {
+func managedByAtlas(ctx context.Context, log *zap.SugaredLogger, atlasClient *admin.APIClient, orgID string) customresource.AtlasChecker {
 	return func(resource mdbv1.AtlasCustomResource) (bool, error) {
 		fedauth, ok := resource.(*mdbv1.AtlasFederatedAuth)
 		if !ok {
@@ -168,6 +168,6 @@ func managedByAtlas(ctx context.Context, atlasClient *admin.APIClient, orgID str
 			return false, err
 		}
 
-		return !federatedSettingsAreEqual(convertedAuth, atlasFedAuth), nil
+		return !federatedSettingsAreEqual(log, convertedAuth, atlasFedAuth), nil
 	}
 }

--- a/pkg/controller/atlasproject/custom_roles.go
+++ b/pkg/controller/atlasproject/custom_roles.go
@@ -5,8 +5,9 @@ import (
 	"errors"
 	"fmt"
 
-	v1 "github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/api/v1"
 	"go.uber.org/zap"
+
+	v1 "github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/api/v1"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"

--- a/pkg/controller/atlasproject/custom_roles.go
+++ b/pkg/controller/atlasproject/custom_roles.go
@@ -331,10 +331,13 @@ func canCustomRolesReconcile(workflowCtx *workflow.Context, protected bool, akoP
 
 	atlasCustomRoles := mapToOperator(atlasData)
 
-	if d := cmp.Diff(latestConfig.CustomRoles, atlasCustomRoles, cmpopts.EquateEmpty()); d != "" {
+	if cmp.Diff(latestConfig.CustomRoles, atlasCustomRoles, cmpopts.EquateEmpty()) == "" {
+		return true, nil
+	}
+
+	if d := cmp.Diff(akoProject.Spec.CustomRoles, atlasCustomRoles, cmpopts.EquateEmpty()); d != "" {
 		workflowCtx.Log.Infof("Custom roles differ from spec: %s", d)
 		return false, nil
 	}
-
 	return true, nil
 }

--- a/pkg/controller/atlasproject/custom_roles_test.go
+++ b/pkg/controller/atlasproject/custom_roles_test.go
@@ -462,6 +462,7 @@ func TestCanCustomRolesReconcile(t *testing.T) {
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: `{"customRoles":[{"name":"testRole1","actions":[{"name":"INSERT","resources":[{"cluster":false,"database":"testDB","collection":"testCollection"}]}]}]}`})
 		workflowCtx := &workflow.Context{
 			Client:  &atlasClient,
+			Log:     zaptest.NewLogger(t).Sugar(),
 			Context: context.Background(),
 		}
 		result, err := canCustomRolesReconcile(workflowCtx, true, akoProject)
@@ -541,6 +542,7 @@ func TestEnsureCustomRoles(t *testing.T) {
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: `{"customRoles":[{"name":"testRole1","actions":[{"name":"INSERT","resources":[{"cluster":false,"database":"testDB","collection":"testCollection"}]}]}]}`})
 		workflowCtx := &workflow.Context{
 			Client:  &atlasClient,
+			Log:     zaptest.NewLogger(t).Sugar(),
 			Context: context.Background(),
 		}
 		result := ensureCustomRoles(workflowCtx, akoProject, true)

--- a/pkg/controller/atlasproject/custom_roles_test.go
+++ b/pkg/controller/atlasproject/custom_roles_test.go
@@ -403,7 +403,7 @@ func TestCanCustomRolesReconcile(t *testing.T) {
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: `{"customRoles":[{"name":"testRole1","actions":[{"name":"INSERT","resources":[{"database":"testDB","collection":"testCollection"}]}]}]}`})
 		workflowCtx := &workflow.Context{
 			Client:  &atlasClient,
-			Log: zaptest.NewLogger(t).Sugar(),
+			Log:     zaptest.NewLogger(t).Sugar(),
 			Context: context.Background(),
 		}
 		result, err := canCustomRolesReconcile(workflowCtx, true, akoProject)

--- a/pkg/controller/atlasproject/custom_roles_test.go
+++ b/pkg/controller/atlasproject/custom_roles_test.go
@@ -403,6 +403,7 @@ func TestCanCustomRolesReconcile(t *testing.T) {
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: `{"customRoles":[{"name":"testRole1","actions":[{"name":"INSERT","resources":[{"database":"testDB","collection":"testCollection"}]}]}]}`})
 		workflowCtx := &workflow.Context{
 			Client:  &atlasClient,
+			Log: zaptest.NewLogger(t).Sugar(),
 			Context: context.Background(),
 		}
 		result, err := canCustomRolesReconcile(workflowCtx, true, akoProject)

--- a/pkg/controller/atlasproject/custom_roles_test.go
+++ b/pkg/controller/atlasproject/custom_roles_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/atlas/mongodbatlas"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
 
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/mocks/atlas"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/pointer"
@@ -73,7 +74,7 @@ func TestCalculateChanges(t *testing.T) {
 				},
 			},
 		},
-		calculateChanges(current, desired),
+		calculateChanges(zaptest.NewLogger(t).Sugar(), current, desired),
 	)
 }
 

--- a/pkg/controller/atlasproject/ipaccess_list.go
+++ b/pkg/controller/atlasproject/ipaccess_list.go
@@ -58,7 +58,8 @@ func ensureIPAccessList(service *workflow.Context, statusFunc atlas.IPAccessList
 	}
 
 	currentList := mapToOperatorSpec(list.GetResults())
-	if cmp.Diff(currentList, akoProject.Spec.ProjectIPAccessList, cmpopts.EquateEmpty()) != "" {
+	if d := cmp.Diff(currentList, akoProject.Spec.ProjectIPAccessList, cmpopts.EquateEmpty()); d != "" {
+		service.Log.Infof("IP Access List differs from spec: %s", d)
 		err = syncIPAccessList(service, akoProject.ID(), currentList, desiredList)
 		if err != nil {
 			result := workflow.Terminate(workflow.ProjectIPNotCreatedInAtlas, fmt.Sprintf("failed to sync desired state with Atlas: %s", err))

--- a/pkg/controller/atlasproject/ipaccess_list_test.go
+++ b/pkg/controller/atlasproject/ipaccess_list_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/atlas-sdk/v20231115004/admin"
+	"go.uber.org/zap/zaptest"
 
 	atlasmock "github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/mocks/atlas"
 	mdbv1 "github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/api/v1"
@@ -303,6 +304,7 @@ func TestEnsureIPAccessList(t *testing.T) {
 		}
 		workflowCtx := &workflow.Context{
 			SdkClient: atlasClient,
+			Log:       zaptest.NewLogger(t).Sugar(),
 			Context:   context.Background(),
 		}
 		result := ensureIPAccessList(

--- a/pkg/controller/atlasproject/team_reconciler.go
+++ b/pkg/controller/atlasproject/team_reconciler.go
@@ -348,7 +348,11 @@ func teamsManagedByAtlas(workflowCtx *workflow.Context) customresource.AtlasChec
 		for _, username := range team.Spec.Usernames {
 			usernames = append(usernames, string(username))
 		}
-
-		return cmp.Diff(usernames, atlasTeam.Usernames) != "", nil
+		workflowCtx.Log.Infof("x")
+		if d := cmp.Diff(usernames, atlasTeam.Usernames); d != "" {
+			workflowCtx.Log.Infof("Atlas team usernames differ from spec: %s", d)
+			return true, nil
+		}
+		return false, nil
 	}
 }

--- a/pkg/controller/atlasproject/team_reconciler.go
+++ b/pkg/controller/atlasproject/team_reconciler.go
@@ -348,7 +348,6 @@ func teamsManagedByAtlas(workflowCtx *workflow.Context) customresource.AtlasChec
 		for _, username := range team.Spec.Usernames {
 			usernames = append(usernames, string(username))
 		}
-		workflowCtx.Log.Infof("x")
 		if d := cmp.Diff(usernames, atlasTeam.Usernames); d != "" {
 			workflowCtx.Log.Infof("Atlas team usernames differ from spec: %s", d)
 			return true, nil

--- a/pkg/controller/atlasproject/team_reconciler_test.go
+++ b/pkg/controller/atlasproject/team_reconciler_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"go.mongodb.org/atlas/mongodbatlas"
+	"go.uber.org/zap/zaptest"
 
 	atlasmock "github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/mocks/atlas"
 	v1 "github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/api/v1"
@@ -144,6 +145,7 @@ func TestTeamManagedByAtlas(t *testing.T) {
 		workflowCtx := &workflow.Context{
 			OrgID:   "orgID-1",
 			Client:  &atlasClient,
+			Log:     zaptest.NewLogger(t).Sugar(),
 			Context: context.Background(),
 		}
 		checker := teamsManagedByAtlas(workflowCtx)

--- a/pkg/controller/atlasproject/teams.go
+++ b/pkg/controller/atlasproject/teams.go
@@ -326,7 +326,12 @@ func canAssignedTeamsReconcile(workflowCtx *workflow.Context, k8sClient client.C
 		return false, err
 	}
 
-	return cmp.Diff(atlasAssignedTeamsInfo, currentAssignedTeamsInfo, cmpopts.EquateEmpty()) == "", nil
+	if d := cmp.Diff(atlasAssignedTeamsInfo, currentAssignedTeamsInfo, cmpopts.EquateEmpty()); d != "" {
+		workflowCtx.Log.Infof("Assigned teams differ from spec: %s", d)
+		return false, nil
+	}
+
+	return true, nil
 }
 
 func collectTeams(ctx context.Context, k8sClient client.Client, projectSpec *v1.AtlasProjectSpec, projectNamespace string) ([]assignedTeamInfo, error) {

--- a/pkg/controller/atlasproject/teams_test.go
+++ b/pkg/controller/atlasproject/teams_test.go
@@ -108,6 +108,7 @@ func TestCanAssignedTeamsReconcile(t *testing.T) {
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: "{}"})
 		workflowCtx := &workflow.Context{
 			Client:  &atlasClient,
+			Log:     zaptest.NewLogger(t).Sugar(),
 			Context: context.Background(),
 		}
 		result, err := canAssignedTeamsReconcile(workflowCtx, k8sClient, true, akoProject)
@@ -248,6 +249,7 @@ func TestCanAssignedTeamsReconcile(t *testing.T) {
 		akoProject.WithAnnotations(map[string]string{customresource.AnnotationLastAppliedConfiguration: `{"teams":[{"teamRef":{"name":"team1","namespace":"default"},"roles":["GROUP_OWNER"]}]}`})
 		workflowCtx := &workflow.Context{
 			Client:  &atlasClient,
+			Log:     zaptest.NewLogger(t).Sugar(),
 			Context: context.Background(),
 		}
 		result, err := canAssignedTeamsReconcile(workflowCtx, k8sClient, true, akoProject)


### PR DESCRIPTION
We currently use cmp.Diff() a lot to compare Atlas state with Kubernetes state. Sometimes we log this at Debug level, and sometimes we don't log it at all. We should always log this to info (if there's a diff), so customers/HELP tickets have an easier time spotting where and why reconciles are occurring.

### All Submissions:

* [x] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if there is one).
* [ ] Update docs/release-notes/release-notes.md if your changes should be included in the release notes for the next release.
