### PR TITLE
Test pre-release 2.2.2-rc0

### DIFF
--- a/bundle/manifests/mongodb-atlas-kubernetes.clusterserviceversion.yaml
+++ b/bundle/manifests/mongodb-atlas-kubernetes.clusterserviceversion.yaml
@@ -179,12 +179,12 @@ metadata:
     features.operators.openshift.io/token-auth-gcp: "false"
     operators.operatorframework.io/builder: operator-sdk-v1.34.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
-    containerImage: mongodb/mongodb-atlas-kubernetes-operator:2.2.1
+    containerImage: mongodb/mongodb-atlas-kubernetes-operator:2.2.2-rc0
   labels:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.arm64: supported
     operatorframework.io/os.linux: supported
-  name: mongodb-atlas-kubernetes.v2.2.1
+  name: mongodb-atlas-kubernetes.v2.2.2-rc0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -487,7 +487,7 @@ spec:
                         valueFrom:
                           fieldRef:
                             fieldPath: metadata.annotations['olm.targetNamespaces']
-                    image: mongodb/mongodb-atlas-kubernetes-operator:2.2.1
+                    image: mongodb/mongodb-atlas-kubernetes-operator:2.2.2-rc0
                     imagePullPolicy: Always
                     livenessProbe:
                       httpGet:
@@ -571,5 +571,5 @@ spec:
   maturity: beta
   provider:
     name: MongoDB, Inc
-  version: 2.2.1
+  version: 2.2.2-rc0
   replaces: mongodb-atlas-kubernetes.v2.2.0


### PR DESCRIPTION
This allows to test PR #1507 

Upon merging, the expectation is this will:
- Trigger the `tag.yml` upon closing the PR, creating a tag `v2.2.2-rc0` for a pre-release.
- And then call workflow `release-port-merge.yml` that should skip GitHub and Helm Chart & RedHat certified release, ad this is a pre-release.
- No errors should happen, specially signature steps should work fine.

### All Submissions:

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
