### PR TITLE
CLOUDP-231189: Make sure Gov tests run on push

### DIFF
--- a/.github/workflows/cloud-tests.yml
+++ b/.github/workflows/cloud-tests.yml
@@ -64,7 +64,6 @@ jobs:
   test-e2e-gov:
     needs:
       - allowed
-    if: github.event_name == 'merge_group' || github.event_name == 'push'
     uses: ./.github/workflows/test-e2e-gov.yml
     secrets: inherit
 

--- a/.github/workflows/test-e2e-gov.yml
+++ b/.github/workflows/test-e2e-gov.yml
@@ -2,11 +2,12 @@ name: E2E Gov tests
 
 on:
   workflow_call:
+  workflow_dispatch:
 
 jobs:
   e2e-gov:
     name: E2E Gov tests
-    if: github.event.pull_request.merged == true
+    if: github.event_name == 'merge_group' || github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - name: Check out code


### PR DESCRIPTION
Seems the blocked was a second if check that I had not noticed before testing: `if: github.event.pull_request.merged == true` Within the actual gov test workflow.

I have replaced it with the check we want, as it needs to happen for both `push` and `merge_group`. 

Note: The `merge_group` event not fire for now, but once we can enable the merge queue, it should start working right away without further changes, then we can probably remove the need to re-test at `push`.

This change also enables workflow_dispatch calls, so we can run it manually as needed.

### All Submissions:

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
