### PR TITLE
CLOUDP-243996: Fix GCP privatelink e2e IP conflict flakiness

### DIFF
--- a/test/e2e/private_link_test.go
+++ b/test/e2e/private_link_test.go
@@ -204,7 +204,7 @@ func privateFlow(userData *model.TestDataProvider, providerAction cloud.Provider
 						ID:         peName,
 						Region:     peStatusItem.Region,
 						Targets:    peStatusItem.ServiceAttachmentNames,
-						SubnetName: cloud.Subnet3Name,
+						SubnetName: cloud.Subnet1Name,
 					},
 				)
 			case provider.ProviderAzure:

--- a/test/e2e/private_link_test.go
+++ b/test/e2e/private_link_test.go
@@ -204,7 +204,7 @@ func privateFlow(userData *model.TestDataProvider, providerAction cloud.Provider
 						ID:         peName,
 						Region:     peStatusItem.Region,
 						Targets:    peStatusItem.ServiceAttachmentNames,
-						SubnetName: cloud.Subnet1Name,
+						SubnetName: cloud.Subnet3Name,
 					},
 				)
 			case provider.ProviderAzure:

--- a/test/helper/e2e/actions/cloud/gcp.go
+++ b/test/helper/e2e/actions/cloud/gcp.go
@@ -99,9 +99,9 @@ func (a *GCPAction) InitNetwork(vpcName, region string, subnets map[string]strin
 
 	return vpcName, nil
 }
-func (a *GCPAction) CreatePrivateEndpoint(name, region, subnet, target string, index int) (string, string, error) {
+
+func (a *GCPAction) CreatePrivateEndpoint(ctx context.Context, name, region, subnet, target string, index int) (string, string, error) {
 	a.t.Helper()
-	ctx := context.Background()
 
 	address := fmt.Sprintf("%s-%s-ip-%d", googleConnectPrefix, name, index)
 	rule := fmt.Sprintf("%s-%s-fr-%d", googleConnectPrefix, name, index)

--- a/test/helper/e2e/actions/cloud/gcp.go
+++ b/test/helper/e2e/actions/cloud/gcp.go
@@ -330,8 +330,12 @@ func (a *GCPAction) randomIP(subnet string) string {
 	ip, network, _ := net.ParseCIDR(a.network.Subnets[subnet])
 
 	ipParts := strings.Split(ip.String(), ".")
+	if len(ipParts) != 4 {
+		panic(fmt.Errorf("failed to parse IPv4 %q into 4 byte parts", ip))
+	}
 
 	for {
+		ipParts[2] = strconv.Itoa(rand.IntN(255))
 		ipParts[3] = strconv.Itoa(rand.IntN(255))
 		genIP := net.ParseIP(strings.Join(ipParts, "."))
 

--- a/test/helper/e2e/actions/cloud/gcp_test.go
+++ b/test/helper/e2e/actions/cloud/gcp_test.go
@@ -1,0 +1,26 @@
+package cloud
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateUsedVirtualAddress(t *testing.T) {
+	if _, ok := os.LookupEnv("GOOGLE_APPLICATION_CREDENTIALS"); !ok {
+		t.Skipf("Can't run test without GCE access credentials")
+	}
+	ctx := context.Background()
+	gt := ginkgo.GinkgoT()
+	ga, err := NewGCPAction(gt, GoogleProjectID)
+	require.NoError(t, err)
+
+	err = ga.createVirtualAddress(ctx, "10.3.0.55", "name1", Subnet2Name, GCPRegion)
+	require.NoError(t, err)
+	defer ga.deleteVirtualAddress(ctx, "name1", GCPRegion)
+	expectedErr := ga.createVirtualAddress(ctx, "10.3.0.55", "name2", Subnet2Name, GCPRegion)
+	require.ErrorContains(t, expectedErr, "IP_IN_USE_BY_ANOTHER_RESOURCE")
+}

--- a/test/helper/e2e/actions/cloud/provider.go
+++ b/test/helper/e2e/actions/cloud/provider.go
@@ -20,12 +20,8 @@ const (
 	ResourceGroupName = "svet-test"
 	Subnet1Name       = "atlas-operator-e2e-test-subnet1"
 	Subnet2Name       = "atlas-operator-e2e-test-subnet2"
-	Subnet3Name       = "atlas-operator-e2e-test-subnet3"
-	Subnet4Name       = "atlas-operator-e2e-test-subnet4"
 	Subnet1CIDR       = "10.0.0.0/25"
 	Subnet2CIDR       = "10.0.0.128/25"
-	Subnet3CIDR       = "10.3.0.0/16"
-	Subnet4CIDR       = "10.4.0.0/16"
 	vpcName           = "atlas-operator-e2e-test-vpc"
 	vpcCIDR           = "10.0.0.0/24"
 )
@@ -348,7 +344,7 @@ func getGCPConfigDefaults() *GCPConfig {
 	return &GCPConfig{
 		Region:  GCPRegion,
 		VPC:     vpcName,
-		Subnets: map[string]string{Subnet3Name: Subnet3CIDR, Subnet4Name: Subnet4CIDR},
+		Subnets: map[string]string{Subnet1Name: Subnet1CIDR, Subnet2Name: Subnet2CIDR},
 	}
 }
 

--- a/test/helper/e2e/actions/cloud/provider.go
+++ b/test/helper/e2e/actions/cloud/provider.go
@@ -1,6 +1,7 @@
 package cloud
 
 import (
+	"context"
 	"errors"
 	"path"
 	"time"
@@ -290,8 +291,8 @@ func (a *ProviderAction) RetryGCPCreateEndpoint(maxRetries int, name, region, su
 	}
 	var rule, ip string
 	var err error
-	wait.ExponentialBackoff(backoff, func() (done bool, err error) {
-		rule, ip, err = a.gcpProvider.CreatePrivateEndpoint(name, region, subnet, target, index)
+	wait.ExponentialBackoffWithContext(context.TODO(), backoff, func(ctx context.Context) (done bool, err error) {
+		rule, ip, err = a.gcpProvider.CreatePrivateEndpoint(ctx, name, region, subnet, target, index)
 		if err != nil {
 			googleErr := &googleapi.Error{}
 			if errors.As(err, &googleErr) &&


### PR DESCRIPTION
Change the method to get a GCP IP address into one that retries up to 7 times if the IP address selected randomly is already in use.

Added a test that verified the error message was coming from `createVirtualAddress`. Also added partial context passing to the GCP method.

### All Submissions:

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
