### PR TITLE
Fix test to use correct sample IP

### DIFF
--- a/test/helper/e2e/actions/cloud/gcp_test.go
+++ b/test/helper/e2e/actions/cloud/gcp_test.go
@@ -18,9 +18,9 @@ func TestCreateUsedVirtualAddress(t *testing.T) {
 	ga, err := NewGCPAction(gt, GoogleProjectID)
 	require.NoError(t, err)
 
-	err = ga.createVirtualAddress(ctx, "10.3.0.55", "name1", Subnet2Name, GCPRegion)
+	err = ga.createVirtualAddress(ctx, "10.0.0.155", "name1", Subnet2Name, GCPRegion)
 	require.NoError(t, err)
 	defer ga.deleteVirtualAddress(ctx, "name1", GCPRegion)
-	expectedErr := ga.createVirtualAddress(ctx, "10.3.0.55", "name2", Subnet2Name, GCPRegion)
+	expectedErr := ga.createVirtualAddress(ctx, "10.0.0.155", "name2", Subnet2Name, GCPRegion)
 	require.ErrorContains(t, expectedErr, "IP_IN_USE_BY_ANOTHER_RESOURCE")
 }


### PR DESCRIPTION
Subnet 2 in GCP must be within the `10.0.0.128` range.

### All Submissions:

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
