### PR TITLE
Do NOT use pull_request_target events

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,9 +12,6 @@ on:
       - '**'
     paths-ignore:
       - 'docs/**'
-  pull_request_target:
-    paths-ignore:
-      - 'docs/**'
   merge_group:
   workflow_dispatch:
 
@@ -23,19 +20,42 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  run-tests:
+    name: Run Tests
+    runs-on: ubuntu-latest
+    # Contributions do NOT run any testing by default, a label is needed to allow testing
+    if: |
+      github.event.pull_request.base.repo.full_name == github.event.pull_request.head.repo.full_name ||
+      contains(github.event.pull_request.labels.*.name, 'safe-to-test') ||
+      contains(github.event.pull_request.labels.*.name, 'cloud-tests') ||
+      contains(github.event.pull_request.labels.*.name, 'retest')
+    steps:
+      - name: allowed message
+        run: echo "Allowed to run tests"
+
   lint:
+    needs:
+      - run-tests
     uses: ./.github/workflows/lint.yaml
 
   validate-manifests:
+    needs:
+      - run-tests
     uses: ./.github/workflows/validate-manifests.yml
   
   unit-tests:
+    needs:
+      - run-tests
     uses: ./.github/workflows/test-unit.yml
 
   check-licenses:
+    needs:
+      - run-tests
     uses: ./.github/workflows/check-licenses.yml
   
   cloud-tests-filter:
+    needs:
+      - run-tests
     uses: ./.github/workflows/cloud-tests-filter.yml
 
   cloud-tests:


### PR DESCRIPTION
Just avoid contributions to run ANY tests at all by default.

Instead, testing needs to be explicitly allowed by labelling the PR after inspecting it looks sane.
___
✅ [Test on fork: Dummy change from another fork had to be labeled to run tests](https://github.com/josvazg/mongodb-atlas-kubernetes/pull/27).
✅ [Test on fork: Dependabot change runs tests after adding the `retest` label, as usual](https://github.com/josvazg/mongodb-atlas-kubernetes/pull/26).
✅ [Test on fork: Regular change runs tests by default](https://github.com/josvazg/mongodb-atlas-kubernetes/pull/28).

### All Submissions:

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
