### PR TITLE
CLOUDP-231153: Do not test backups on an M0

### DIFF
--- a/test/helper/e2e/actions/steps.go
+++ b/test/helper/e2e/actions/steps.go
@@ -36,7 +36,7 @@ func WaitDeployment(data *model.TestDataProvider, generation int) {
 				g.Expect(err).ToNot(HaveOccurred())
 				return gen
 			},
-		).WithTimeout(5 * time.Minute).WithPolling(10 * time.Second).Should(Equal(generation))
+		).WithTimeout(5 * time.Minute).WithPolling(10 * time.Second).Should(BeNumerically(">=", generation))
 
 		WaitDeploymentWithoutGenerationCheck(data)
 	}
@@ -48,7 +48,7 @@ func WaitDeployment(data *model.TestDataProvider, generation int) {
 				g.Expect(err).ToNot(HaveOccurred())
 				return gen
 			},
-		).WithTimeout(5 * time.Minute).WithPolling(10 * time.Second).Should(Equal(generation))
+		).WithTimeout(5 * time.Minute).WithPolling(10 * time.Second).Should(BeNumerically(">=", generation))
 
 		WaitDeploymentWithoutGenerationCheckV2(data)
 	}

--- a/test/helper/e2e/data/atlasdeployment_basic_helm.yaml
+++ b/test/helper/e2e/data/atlasdeployment_basic_helm.yaml
@@ -12,7 +12,7 @@ spec:
       - zoneName: Zone 1
         regionConfigs:
           - electableSpecs:
-              instanceSize: M0
+              instanceSize: M2
               nodeCount: 1
             providerName: TENANT
             backingProviderName: "AWS"


### PR DESCRIPTION
Also improve test reliability by expecting any progress on generations.

This issue was introduced by #1182 

In concrete the M10 instance was changed to an M0 which does not allow for backups:
https://github.com/mongodb/mongodb-atlas-kubernetes/pull/1182/files#diff-0269841ec7d5fd9935fb6088f4f2aa50fda6052321278541ce5b5ad669bb513bL11

The failure might not have been seen before due to this other change that might have made experience flaky behaviour:
https://github.com/mongodb/mongodb-atlas-kubernetes/pull/1182/files#diff-fae195fa8f187a7dc9d0d23e2779416cb565f061c183ebf8f501f53fa4477303L32
Changing the expected generation.

We should also follow up on relying on generations on tests, we should probably avoid it.

### All Submissions:

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
