### PR TITLE
CLOUDP-242965: Name matrix compute step

### DIFF
--- a/.github/workflows/cloud-tests-filter.yml
+++ b/.github/workflows/cloud-tests-filter.yml
@@ -52,11 +52,7 @@ jobs:
             PR_HEAD_REPONAME: ${{ github.event.pull_request.head.repo.full_name }}
             REPONAME: ${{ github.repository }}
             ACTOR: ${{ github.actor }}
-            GITHUB_CONTEXT: ${{ toJson(github) }}
           run: |
-            echo "Start ------ GitHub Context ------"
-            echo "$GITHUB_CONTEXT"
-            echo "End ------ GitHub Context ------"
             # Evaluate whether or not cloud tests should run
             RUN_CLOUD_TESTS='false'
             # Scheduled runs on default branch always run all tests

--- a/.github/workflows/cloud-tests-filter.yml
+++ b/.github/workflows/cloud-tests-filter.yml
@@ -52,7 +52,11 @@ jobs:
             PR_HEAD_REPONAME: ${{ github.event.pull_request.head.repo.full_name }}
             REPONAME: ${{ github.repository }}
             ACTOR: ${{ github.actor }}
+            GITHUB_CONTEXT: ${{ toJson(github) }}
           run: |
+            echo "Start ------ GitHub Context ------"
+            echo "$GITHUB_CONTEXT"
+            echo "End ------ GitHub Context ------"
             # Evaluate whether or not cloud tests should run
             RUN_CLOUD_TESTS='false'
             # Scheduled runs on default branch always run all tests

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -20,6 +20,7 @@ jobs:
       test_matrix: ${{ steps.test.outputs.matrix }}
     steps:
       - id: test
+        name: Compute Test Matrix
         run: |
           # Note the use of external single quotes to allow for doble quotes at inline YAML array
           matrix='["v1.27.1-kind"]'

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -14,8 +14,6 @@ jobs:
     environment: test
     name: "Compute test matrix"
     runs-on: ubuntu-latest
-    env:
-      GH_REF: ${{ github.ref }}
     outputs:
       test_matrix: ${{ steps.test.outputs.matrix }}
     steps:
@@ -24,7 +22,7 @@ jobs:
         run: |
           # Note the use of external single quotes to allow for doble quotes at inline YAML array
           matrix='["v1.27.1-kind"]'
-          if [ "${GH_REF}" == "refs/heads/main" ];then
+          if [ "${{ github.ref }}" == "refs/heads/main" ];then
             matrix='["v1.27.1-kind", "v1.29.2-kind"]'
           fi
           echo "matrix=${matrix}" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -15,7 +15,7 @@ jobs:
     name: "Compute test matrix"
     runs-on: ubuntu-latest
     env:
-      GH_HEAD_REF: ${{ github.head_ref }}
+      GH_REF: ${{ github.ref }}
     outputs:
       test_matrix: ${{ steps.test.outputs.matrix }}
     steps:
@@ -24,7 +24,7 @@ jobs:
         run: |
           # Note the use of external single quotes to allow for doble quotes at inline YAML array
           matrix='["v1.27.1-kind"]'
-          if [ "${GH_HEAD_REF}" == "main" ];then
+          if [ "${GH_REF}" == "refs/heads/main" ];then
             matrix='["v1.27.1-kind", "v1.29.2-kind"]'
           fi
           echo "matrix=${matrix}" >> "${GITHUB_OUTPUT}"


### PR DESCRIPTION
Fix the computation of the test matrix for **scheduled** events.

Looking at [this example from today's schedule](https://github.com/mongodb/mongodb-atlas-kubernetes/actions/runs/8776607163/job/24080359511):

```
    GH_REF: refs/heads/main
    GH_HEAD_REF: 
```

The value `github.head_ref` (**GH_HEAD_REF**) is not set on a scheduled event, but `github.ref` (**GH_REF**) is set as `refs/heads/main`. This change takes that into account to fix the comparison to be triggered correctly on scheduled test runs.

### All Submissions:

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
