### PR TITLE
CLOUDP-244156: Fix the concurrent writes for the ResourceWatcher

### DIFF
--- a/pkg/controller/watch/resource_watcher.go
+++ b/pkg/controller/watch/resource_watcher.go
@@ -1,9 +1,10 @@
 package watch
 
 import (
+	"sync"
+
 	"go.uber.org/zap"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sync"
 )
 
 func NewResourceWatcher() ResourceWatcher {


### PR DESCRIPTION
### All Submissions:

Fix the concurrent writes for the ResourceWatcher

* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if there is one).
* [ ] Update docs/release-notes/release-notes.md if your changes should be included in the release notes for the next release.
