### PR TITLE
CLOUDP-231603: Add permissions on fix bot workflow

### DIFF
--- a/.github/workflows/update-licenses.yml
+++ b/.github/workflows/update-licenses.yml
@@ -12,6 +12,10 @@ on:
     branches:
       - dependabot/go_modules/**
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   run:
     name: Recompute licenses & update PR


### PR DESCRIPTION
Hopping this will fix the bot access on this workflow:
https://github.com/ad-m/github-push-action/issues/96

### All Submissions:

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
