### PR TITLE
CLOUDP-230515: Datadog new regions

### DIFF
--- a/test/e2e/integration_test.go
+++ b/test/e2e/integration_test.go
@@ -114,6 +114,22 @@ var _ = Describe("Project Third-Party Integration", Label("integration-ns"), fun
 				integration.APIKeyRef = ref
 			},
 		),
+		Entry("Users can integrate DATADOG on region AP1", Label("project-integration"),
+			model.DataProvider(
+				"datatog-ap1",
+				model.NewEmptyAtlasKeyType().UseDefaultFullAccess(),
+				30018,
+				[]func(*model.TestDataProvider){},
+			).WithProject(data.DefaultProject()),
+			project.Integration{
+				Type:   "DATADOG",
+				Region: "AP1",
+			},
+			datadogEnvKey,
+			func(integration *project.Integration, ref common.ResourceRefNamespaced) {
+				integration.APIKeyRef = ref
+			},
+		),
 		Entry("Users can integrate PagerDuty on region US", Label("project-integration"),
 			model.DataProvider(
 				"pager-duty-us",


### PR DESCRIPTION
### All Submissions:

* [x] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if there is one).
* [ ] Update docs/release-notes/release-notes.md if your changes should be included in the release notes for the next release.

New regions are supported out of the box in Datadog integration, however, I added a test case to validate the new AP1 region. As we don't have a similar test for the Cloud for Government and it also requires a different API key from Datadog to write one, there is no test validating support for US1-Fed. Still, it's expected to work as simple as commercial Atlas.