### PR TITLE
CLOUDP-238747: Act only on (pre)releases or manual launches

### DIFF
--- a/.github/workflows/release-post-merge.yml
+++ b/.github/workflows/release-post-merge.yml
@@ -6,6 +6,9 @@ name: Create Release
 
 on:
   pull_request:
+    branches:
+      - pre-release/**
+      - release/**
     types:
       - closed
   workflow_dispatch:
@@ -53,6 +56,7 @@ jobs:
   create-release:
     environment: release
     name: Create Release
+    if: github.event.pull_request.merged == true || github.event_name != 'workflow_dispatch'
     runs-on: ubuntu-latest
     env:
       IMAGE_REPOSITORY: ${{ github.event.inputs.image_repo }}
@@ -84,7 +88,7 @@ jobs:
               repo="mongodb/mongodb-atlas-kubernetes-operator-prerelease"
               RELEASE_HELM=false
               CERTIFY=false
-              RELEASE_TO_GITHUB=true
+              RELEASE_TO_GITHUB=false
             else
               echo "Release branch must be 'release/...' or 'pre-release/...' but got: $release"
               exit 1


### PR DESCRIPTION
And do not release to GitHub on pre-releases.

This should avoid launching the "**Create Release**" workflow unless it is a release, pre-release or a manual invocation. Which should avoid noise here:
https://github.com/mongodb/mongodb-atlas-kubernetes/actions/workflows/release-post-merge.yml

### All Submissions:

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
