### PR TITLE
CLOUDP-231603: Make AKOBot create PRs as needed

### DIFF
--- a/.github/workflows/akobot.yml
+++ b/.github/workflows/akobot.yml
@@ -1,0 +1,23 @@
+name: AKOBot
+
+on:
+  schedule:
+    - cron: "0 7 * * 3,5" # At 7:00 on Wednesday and Friday
+  workflow_dispatch:
+
+jobs:
+  check-licenses:
+    name: AKO Bot
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          cache: false
+
+      - name: Run akobot
+        run: make akobot

--- a/Makefile
+++ b/Makefile
@@ -480,3 +480,10 @@ verify: cosign ./ako.pem ## Verify an AKO multi-architecture image's signature
 	@echo "Verifying multi-architecture image signature $(IMG)..."
 	IMG=$(IMG) SIGNATURE_REPO=$(SIGNATURE_REPO) \
 	./scripts/sign-multiarch.sh verify && echo "VERIFIED OK"
+
+akobot: recompute-licenses ## AKOBot checks for needed changes and create a PR if needed
+ifndef GITHUB_TOKEN
+	echo "Getting GitHub token..."
+	$(eval GITHUB_TOKEN := $(shell $(MAKE) -s github-token))
+endif
+	@REPO=mongodb/mongodb-atlas-kubernetes ./scripts/make-pr.sh

--- a/pkg/controller/touch.go
+++ b/pkg/controller/touch.go
@@ -1,0 +1,1 @@
+package controller // updated at: 2024-02-23T10:01+00:00

--- a/scripts/make-pr.sh
+++ b/scripts/make-pr.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+set -euo pipefail
+
+repo=${REPO:-mongodb/mongodb-atlas-kubernetes}
+github_token=${GITHUB_TOKEN:-unset}
+
+if [[ $(git diff --stat) = '' ]]; then
+  echo 'No PR needed, git is clean'
+  exit 0
+fi
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+update_timestamp=$(date -u --iso-8601='minutes')
+title="AKOBot Automatic Update ${update_timestamp}"
+
+echo "Touching pkg/controller/touch.go to force the full test suite to run"
+echo "package controller // updated at: ${update_timestamp}" \
+  > "${SCRIPT_DIR}/../pkg/controller/touch.go"
+
+echo "Creating branch akobot-update and pushing it"
+git branch -m akobot-update
+git add .
+git commit -m "${title}"
+git push -fu origin akobot-update
+
+echo "Creating PR"
+curl -L \
+  -X POST \
+  -H "Accept: application/vnd.github+json" \
+  -H "Authorization: Bearer ${github_token}" \
+  -H "X-GitHub-Api-Version: 2022-11-28" \
+  "https://api.github.com/repos/${repo}/pulls" -d "{\"title\":\"${title}\"}"


### PR DESCRIPTION
After #1389 we have:
- Regular PRs failign if we forget to `make recompute-licenses` after changes to dependencies in `go.mod`.
- But `dependabot` PRs won't do that, so we skip that check for them.

This PR adds a new bot AKA `AKOBot` that runs after `dependabot` to ensure 2 things:
- The licenses will be recomputed WHEN needed on a new PR.
- When the PR is created, it will run cloud tests, to ensure we did not break `main`.

### All Submissions:

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
