### PR TITLE
CLOUDP-244541: Avoid GCE creds file leftover

### DIFF
--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -74,6 +74,7 @@ func checkUpAzureEnvironment() {
 
 func checkNSetUpGCPEnvironment() {
 	Expect(os.Getenv("GCP_SA_CRED")).ShouldNot(BeEmpty(), "Please, setup GCP_SA_CRED environment variable for test with GCP (req. Service Account)")
+	Expect(os.MkdirAll("../../output", 0750)).ShouldNot(HaveOccurred())
 	Expect(utils.SaveToFile(config.FileNameSAGCP, []byte(os.Getenv("GCP_SA_CRED")))).ShouldNot(HaveOccurred())
 	Expect(os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", config.FileNameSAGCP)).ShouldNot(HaveOccurred())
 	Expect(os.Getenv("GOOGLE_APPLICATION_CREDENTIALS")).ShouldNot(BeEmpty(), "Please, setup GOOGLE_APPLICATION_CREDENTIALS environment variable for test with GCP")

--- a/test/helper/e2e/config/config.go
+++ b/test/helper/e2e/config/config.go
@@ -41,5 +41,5 @@ const (
 	AzureRegionEU = "northeurope"
 
 	// GCP
-	FileNameSAGCP = "gcp_service_account.json"
+	FileNameSAGCP = "../../output/gcp_service_account.json"
 )


### PR DESCRIPTION
Moving the creds file to the `output/` folder stops it from showing up as "untracked" by git and also prevents it from being checked in by mistake.

### All Submissions:

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
