### PR TITLE
CLOUDP-212054: Sign images with Garasign

### DIFF
--- a/.github/workflows/rebuild-released-images.yaml
+++ b/.github/workflows/rebuild-released-images.yaml
@@ -159,5 +159,14 @@ jobs:
           GRS_USERNAME:  ${{ secrets.GRS_USERNAME }}
           GRS_PASSWORD:  ${{ secrets.GRS_PASSWORD }}
         run: |
-          make sign IMG_TO_SIGN="${{ env.IMAGE_REPOSITORY }}:${{ steps.daily-tag.outputs.daily-tag }}" SIGNATURE_REPO=${{ env.IMAGE_REPOSITORY }}
-          make sign IMG_TO_SIGN="quay.io/${{ env.IMAGE_REPOSITORY }}:${{ steps.daily-tag.outputs.daily-tag }}" SIGNATURE_REPO=${{ env.IMAGE_REPOSITORY }}
+          make sign IMG="${{ env.IMAGE_REPOSITORY }}:${{ steps.daily-tag.outputs.daily-tag }}" SIGNATURE_REPO=${{ env.IMAGE_REPOSITORY }}
+          make sign IMG="quay.io/${{ env.IMAGE_REPOSITORY }}:${{ steps.daily-tag.outputs.daily-tag }}" SIGNATURE_REPO=${{ env.IMAGE_REPOSITORY }}
+      - name: Self-verify images
+        if: steps.check-signing-support.outputs.sign == 'true'
+        env:
+          PKCS11_URI: ${{ secrets.PKCS11_URI }}
+          GRS_USERNAME:  ${{ secrets.GRS_USERNAME }}
+          GRS_PASSWORD:  ${{ secrets.GRS_PASSWORD }}
+        run: |
+          make verify IMG="${{ env.IMAGE_REPOSITORY }}:${{ steps.daily-tag.outputs.daily-tag }}" SIGNATURE_REPO=${{ env.IMAGE_REPOSITORY }}
+          make verify IMG="quay.io/${{ env.IMAGE_REPOSITORY }}:${{ steps.daily-tag.outputs.daily-tag }}" SIGNATURE_REPO=${{ env.IMAGE_REPOSITORY }}

--- a/.github/workflows/rebuild-released-images.yaml
+++ b/.github/workflows/rebuild-released-images.yaml
@@ -52,6 +52,7 @@ jobs:
           fi
   
   build-and-publish-image:
+    environment: release
     runs-on: ubuntu-latest
     needs:
       - read-versions
@@ -101,6 +102,14 @@ jobs:
           else
             echo "dockerfile=Dockerfile" >> $GITHUB_OUTPUT
           fi
+      - name: Check signing supported
+        id: check-signing-support
+        run: |
+            if test -f "./scripts/sign-multiarch.sh"; then
+              echo "sign=true" >> $GITHUB_OUTPUT
+            else
+              echo "sign=false" >> $GITHUB_OUTPUT
+            fi
       - name: Build all platforms & check version
         if: steps.pick-dockerfile.outputs.dockerfile == 'fast.Dockerfile'
         run: |
@@ -143,3 +152,12 @@ jobs:
             ${{ env.IMAGE_REPOSITORY }}:${{ matrix.version }}
             quay.io/${{ env.IMAGE_REPOSITORY }}:${{ steps.daily-tag.outputs.daily-tag }}
             quay.io/${{ env.IMAGE_REPOSITORY }}:${{ matrix.version }}
+      - name: Sign images
+        if: steps.check-signing-support.outputs.sign == 'true'
+        env:
+          PKCS11_URI: ${{ secrets.PKCS11_URI }}
+          GRS_USERNAME:  ${{ secrets.GRS_USERNAME }}
+          GRS_PASSWORD:  ${{ secrets.GRS_PASSWORD }}
+        run: |
+          make sign IMG_TO_SIGN="${{ env.IMAGE_REPOSITORY }}:${{ steps.daily-tag.outputs.daily-tag }}" SIGNATURE_REPO=${{ env.IMAGE_REPOSITORY }}
+          make sign IMG_TO_SIGN="quay.io/${{ env.IMAGE_REPOSITORY }}:${{ steps.daily-tag.outputs.daily-tag }}" SIGNATURE_REPO=${{ env.IMAGE_REPOSITORY }}

--- a/.github/workflows/release-post-merge.yml
+++ b/.github/workflows/release-post-merge.yml
@@ -170,9 +170,19 @@ jobs:
           GRS_USERNAME:  ${{ secrets.GRS_USERNAME }}
           GRS_PASSWORD:  ${{ secrets.GRS_PASSWORD }}
         run: |
-          make sign IMG_TO_SIGN="${{ env.IMAGE_REPOSITORY }}:${{ steps.tag.outputs.version }}" SIGNATURE_REPO=${{ env.IMAGE_REPOSITORY }}
-          make sign IMG_TO_SIGN="quay.io/${{ env.IMAGE_REPOSITORY }}:${{ steps.tag.outputs.version }}" SIGNATURE_REPO=${{ env.IMAGE_REPOSITORY }}
-          make sign IMG_TO_SIGN="quay.io/${{ env.IMAGE_REPOSITORY }}:${{ steps.tag.outputs.version }}-certified" SIGNATURE_REPO=${{ env.IMAGE_REPOSITORY }}
+          make sign IMG="${{ env.IMAGE_REPOSITORY }}:${{ steps.tag.outputs.version }}" SIGNATURE_REPO=${{ env.IMAGE_REPOSITORY }}
+          make sign IMG="quay.io/${{ env.IMAGE_REPOSITORY }}:${{ steps.tag.outputs.version }}" SIGNATURE_REPO=${{ env.IMAGE_REPOSITORY }}
+          make sign IMG="quay.io/${{ env.IMAGE_REPOSITORY }}:${{ steps.tag.outputs.version }}-certified" SIGNATURE_REPO=${{ env.IMAGE_REPOSITORY }}
+      - name: Self-verify images
+        if: steps.check-signing-support.outputs.sign == 'true'
+        env:
+          PKCS11_URI: ${{ secrets.PKCS11_URI }}
+          GRS_USERNAME:  ${{ secrets.GRS_USERNAME }}
+          GRS_PASSWORD:  ${{ secrets.GRS_PASSWORD }}
+        run: |
+          make verify IMG="${{ env.IMAGE_REPOSITORY }}:${{ steps.tag.outputs.version }}" SIGNATURE_REPO=${{ env.IMAGE_REPOSITORY }}
+          make verify IMG="quay.io/${{ env.IMAGE_REPOSITORY }}:${{ steps.tag.outputs.version }}" SIGNATURE_REPO=${{ env.IMAGE_REPOSITORY }}
+          make verify IMG="quay.io/${{ env.IMAGE_REPOSITORY }}:${{ steps.tag.outputs.version }}-certified" SIGNATURE_REPO=${{ env.IMAGE_REPOSITORY }}
       - name: Create configuration package
         run: |
           set -x
@@ -200,4 +210,3 @@ jobs:
           asset_path: ./atlas-operator-all-in-one-${{ steps.tag.outputs.version }}.tar.gz
           asset_name: atlas-operator-all-in-one-${{ steps.tag.outputs.version }}.tar.gz
           asset_content_type: application/tgz
-

--- a/.github/workflows/release-post-merge.yml
+++ b/.github/workflows/release-post-merge.yml
@@ -114,6 +114,14 @@ jobs:
           else
             echo "dockerfile=Dockerfile" >> $GITHUB_OUTPUT
           fi
+      - name: Check signing supported
+        id: check-signing-support
+        run: |
+            if test -f "./scripts/sign-multiarch.sh"; then
+              echo "sign=true" >> $GITHUB_OUTPUT
+            else
+              echo "sign=false" >> $GITHUB_OUTPUT
+            fi
       - name: Build all platforms & check version
         if: steps.pick-dockerfile.outputs.dockerfile == 'fast.Dockerfile'
         run: |
@@ -148,6 +156,23 @@ jobs:
           quay_password: ${{ secrets.QUAY_PASSWORD }}
           rhcc_token: ${{ secrets.RH_CERTIFICATION_PYXIS_API_TOKEN }}
           rhcc_project: ${{ secrets.RH_CERTIFICATION_OSPID }}
+      - name: Login to artifactory.corp.mongodb.com
+        if: steps.check-signing-support.outputs.sign == 'true'
+        uses: docker/login-action@v3
+        with:
+          registry: artifactory.corp.mongodb.com
+          username: ${{ secrets.MDB_ARTIFACTORY_USERNAME }}
+          password: ${{ secrets.MDB_ARTIFACTORY_PASSWORD }}
+      - name: Sign images
+        if: steps.check-signing-support.outputs.sign == 'true'
+        env:
+          PKCS11_URI: ${{ secrets.PKCS11_URI }}
+          GRS_USERNAME:  ${{ secrets.GRS_USERNAME }}
+          GRS_PASSWORD:  ${{ secrets.GRS_PASSWORD }}
+        run: |
+          make sign IMG_TO_SIGN="${{ env.IMAGE_REPOSITORY }}:${{ steps.tag.outputs.version }}" SIGNATURE_REPO=${{ env.IMAGE_REPOSITORY }}
+          make sign IMG_TO_SIGN="quay.io/${{ env.IMAGE_REPOSITORY }}:${{ steps.tag.outputs.version }}" SIGNATURE_REPO=${{ env.IMAGE_REPOSITORY }}
+          make sign IMG_TO_SIGN="quay.io/${{ env.IMAGE_REPOSITORY }}:${{ steps.tag.outputs.version }}-certified" SIGNATURE_REPO=${{ env.IMAGE_REPOSITORY }}
       - name: Create configuration package
         run: |
           set -x

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ tools/clean/clean
 tools/makejwt/makejwt
 tools/metrics/metrics
 
+# ignore the ako.siging key local copy
+ako.pem
+

--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,10 @@ ifndef IMG
 IMG := ${OPERATOR_REGISTRY}:${VERSION}
 endif
 
+# Image to be signed, including tag (but not SHAs)
+IMG_TO_SIGN ?= IMG
+SIGNATURE_REPO ?= OPERATOR_REGISTRY
+
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
 GOBIN=$(shell go env GOPATH)/bin
@@ -457,3 +461,8 @@ test-metrics:
 
 .PHONY: test-tools ## Test all tools
 test-tools: test-clean test-makejwt test-metrics
+
+.PHONY: sign ## Sign an AKO multi-architecture image
+sign:
+	@echo "Signing multi-architecture image $(IMG_TO_SIGN)..."
+	IMG_TO_SIGN=$(IMG_TO_SIGN) SIGNATURE_REPO=$(SIGNATURE_REPO) ./scripts/sign-multiarch.sh

--- a/scripts/sign-multiarch.sh
+++ b/scripts/sign-multiarch.sh
@@ -3,19 +3,20 @@
 set -euo pipefail
 
 REPO=${IMG_REPO:-docker.io/mongodb/mongodb-atlas-kubernetes-operator-prerelease}
-img_to_sign=${IMG_TO_SIGN:-$REPO:$VERSION}
+img=${IMG:-$REPO:$VERSION}
+action=${1:-sign}
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
-docker pull "${img_to_sign}"
-MULTIARCH_IMG_SHA=$(docker inspect "${img_to_sign}" |jq -rc '.[0].Id')
-IMG_PLATFORMS_SHAS=$(docker manifest inspect "${img_to_sign}" | \
+docker pull "${img}"
+MULTIARCH_IMG_SHA=$(docker inspect "${img}" |jq -rc '.[0].Id')
+IMG_PLATFORMS_SHAS=$(docker manifest inspect "${img}" | \
   jq -rc '.manifests[] | select(.platform.os != "unknown" and .platform.architecture != "unknown") | .digest')
 
-echo "Signing parent multiarch image ${img_to_sign}@${MULTIARCH_IMG_SHA}..."
-IMG_TO_SIGN="${img_to_sign}@${MULTIARCH_IMG_SHA}" "${SCRIPT_DIR}"/sign.sh
+echo "${action} parent multiarch image ${img}@${MULTIARCH_IMG_SHA}..."
+IMG="${img}@${MULTIARCH_IMG_SHA}" "${SCRIPT_DIR}/${action}.sh"
 
 for platform_sha in ${IMG_PLATFORMS_SHAS}; do
-  echo "Signing platform image ${img_to_sign}@${platform_sha}..."
-  IMG_TO_SIGN="${img_to_sign}@${platform_sha}" "${SCRIPT_DIR}"/sign.sh
+  echo "${action} platform image ${img}@${platform_sha}..."
+  IMG="${img}@${platform_sha}" "${SCRIPT_DIR}/${action}.sh"
 done

--- a/scripts/sign-multiarch.sh
+++ b/scripts/sign-multiarch.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -euo pipefail
+
+REPO=${IMG_REPO:-docker.io/mongodb/mongodb-atlas-kubernetes-operator-prerelease}
+img_to_sign=${IMG_TO_SIGN:-$REPO:$VERSION}
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+docker pull "${img_to_sign}"
+MULTIARCH_IMG_SHA=$(docker inspect "${img_to_sign}" |jq -rc '.[0].Id')
+IMG_PLATFORMS_SHAS=$(docker manifest inspect "${img_to_sign}" | \
+  jq -rc '.manifests[] | select(.platform.os != "unknown" and .platform.architecture != "unknown") | .digest')
+
+echo "Signing parent multiarch image ${img_to_sign}@${MULTIARCH_IMG_SHA}..."
+IMG_TO_SIGN="${img_to_sign}@${MULTIARCH_IMG_SHA}" "${SCRIPT_DIR}"/sign.sh
+
+for platform_sha in ${IMG_PLATFORMS_SHAS}; do
+  echo "Signing platform image ${img_to_sign}@${platform_sha}..."
+  IMG_TO_SIGN="${img_to_sign}@${platform_sha}" "${SCRIPT_DIR}"/sign.sh
+done

--- a/scripts/sign.sh
+++ b/scripts/sign.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+set -euo pipefail
+
+REPO=${IMG_REPO:-docker.io/mongodb/mongodb-atlas-kubernetes-operator-prerelease}
+img_to_sign=${IMG_TO_SIGN:-$REPO:$VERSION}
+SIGNATURE_REPO=${SIGNATURE_REPO:-$REPO}
+TMPDIR=${TMPDIR:-/tmp}
+
+# Useful for setups with credential helpers
+SIGNING_DOCKERCFG_BASE64=${SIGNING_DOCKERCFG_BASE64:-EMPTY}
+if [ "${SIGNING_DOCKERCFG_BASE64}" != "EMPTY" ]; then
+  DOCKER_CFG="${TMPDIR}/signing-docker-config.json"
+  echo "${SIGNING_DOCKERCFG_BASE64}" | base64 -d > "${DOCKER_CFG}"
+fi
+
+DOCKER_CFG=${DOCKER_CFG:-~/.docker/config.json}
+
+SIGNING_ENVFILE="${TMPDIR}/signing-envfile"
+
+{
+  echo "GRS_CONFIG_USER1_USERNAME=${GRS_USERNAME}";
+  echo "GRS_CONFIG_USER1_PASSWORD=${GRS_PASSWORD}";
+  echo "COSIGN_REPOSITORY=${SIGNATURE_REPO}";
+}  > "${SIGNING_ENVFILE}"
+
+docker run \
+  --env-file="${SIGNING_ENVFILE}" \
+  -v "${DOCKER_CFG}:/root/.docker/config.json" \
+  --rm \
+  -v "$(pwd):$(pwd)" \
+  -w "$(pwd)" \
+  artifactory.corp.mongodb.com/release-tools-container-registry-local/garasign-cosign \
+  cosign sign --key "${PKCS11_URI}" --tlog-upload=false "${img_to_sign}"

--- a/scripts/sign.sh
+++ b/scripts/sign.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 REPO=${IMG_REPO:-docker.io/mongodb/mongodb-atlas-kubernetes-operator-prerelease}
-img_to_sign=${IMG_TO_SIGN:-$REPO:$VERSION}
+img=${IMG:-$REPO:$VERSION}
 SIGNATURE_REPO=${SIGNATURE_REPO:-$REPO}
 TMPDIR=${TMPDIR:-/tmp}
 
@@ -31,4 +31,4 @@ docker run \
   -v "$(pwd):$(pwd)" \
   -w "$(pwd)" \
   artifactory.corp.mongodb.com/release-tools-container-registry-local/garasign-cosign \
-  cosign sign --key "${PKCS11_URI}" --tlog-upload=false "${img_to_sign}"
+  cosign sign --key "${PKCS11_URI}" --tlog-upload=false "${img}"

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -9,4 +9,4 @@ SIGNATURE_REPO=${SIGNATURE_REPO:-$REPO}
 KEY_FILE=${KEY_FILE:-ako.pem}
 
 COSIGN_REPOSITORY="${SIGNATURE_REPO}" cosign verify \
-  --key="${KEY_FILE}" "${img_to_verify}" # --insecure-ignore-tlog 
+  --key="${KEY_FILE}" "${img_to_verify}"

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -euo pipefail
+
+REPO=${IMG_REPO:-docker.io/mongodb/mongodb-atlas-kubernetes-operator-prerelease}
+img_to_verify=${IMG:-$REPO:$VERSION}
+SIGNATURE_REPO=${SIGNATURE_REPO:-$REPO}
+
+KEY_FILE=${KEY_FILE:-ako.pem}
+
+COSIGN_REPOSITORY="${SIGNATURE_REPO}" cosign verify \
+  --key="${KEY_FILE}" "${img_to_verify}" # --insecure-ignore-tlog 


### PR DESCRIPTION
✅ [Sign and self verification test passed](https://github.com/mongodb/mongodb-atlas-kubernetes/actions/runs/8003743939/job/21859696852)

Includes:
- Signing images for releases and rebuilds.
- Signing from Makefile rule.
- Script to detect multi architecture SHAs and sing the parent manifest and platform images.
- Script for each individual image signature.

Note the new secrets required and already populated in the CI `release` environment:
- Parameter `PKCS11_URI` required by Garasign
- Credentials for Garasign: `GRS_USERNAME` & `GRS_PASSWORD`
- Credentials for the MongoDB Artifactory holding the Garasign container `MDB_ARTIFACTORY_USERNAME` & `MDB_ARTIFACTORY_PASSWORD`

### All Submissions:

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
