### PR TITLE
CLOUDP-245131: Fix ST1019 from staticcheck

### DIFF
--- a/test/e2e/encryption_at_rest_test.go
+++ b/test/e2e/encryption_at_rest_test.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"go.mongodb.org/atlas-sdk/v20231115008/admin"
@@ -381,7 +380,7 @@ var _ = Describe("Encryption at rest AWS", Label("encryption-at-rest", "encrypti
 					Execute()
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(projectData).NotTo(BeNil())
-				ginkgo.GinkgoLogr.Info("Project ID", projectData.GetId())
+				GinkgoLogr.Info("Project ID", projectData.GetId())
 				projectID = projectData.GetId()
 				return nil
 			}).WithTimeout(2 * time.Minute).WithPolling(10 * time.Second).Should(Succeed())


### PR DESCRIPTION
CLOUDP-245131

Fixes:
```go
test/e2e/encryption_at_rest_test.go:9:2: package "github.com/onsi/ginkgo/v2" is being imported more than once (ST1019)
	test/e2e/encryption_at_rest_test.go:10:2: other import of "github.com/onsi/ginkgo/v2"
```

### All Submissions:

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
