### PR TITLE
CLOUDP-238190: certify-openshift-images/Dockerfile: bump preflight check version

### DIFF
--- a/.github/actions/certify-openshift-images/Dockerfile
+++ b/.github/actions/certify-openshift-images/Dockerfile
@@ -17,7 +17,7 @@ RUN yum-config-manager --add-repo https://download.docker.com/linux/centos/docke
 
 RUN yum clean all
 
-RUN curl -LO https://github.com/redhat-openshift-ecosystem/openshift-preflight/releases/download/1.4.3/preflight-linux-amd64  && \
+RUN curl -LO https://github.com/redhat-openshift-ecosystem/openshift-preflight/releases/download/1.9.1/preflight-linux-amd64  && \
   chmod +x ./preflight-linux-amd64 && \
   mv ./preflight-linux-amd64 /usr/local/bin/preflight
 

--- a/.github/actions/certify-openshift-images/entrypoint.sh
+++ b/.github/actions/certify-openshift-images/entrypoint.sh
@@ -1,18 +1,23 @@
-#!/bin/sh
+#!/bin/bash
 
 set -eou pipefail
 
 docker login -u mongodb+mongodb_atlas_kubernetes -p "${QUAY_PASSWORD}" quay.io
 
 DIGESTS=$(docker manifest inspect "quay.io/${REPOSITORY}:${VERSION}" | jq -r '.manifests[] | select(.platform.os!="unknown") | .digest')
+mapfile -t PLATFORMS < <(docker manifest inspect "quay.io/${REPOSITORY}:${VERSION}" | jq -r '.manifests[] | select(.platform.os!="unknown") | .platform.architecture')
 
+INDEX=0
 for DIGEST in $DIGESTS; do
     echo "Check and Submit result to RedHat Connect"
     # Send results to RedHat if preflight finished wthout errors
     preflight check container "quay.io/${REPOSITORY}@${DIGEST}" \
       --artifacts "${DIGEST}" \
+      --platform "${PLATFORMS[$INDEX]}" \
       --pyxis-api-token="${RHCC_TOKEN}" \
       --certification-project-id="${RHCC_PROJECT}" \
       --docker-config="${HOME}/.docker/config.json" \
       --submit
+
+  (( INDEX++ )) || true
 done


### PR DESCRIPTION
### All Submissions:

* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if there is one).
* [ ] Update docs/release-notes/release-notes.md if your changes should be included in the release notes for the next release.

**Note:** preflight 1.9.1 requires `--platform` to be set, otherwise it errors:
```
Error: cannot process image manifest of different arch without platform override
```

This was verified locally using:
```bash
#!/bin/sh

set -eou pipefail

REPOSITORY=mongodb/mongodb-atlas-kubernetes-operator
VERSION=2.1.0
DIGESTS=$(docker manifest inspect "quay.io/${REPOSITORY}:${VERSION}" | jq -r '.manifests[] | select(.platform.os!="unknown") | .digest')
PLATFORMS=($(docker manifest inspect "quay.io/${REPOSITORY}:${VERSION}" | jq -r '.manifests[] | select(.platform.os!="unknown") | .platform.architecture'))

INDEX=0
for DIGEST in $DIGESTS; do
    preflight check container "quay.io/${REPOSITORY}@${DIGEST}" \
      --artifacts "${DIGEST}" \
      --platform "${PLATFORMS[$INDEX]}"

    let INDEX=${INDEX}+1
done
```
Output:
```
time="2024-03-18T13:20:35Z" level=info msg="certification library version" version="1.9.1 <commit: f19c2a2f587f9890d45ef8b9c13503a4c03f3218>"
time="2024-03-18T13:20:36Z" level=info msg="running checks for quay.io/mongodb/mongodb-atlas-kubernetes-operator@sha256:cd3e10d426ef18bb60121e9ec20d5196730e8efeddf219c07d5641a4a7050b35 for platform arm64"
time="2024-03-18T13:20:36Z" level=info msg="target image" image="quay.io/mongodb/mongodb-atlas-kubernetes-operator@sha256:cd3e10d426ef18bb60121e9ec20d5196730e8efeddf219c07d5641a4a7050b35"
time="2024-03-18T13:20:40Z" level=info msg="check completed" check=HasLicense result=PASSED
time="2024-03-18T13:20:43Z" level=info msg="check completed" check=HasUniqueTag result=PASSED
time="2024-03-18T13:20:43Z" level=info msg="check completed" check=LayerCountAcceptable result=PASSED
time="2024-03-18T13:20:43Z" level=info msg="check completed" check=HasNoProhibitedPackages result=PASSED
time="2024-03-18T13:20:43Z" level=info msg="check completed" check=HasRequiredLabel result=PASSED
time="2024-03-18T13:20:43Z" level=info msg="USER 1001:0 specified that is non-root"
time="2024-03-18T13:20:43Z" level=info msg="check completed" check=RunAsNonRoot result=PASSED
time="2024-03-18T13:20:44Z" level=info msg="check completed" check=HasModifiedFiles result=PASSED
time="2024-03-18T13:20:45Z" level=info msg="check completed" check=BasedOnUbi result=PASSED
time="2024-03-18T13:20:45Z" level=info msg="Warning: You've provided an image by digest. When submitting this image to Red Hat for certification, no tag will be associated with this image. If you would like to associate a tag with this image, please rerun this tool replacing your image reference with a tag."
{
    "image": "quay.io/mongodb/mongodb-atlas-kubernetes-operator@sha256:cd3e10d426ef18bb60121e9ec20d5196730e8efeddf219c07d5641a4a7050b35",
    "passed": true,
    "test_library": {
        "name": "github.com/redhat-openshift-ecosystem/openshift-preflight",
        "version": "1.9.1",
        "commit": "f19c2a2f587f9890d45ef8b9c13503a4c03f3218"
    },
    "results": {
        "passed": [
            {
                "name": "HasLicense",
                "elapsed_time": 0,
                "description": "Checking if terms and conditions applicable to the software including open source licensing information are present. The license must be at /licenses"
            },
            {
                "name": "HasUniqueTag",
                "elapsed_time": 3538,
                "description": "Checking if container has a tag other than 'latest', so that the image can be uniquely identified."
            },
            {
                "name": "LayerCountAcceptable",
                "elapsed_time": 0,
                "description": "Checking if container has less than 40 layers.  Too many layers within the container images can degrade container performance."
            },
            {
                "name": "HasNoProhibitedPackages",
                "elapsed_time": 41,
                "description": "Checks to ensure that the image in use does not include prohibited packages, such as Red Hat Enterprise Linux (RHEL) kernel packages."
            },
            {
                "name": "HasRequiredLabel",
                "elapsed_time": 0,
                "description": "Checking if the required labels (name, vendor, version, release, summary, description) are present in the container metadata."
            },
            {
                "name": "RunAsNonRoot",
                "elapsed_time": 0,
                "description": "Checking if container runs as the root user because a container that does not specify a non-root user will fail the automatic certification, and will be subject to a manual review before the container can be approved for publication"
            },
            {
                "name": "HasModifiedFiles",
                "elapsed_time": 1110,
                "description": "Checks that no files installed via RPM in the base Red Hat layer have been modified"
            },
            {
                "name": "BasedOnUbi",
                "elapsed_time": 518,
                "description": "Checking if the container's base image is based upon the Red Hat Universal Base Image (UBI)"
            }
        ],
        "failed": [],
        "errors": []
    }
}
time="2024-03-18T13:20:45Z" level=info msg="Preflight result: PASSED"
time="2024-03-18T13:20:45Z" level=info msg="certification library version" version="1.9.1 <commit: f19c2a2f587f9890d45ef8b9c13503a4c03f3218>"
time="2024-03-18T13:20:46Z" level=info msg="running checks for quay.io/mongodb/mongodb-atlas-kubernetes-operator@sha256:bc37b8151f7ff02eacbb1a64dc6499bb3004005ed353bb82202ad7b421c298b7 for platform amd64"
time="2024-03-18T13:20:46Z" level=info msg="target image" image="quay.io/mongodb/mongodb-atlas-kubernetes-operator@sha256:bc37b8151f7ff02eacbb1a64dc6499bb3004005ed353bb82202ad7b421c298b7"
time="2024-03-18T13:20:52Z" level=info msg="check completed" check=HasLicense result=PASSED
time="2024-03-18T13:20:56Z" level=info msg="check completed" check=HasUniqueTag result=PASSED
time="2024-03-18T13:20:56Z" level=info msg="check completed" check=LayerCountAcceptable result=PASSED
time="2024-03-18T13:20:56Z" level=info msg="check completed" check=HasNoProhibitedPackages result=PASSED
time="2024-03-18T13:20:56Z" level=info msg="check completed" check=HasRequiredLabel result=PASSED
time="2024-03-18T13:20:56Z" level=info msg="USER 1001:0 specified that is non-root"
time="2024-03-18T13:20:56Z" level=info msg="check completed" check=RunAsNonRoot result=PASSED
time="2024-03-18T13:20:57Z" level=info msg="check completed" check=HasModifiedFiles result=PASSED
time="2024-03-18T13:20:57Z" level=info msg="check completed" check=BasedOnUbi result=PASSED
time="2024-03-18T13:20:57Z" level=info msg="Warning: You've provided an image by digest. When submitting this image to Red Hat for certification, no tag will be associated with this image. If you would like to associate a tag with this image, please rerun this tool replacing your image reference with a tag."
{
    "image": "quay.io/mongodb/mongodb-atlas-kubernetes-operator@sha256:bc37b8151f7ff02eacbb1a64dc6499bb3004005ed353bb82202ad7b421c298b7",
    "passed": true,
    "test_library": {
        "name": "github.com/redhat-openshift-ecosystem/openshift-preflight",
        "version": "1.9.1",
        "commit": "f19c2a2f587f9890d45ef8b9c13503a4c03f3218"
    },
    "results": {
        "passed": [
            {
                "name": "HasLicense",
                "elapsed_time": 0,
                "description": "Checking if terms and conditions applicable to the software including open source licensing information are present. The license must be at /licenses"
            },
            {
                "name": "HasUniqueTag",
                "elapsed_time": 3641,
                "description": "Checking if container has a tag other than 'latest', so that the image can be uniquely identified."
            },
            {
                "name": "LayerCountAcceptable",
                "elapsed_time": 0,
                "description": "Checking if container has less than 40 layers.  Too many layers within the container images can degrade container performance."
            },
            {
                "name": "HasNoProhibitedPackages",
                "elapsed_time": 50,
                "description": "Checks to ensure that the image in use does not include prohibited packages, such as Red Hat Enterprise Linux (RHEL) kernel packages."
            },
            {
                "name": "HasRequiredLabel",
                "elapsed_time": 0,
                "description": "Checking if the required labels (name, vendor, version, release, summary, description) are present in the container metadata."
            },
            {
                "name": "RunAsNonRoot",
                "elapsed_time": 0,
                "description": "Checking if container runs as the root user because a container that does not specify a non-root user will fail the automatic certification, and will be subject to a manual review before the container can be approved for publication"
            },
            {
                "name": "HasModifiedFiles",
                "elapsed_time": 1193,
                "description": "Checks that no files installed via RPM in the base Red Hat layer have been modified"
            },
            {
                "name": "BasedOnUbi",
                "elapsed_time": 276,
                "description": "Checking if the container's base image is based upon the Red Hat Universal Base Image (UBI)"
            }
        ],
        "failed": [],
        "errors": []
    }
}
time="2024-03-18T13:20:57Z" level=info msg="Preflight result: PASSED"
```