### PR TITLE
CLOUDP-238915: Move to operator-sdk v1.34.1

### DIFF
--- a/.github/actions/gen-install-scripts/Dockerfile
+++ b/.github/actions/gen-install-scripts/Dockerfile
@@ -19,7 +19,7 @@ RUN CONTROLLER_GEN_TMP_DIR=$(mktemp -d) && \
     rm -rf $CONTROLLER_GEN_TMP_DIR && \
     CONTROLLER_GEN=${GOBIN}/controller-gen
 
-RUN curl -LO https://github.com/operator-framework/operator-sdk/releases/download/v1.16.0/operator-sdk_linux_amd64 && \
+RUN curl -LO https://github.com/operator-framework/operator-sdk/releases/download/v1.34.1/operator-sdk_linux_amd64 && \
     chmod +x operator-sdk_linux_amd64 && \
     mv operator-sdk_linux_amd64 /usr/local/bin/operator-sdk
 

--- a/.github/workflows/openshift-upgrade-test.yaml
+++ b/.github/workflows/openshift-upgrade-test.yaml
@@ -67,7 +67,7 @@ jobs:
           tar xvf kustomize.tar.gz
           chmod +x kustomize && mkdir -p ./bin/ && mv kustomize ./bin/kustomize
 
-          wget https://github.com/operator-framework/operator-sdk/releases/download/v1.22.2/operator-sdk_linux_amd64 -O operator-sdk -q
+          wget https://github.com/operator-framework/operator-sdk/releases/download/v1.34.1/operator-sdk_linux_amd64 -O operator-sdk -q
           chmod +x operator-sdk && sudo mv operator-sdk /usr/local/bin/operator-sdk
 
           wget https://github.com/mikefarah/yq/releases/download/v4.27.2/yq_linux_amd64 -O yq -q

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -221,9 +221,9 @@ jobs:
         with:
           go-version-file: "${{ github.workspace }}/go.mod"
           cache: false
-      - name: Install operator-sdk-v1.22.0
+      - name: Install operator-sdk
         run: |
-          wget https://github.com/operator-framework/operator-sdk/releases/download/v1.22.0/operator-sdk_linux_amd64 -q
+          wget https://github.com/operator-framework/operator-sdk/releases/download/v1.34.1/operator-sdk_linux_amd64 -q
           chmod +x operator-sdk_linux_amd64 && sudo mv operator-sdk_linux_amd64 /usr/local/bin/operator-sdk
           operator-sdk version
       - name: Print kubectl version

--- a/PROJECT
+++ b/PROJECT
@@ -1,6 +1,6 @@
 domain: mongodb.com
 layout:
-- go.kubebuilder.io/v2
+- go.kubebuilder.io/v4
 plugins:
   manifests.sdk.operatorframework.io/v2: {}
   scorecard.sdk.operatorframework.io/v2: {}
@@ -35,7 +35,7 @@ resources:
   path: github.com/mongodb/mongodb-atlas-kubernetes/api/v1
   version: v1
 - api:
-    crdVersion: v1beta1
+    crdVersion: v1
     namespaced: true
   controller: true
   domain: mongodb.com
@@ -44,7 +44,7 @@ resources:
   path: github.com/mongodb/mongodb-atlas-kubernetes/api/v1
   version: v1
 - api:
-    crdVersion: v1beta1
+    crdVersion: v1
     namespaced: true
   controller: true
   domain: mongodb.com


### PR DESCRIPTION
### All Submissions:

* [x] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if there is one).
* [ ] Update docs/release-notes/release-notes.md if your changes should be included in the release notes for the next release.

I'm anticipating this task once I'd like to have it to be able to ship some code with generics at https://github.com/mongodb/mongodb-atlas-kubernetes/pull/1466

As I have been using operator-sdk in the latest version for a while locally, I checked what was necessary to migrate/update it and it seems to be as simple as this PR shows. No changes in base manifests.
The next release, bundle will reflect the update of controller gen in the manifests and the new project layout, `go.kubebuilder.io/v4` in the CSV:

The warning triggered was because `PROJECT` config had v1beta1 API set for backup CRDs (not sure why) but both CRDs were already in v1(along with all others) and didn't have changes in them.