### PR TITLE
CLOUDP-245131: Run govulncheck at lint time

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -24,3 +24,6 @@ jobs:
 
       - name: Run ShellCheck
         uses: bewuethr/shellcheck-action@v2
+
+      - name: Run govulncheck
+        run: make vulncheck

--- a/Makefile
+++ b/Makefile
@@ -474,3 +474,10 @@ verify: cosign ./ako.pem ## Verify an AKO multi-architecture image's signature
 	@echo "Verifying multi-architecture image signature $(IMG)..."
 	IMG=$(IMG) SIGNATURE_REPO=$(SIGNATURE_REPO) \
 	./scripts/sign-multiarch.sh verify && echo "VERIFIED OK"
+
+govulncheck:
+	go install golang.org/x/vuln/cmd/govulncheck@latest
+
+.PHONY: vulncheck
+vulncheck: ## Run govulncheck to find vulnerabilities in code
+	@./scripts/vulncheck.sh ./vuln-ignore

--- a/scripts/vulncheck.sh
+++ b/scripts/vulncheck.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+ignore_file=${1:-./vuln-ignore}
+
+ignore_lines=$(grep -v '^#' "${ignore_file}")
+check_cmd='govulncheck ./... |grep "Vulnerability #"'
+while IFS= read -r line; do
+  if [ "${line}" != "" ]; then
+    check_cmd+="|grep -v \"${line}\""
+  fi
+done <<< "${ignore_lines}"
+
+echo "${check_cmd}"
+vulns=$(eval "${check_cmd}")
+count=$(echo "${vulns}" |grep -c "\S")
+echo "govulncheck found ${count} non ignored vulnerabilities"
+if (( count != 0 )); then
+  echo "${vulns}"
+  echo "FAIL"
+  exit 1
+fi
+echo "PASS"

--- a/vuln-ignore
+++ b/vuln-ignore
@@ -1,0 +1,5 @@
+## Use entries such as:
+## # url comment/reason for ignoring
+## GO-xxxx-yyyy
+# https://pkg.go.dev/vuln/GO-2024-2687 not bumped to go 1.22.2 yet
+GO-2024-2687


### PR DESCRIPTION
Selectively ignoring vulnerabilities.

The check is relatively cheap and makes more sense to do as early as possible. Developers are responsible for sending PRs that either pass the check or add ignored vulnerabilities to the list if they cannot be solved right away.

The script `scripts/vulncheck.sh` runs **govulncheck** removing all explicitly ignored vulnerabilities. It fails only any vulnerabilities are found after filtering the ignored ones.

The `vuln-ignore` file is expected to contain vulnerabilities using a pair of lines each in the following format:
```
# https://pkg.go.dev/vuln/GO-xxxx-yyy {reason for ignoring}
GO-xxxx-yyyy
```
- Lines starting with `"##"` will be ignored, they are self documentation.
- Lines starting with `"# "` can be used for the SDLC checklist reporting the ignored vulnerabilities on a release.
- The rest of non empty lines are used to match and skip vulnerabilities from `govulncheck`.

Note the idea is NOT to ignore vulnerabilities for ever or keep accumulating them. Instead, as soon as a fix can be applied, it should be applied and the ignore entry be removed from `vuln-ignore`.

### All Submissions:

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
