### PR TITLE
CLOUDP-242965: Setup nightly tests on oldest and newest Kubernetes

### DIFF
--- a/.github/workflows/cloud-tests-filter.yml
+++ b/.github/workflows/cloud-tests-filter.yml
@@ -48,14 +48,21 @@ jobs:
             DRAFT: ${{ github.event.pull_request.draft }}
             CODE_CHANGED: ${{ steps.paths-filter.outputs.production-code-changed }}
             GH_REF: ${{ github.ref }}
+            GH_HEAD_REF: ${{ github.head_ref }}
             PR_HEAD_REPONAME: ${{ github.event.pull_request.head.repo.full_name }}
             REPONAME: ${{ github.repository }}
             ACTOR: ${{ github.actor }}
           run: |
             # Evaluate whether or not cloud tests should run
             RUN_CLOUD_TESTS='false'
+            # Scheduled runs on default branch always run all tests
+            if [ "${EVENT}" == "schedule" ];then
+              RUN_CLOUD_TESTS='true'
+            # Release branches always run all tests
+            elif [[ "${GH_HEAD_REF}" == release/* ]];then
+              RUN_CLOUD_TESTS='true'
             # push events run all tests when code was changed
-            if [ "${EVENT}" == "push" ] && [ "${CODE_CHANGED}" == "true" ];then
+            elif [ "${EVENT}" == "push" ] && [ "${CODE_CHANGED}" == "true" ];then
               RUN_CLOUD_TESTS='true'
             # cloud-tests label forces cloud tests to run, BUT only on AKO PRs, not from forked repos 
             elif [ "${CLOUD_TESTS_LABEL}" == "true" ] && [ "${FORKED}" == "false" ];then

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -22,9 +22,9 @@ jobs:
       - id: test
         run: |
           # Note the use of external single quotes to allow for doble quotes at inline YAML array
-          matrix='["v1.21.1-kind"]'
+          matrix='["v1.27.1-kind"]'
           if [ "${GH_HEAD_REF}" == "main" ];then
-            matrix='["v1.21.1-kind", "v1.29.2-kind"]'
+            matrix='["v1.27.1-kind", "v1.29.2-kind"]'
           fi
           echo "matrix=${matrix}" >> "${GITHUB_OUTPUT}"
           cat "${GITHUB_OUTPUT}"

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -228,7 +228,7 @@ jobs:
         if: ${{ steps.properties.outputs.k8s_platform == 'kind' && !env.ACT }}
         uses: helm/kind-action@v1.9.0
         with:
-          version: v0.11.1
+          version: v0.22.0
           config: test/helper/e2e/config/kind.yaml
           node_image: kindest/node:${{ steps.properties.outputs.k8s_version }}
           cluster_name: ${{ matrix.test }}

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -10,6 +10,24 @@ on:
   workflow_dispatch:
 
 jobs:
+  compute:
+    environment: test
+    name: "Compute test matrix"
+    runs-on: ubuntu-latest
+    env:
+      GH_HEAD_REF: ${{ github.head_ref }}
+    outputs:
+      test_matrix: ${{ steps.test.outputs.matrix }}
+    steps:
+      - id: test
+        run: |
+          # Note the use of external single quotes to allow for doble quotes at inline YAML array
+          matrix='["v1.21.1-kind"]'
+          if [ "${GH_HEAD_REF}" == "main" ];then
+            matrix='["v1.21.1-kind", "v1.29.2-kind"]'
+          fi
+          echo "matrix=${matrix}" >> "${GITHUB_OUTPUT}"
+          cat "${GITHUB_OUTPUT}"
   prepare-e2e:
     name: Prepare E2E configuration and image
     runs-on: ubuntu-latest
@@ -118,7 +136,7 @@ jobs:
           forked: ${{ inputs.forked }}
   e2e:
     name: E2E tests
-    needs: [prepare-e2e, prepare-e2e-bundle]
+    needs: [compute, prepare-e2e, prepare-e2e-bundle]
     runs-on: ubuntu-latest
     env:
       GHCR_REPO: ghcr.io/mongodb/mongodb-atlas-kubernetes-operator-prerelease
@@ -126,8 +144,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # k8s: ["1.17-kind", "1.19-kind", "1.17-opeshift"] # <supported platform version>-<platform>
-        k8s: [ "v1.21.1-kind" ] # <K8sGitVersion>-<Platform>
+        k8s: ${{fromJson(needs.compute.outputs.test_matrix)}}
         test:
           [
             "alert-config",

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,8 @@
 name: Test
 
 on:
+  schedule:
+    - cron: '0 0 * * 1-5' # Run a nightly test 
   push:
     branches:
       - 'main'


### PR DESCRIPTION
- Run nightly tests at midnight, Monday to Friday.
- Always run **cloud tests** for the nightly schedules and release branches, which name starts with `release/`.
- For nightly tests on main, run the nightly Kubernetes test matrix (complete).
- Nightly run oldest and newest supported Kubernetes versions.

### All Submissions:

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
