### PR TITLE
set ginkgo interceptor to none

### DIFF
--- a/.github/workflows/test-e2e-gov.yml
+++ b/.github/workflows/test-e2e-gov.yml
@@ -53,7 +53,7 @@ jobs:
           cd test/e2e
           ginkgo labels
           echo 'Running: AKO_E2E_TEST=1 ginkgo --label-filter="atlas-gov" --timeout 120m --nodes=10  --flake-attempts=1 --randomize-all --cover --v --trace --show-nodes-events --output-interceptor-mode=none' && \
-          AKO_E2E_TEST=1 ginkgo --label-filter="atlas-gov" --timeout 120m --nodes=10 --flake-attempts=1 --randomize-all --cover --v --trace --show-node-events --output-interceptor-mode=none --coverpkg=github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/...
+          AKO_E2E_TEST=1 ginkgo --output-interceptor-mode=none --label-filter="atlas-gov" --timeout 120m --nodes=10 --flake-attempts=1 --randomize-all --cover --v --trace --show-node-events --output-interceptor-mode=none --coverpkg=github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/...
       - name: Upload operator logs
         if: ${{ failure() }}
         uses: actions/upload-artifact@v4

--- a/.github/workflows/test-e2e-gov.yml
+++ b/.github/workflows/test-e2e-gov.yml
@@ -53,7 +53,7 @@ jobs:
           cd test/e2e
           ginkgo labels
           echo 'Running: AKO_E2E_TEST=1 ginkgo --label-filter="atlas-gov" --timeout 120m --nodes=10  --flake-attempts=1 --randomize-all --cover --v --trace --show-nodes-events --output-interceptor-mode=none' && \
-          AKO_E2E_TEST=1 ginkgo --output-interceptor-mode=none --label-filter="atlas-gov" --timeout 120m --nodes=10 --flake-attempts=1 --randomize-all --cover --v --trace --show-node-events --output-interceptor-mode=none --coverpkg=github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/...
+          AKO_E2E_TEST=1 ginkgo --label-filter="atlas-gov" --timeout 120m --nodes=10 --flake-attempts=1 --randomize-all --cover --v --trace --show-node-events --output-interceptor-mode=none --coverpkg=github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/...
       - name: Upload operator logs
         if: ${{ failure() }}
         uses: actions/upload-artifact@v4

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -271,7 +271,7 @@ jobs:
           # no `long-run`, no `broken` tests. `Long-run` tests run as a separate job
           [[ $TEST_NAME == 'long-run' ]]  &&  filter='long-run && !broken' || filter="$TEST_NAME"' && !long-run && !broken' && \
           echo 'Running: AKO_E2E_TEST=1 ginkgo --label-filter="${filter}" --timeout 120m --nodes=10 --cover --v' && \
-          AKO_E2E_TEST=1 ginkgo --label-filter="${filter}" --timeout 120m --nodes=10  --flake-attempts=1 --cover --v --coverpkg=github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/...
+          AKO_E2E_TEST=1 ginkgo --output-interceptor-mode=none --label-filter="${filter}" --timeout 120m --nodes=10  --flake-attempts=1 --cover --v --coverpkg=github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/...
       - name: Upload operator logs
         if: ${{ failure() }}
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
### All Submissions:

* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if there is one).
* [ ] Update docs/release-notes/release-notes.md if your changes should be included in the release notes for the next release.

This might help with serverless-pe failures like this:
```
Ginkgo timed out waiting for all parallel procs to report back
```