### PR TITLE
CLOUDP-238743: Use mongodb/signatures

### DIFF
--- a/.github/workflows/rebuild-released-images.yaml
+++ b/.github/workflows/rebuild-released-images.yaml
@@ -168,6 +168,7 @@ jobs:
         run: |
           make sign IMG="${{ env.IMAGE_REPOSITORY }}:${{ steps.daily-tag.outputs.daily-tag }}" SIGNATURE_REPO=${{ env.IMAGE_REPOSITORY }}
           make sign IMG="quay.io/${{ env.IMAGE_REPOSITORY }}:${{ steps.daily-tag.outputs.daily-tag }}" SIGNATURE_REPO=${{ env.IMAGE_REPOSITORY }}
+          make sign IMG="${{ env.IMAGE_REPOSITORY }}:${{ steps.daily-tag.outputs.daily-tag }}" SIGNATURE_REPO=mongodb/signatures
       - name: Self-verify images
         if: steps.check-signing-support.outputs.sign == 'true'
         env:
@@ -177,3 +178,4 @@ jobs:
         run: |
           make verify IMG="${{ env.IMAGE_REPOSITORY }}:${{ steps.daily-tag.outputs.daily-tag }}" SIGNATURE_REPO=${{ env.IMAGE_REPOSITORY }}
           make verify IMG="quay.io/${{ env.IMAGE_REPOSITORY }}:${{ steps.daily-tag.outputs.daily-tag }}" SIGNATURE_REPO=${{ env.IMAGE_REPOSITORY }}
+          make verify IMG="${{ env.IMAGE_REPOSITORY }}:${{ steps.daily-tag.outputs.daily-tag }}" SIGNATURE_REPO=mongodb/signatures

--- a/.github/workflows/release-post-merge.yml
+++ b/.github/workflows/release-post-merge.yml
@@ -186,9 +186,11 @@ jobs:
           GRS_USERNAME:  ${{ secrets.GRS_USERNAME }}
           GRS_PASSWORD:  ${{ secrets.GRS_PASSWORD }}
         run: |
-          make sign IMG="${{ steps.tag.outputs.repo }}:${{ steps.tag.outputs.version }}" SIGNATURE_REPO=${{ steps.tag.outputs.repo }}
-          make sign IMG="quay.io/${{ steps.tag.outputs.repo }}:${{ steps.tag.outputs.version }}" SIGNATURE_REPO=${{ steps.tag.outputs.repo }}
-          make sign IMG="quay.io/${{ steps.tag.outputs.repo }}:${{ steps.tag.outputs.version }}-certified" SIGNATURE_REPO=${{ steps.tag.outputs.repo }}
+          make sign IMG="${{ env.IMAGE_REPOSITORY }}:${{ steps.tag.outputs.version }}" SIGNATURE_REPO=${{ env.IMAGE_REPOSITORY }}
+          make sign IMG="quay.io/${{ env.IMAGE_REPOSITORY }}:${{ steps.tag.outputs.version }}" SIGNATURE_REPO=${{ env.IMAGE_REPOSITORY }}
+          make sign IMG="quay.io/${{ env.IMAGE_REPOSITORY }}:${{ steps.tag.outputs.version }}-certified" SIGNATURE_REPO=${{ env.IMAGE_REPOSITORY }}
+          make sign IMG="${{ env.IMAGE_REPOSITORY }}:${{ steps.tag.outputs.version }}" SIGNATURE_REPO=mongodb/signatures
+          make sign IMG="quay.io/${{ env.IMAGE_REPOSITORY }}:${{ steps.tag.outputs.version }}-certified" SIGNATURE_REPO=mongodb/signatures
       - name: Self-verify images
         if: steps.check-signing-support.outputs.sign == 'true'
         env:
@@ -196,9 +198,11 @@ jobs:
           GRS_USERNAME:  ${{ secrets.GRS_USERNAME }}
           GRS_PASSWORD:  ${{ secrets.GRS_PASSWORD }}
         run: |
-          make verify IMG="${{ steps.tag.outputs.repo }}:${{ steps.tag.outputs.version }}" SIGNATURE_REPO=${{ steps.tag.outputs.repo }}
-          make verify IMG="quay.io/${{ steps.tag.outputs.repo }}:${{ steps.tag.outputs.version }}" SIGNATURE_REPO=${{ steps.tag.outputs.repo }}
-          make verify IMG="quay.io/${{ steps.tag.outputs.repo }}:${{ steps.tag.outputs.version }}-certified" SIGNATURE_REPO=${{ steps.tag.outputs.repo }}
+          make verify IMG="${{ env.IMAGE_REPOSITORY }}:${{ steps.tag.outputs.version }}" SIGNATURE_REPO=${{ env.IMAGE_REPOSITORY }}
+          make verify IMG="quay.io/${{ env.IMAGE_REPOSITORY }}:${{ steps.tag.outputs.version }}" SIGNATURE_REPO=${{ env.IMAGE_REPOSITORY }}
+          make verify IMG="quay.io/${{ env.IMAGE_REPOSITORY }}:${{ steps.tag.outputs.version }}-certified" SIGNATURE_REPO=${{ env.IMAGE_REPOSITORY }}
+          make verify IMG="${{ env.IMAGE_REPOSITORY }}:${{ steps.tag.outputs.version }}" SIGNATURE_REPO=mongodb/signatures
+          make verify IMG="quay.io/${{ env.IMAGE_REPOSITORY }}:${{ steps.tag.outputs.version }}-certified" SIGNATURE_REPO=mongodb/signatures
       - name: Create configuration package
         run: |
           set -x

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -9,4 +9,4 @@ SIGNATURE_REPO=${SIGNATURE_REPO:-$REPO}
 KEY_FILE=${KEY_FILE:-ako.pem}
 
 COSIGN_REPOSITORY="${SIGNATURE_REPO}" cosign verify \
-  --key="${KEY_FILE}" "${img_to_verify}"
+  --insecure-ignore-tlog --key="${KEY_FILE}" "${img_to_verify}"


### PR DESCRIPTION
Before merging this I would need to update the secrets `DOCKER_USERNAME` and `DOCKER_PASSWORD`.

New username is [svcdockerhubatlaskubernetes202](https://hub.docker.com/u/svcdockerhubatlaskubernetes202)

Note those creds will be lost once we do the change. I have tested we can push to all 3 registries in use:

- [docker.io/mongodb/mongodb-atlas-kubernetes-operator](https://hub.docker.com/r/mongodb/mongodb-atlas-kubernetes-operator/tags)
- [docker.io/mongodb/mongodb-atlas-kubernetes-operator-prerelease](https://hub.docker.com/r/mongodb/mongodb-atlas-kubernetes-operator-prerelease/tags)
- [docker.io/mongodb/signatures](https://hub.docker.com/r/mongodb/signatures/tags)

Any other testing required needs to happen before we make the **credentials** change.

### All Submissions:

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
