### PR TITLE
CLOUDP-231189: Allow workflow_dispatch to run gov tests

### DIFF
--- a/.github/workflows/test-e2e-gov.yml
+++ b/.github/workflows/test-e2e-gov.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   e2e-gov:
     name: E2E Gov tests
-    if: github.event_name == 'merge_group' || github.event_name == 'push'
+    if: github.event_name == 'merge_group' || github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - name: Check out code


### PR DESCRIPTION
Otherwise we [can try to trigger it manually](https://github.com/mongodb/mongodb-atlas-kubernetes/actions/workflows/test-e2e-gov.yml), but [it gets skipped](https://github.com/mongodb/mongodb-atlas-kubernetes/actions/runs/8016888440).

### All Submissions:

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
