### PR TITLE
CLOUDP-246462: Fix passing arg to wf call

### DIFF
--- a/.github/workflows/release-post-merge.yml
+++ b/.github/workflows/release-post-merge.yml
@@ -12,7 +12,7 @@ on:
     inputs:
       tag:
         type: string
-        description: "Name of existing tag (or branch) to release (format should be 'v*')"
+        description: "Name of existing tag to release (format should be 'v*')"
         required: true
   workflow_dispatch:
     inputs:
@@ -61,7 +61,7 @@ jobs:
       RELEASE_HELM: ${{ github.event.inputs.release_helm || 'true' }}
       CERTIFY: ${{ github.event.inputs.certify || 'true' }}
       RELEASE_TO_GITHUB: ${{ github.event.inputs.release_to_github || 'true' }}
-      TAG: ${{ github.event.inputs.tag || github.head_ref || github.ref_name }}
+      TAG: ${{ inputs.tag || github.head_ref || github.ref_name }}
     steps:
       - name: Free disk space
         run: | 
@@ -70,7 +70,7 @@ jobs:
           sudo apt clean
           docker rmi $(docker image ls -aq)
           df -h
-      - name: Check release and show environment & version
+      - name: Compute release tag and options
         id: tag
         run: |
           version=$(echo "${TAG}" |awk -F'^v' '{print $2}')
@@ -91,6 +91,7 @@ jobs:
           echo "repo=${repo}" >> "$GITHUB_OUTPUT"
           echo "version=${version}" >> "$GITHUB_OUTPUT"
           echo "certified_version=${version}-certified" >> "$GITHUB_OUTPUT"
+          cat "$GITHUB_OUTPUT"
       - name: Check out code
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -6,7 +6,7 @@ on:
     - closed
 
 jobs:
-  tag-release:
+  tag:
     if: (github.event.pull_request.merged == true && (startsWith(github.head_ref, 'release/') || startsWith(github.head_ref, 'pre-release/')))
     environment: release
     name: Tag Release
@@ -32,11 +32,12 @@ jobs:
           git tag "${tag}"
           git push origin "${tag}"
           echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+          cat "$GITHUB_OUTPUT"
 
   release-post-merge:
     needs:
-    - tag-release
+    - tag
     uses: ./.github/workflows/release-post-merge.yml
     secrets: inherit
     with:
-      tag: ${{ needs.tag-release.outputs.tag }}
+      tag: ${{ needs.tag.outputs.tag }}


### PR DESCRIPTION
Workflow calls use `inputs.arg` instead of `github.event.inputs.arg`.

Also simplified some names and added traces on outputs.

Tested on a separate fork.

### All Submissions:

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
