### PR TITLE
CLOUDP-230403: Avoid error 'version' not provided

### DIFF
--- a/.github/workflows/release-post-merge.yml
+++ b/.github/workflows/release-post-merge.yml
@@ -117,10 +117,10 @@ jobs:
       - name: Build all platforms & check version
         if: steps.pick-dockerfile.outputs.dockerfile == 'fast.Dockerfile'
         run: |
-          make all-platforms VERSION=${{ github.event.inputs.version }}
+          make all-platforms VERSION=${{ steps.tag.outputs.version }}
           # not all versions Makefiles support the version check
           if make | grep -q check-version; then
-            make check-version VERSION=${{ github.event.inputs.version }}
+            make check-version VERSION=${{ steps.tag.outputs.version }}
           fi
       - name: Build and Push image
         uses: ./.github/actions/build-push-image


### PR DESCRIPTION
The version is calculated at the `Print Env and Get version` step. Such version takes the input version as a hint, or calculates it from the push event branch name.

In either case, the version to use after that step is always `steps.tag.outputs.version`, **never** `github.event.inputs.version` again. 

### All Submissions:

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
