### PR TITLE
CLOUDP-240887: Fix CI signatures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -464,7 +464,7 @@ sign: ## Sign an AKO multi-architecture image
 	IMG=$(IMG) SIGNATURE_REPO=$(SIGNATURE_REPO) ./scripts/sign-multiarch.sh
 
 cosign:
-	@which cosign || go install github.com/sigstore/cosign/cmd/cosign@latest
+	@which cosign || go install github.com/sigstore/cosign/v2/cmd/cosign@latest
 
 ./ako.pem:
 	curl $(AKO_SIGN_PUBKEY) > $@

--- a/scripts/sign-multiarch.sh
+++ b/scripts/sign-multiarch.sh
@@ -9,7 +9,7 @@ action=${1:-sign}
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 docker pull "${img}"
-MULTIARCH_IMG_SHA=$(docker inspect "${img}" |jq -rc '.[0].Id')
+MULTIARCH_IMG_SHA=$(docker inspect --format='{{index .RepoDigests 0}}' "${img}" |awk -F@ '{print $2}')
 IMG_PLATFORMS_SHAS=$(docker manifest inspect "${img}" | \
   jq -rc '.manifests[] | select(.platform.os != "unknown" and .platform.architecture != "unknown") | .digest')
 


### PR DESCRIPTION
✅ [Build and sign tag 2.2.1-rc0](https://github.com/mongodb/mongodb-atlas-kubernetes/actions/runs/8539965791/job/23395938488)

- Use the digest directly as the multi-arch image SHA to sign, rather than the inspected JSON ID. That ID does not always match the digest.
- Install cosign version 2 on the CI.

### All Submissions:

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
