### PR TITLE
Bump up preflight tool version to 1.9.2

### DIFF
--- a/.github/actions/certify-openshift-images/Dockerfile
+++ b/.github/actions/certify-openshift-images/Dockerfile
@@ -1,23 +1,23 @@
 FROM registry.access.redhat.com/ubi8/ubi:latest
 
 RUN yum install -y \
-      bzip2 \
-      gzip \
-      tar \
-      iptables \
-      yum-utils \
-      jq
+  bzip2 \
+  gzip \
+  tar \
+  iptables \
+  yum-utils \
+  jq
 
 RUN yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo && \
-    yum list docker-ce --showduplicates | sort -r && \
-    yum install -y \
-      docker-ce \
-      docker-ce-cli \
-      containerd.io
+  yum list docker-ce --showduplicates | sort -r && \
+  yum install -y \
+  docker-ce \
+  docker-ce-cli \
+  containerd.io
 
 RUN yum clean all
 
-RUN curl -LO https://github.com/redhat-openshift-ecosystem/openshift-preflight/releases/download/1.9.1/preflight-linux-amd64  && \
+RUN curl -LO https://github.com/redhat-openshift-ecosystem/openshift-preflight/releases/download/1.9.2/preflight-linux-amd64  && \
   chmod +x ./preflight-linux-amd64 && \
   mv ./preflight-linux-amd64 /usr/local/bin/preflight
 


### PR DESCRIPTION
### All Submissions:

The `preflight-tool` is outdated. Bumping up to v1.9.2:
```
Error: could not submit to pyxis: could not create test results: status code: 400: body: {"type": "about:blank", "title": "Bad Request", "detail": "Validation error: 'github.com/redhat-openshift-ecosystem/openshift-preflight' version '1.9.1' is not supported. Supported versions are: ['1.9.2', '1.9.4']", "status": 400, "trace_id": "0xa1aabed1b8c70960041f62de7632cfb4"} 2024/05/08 17:46:34 could not submit to pyxis: could not create test results: status code: 400: body: {"type": "about:blank", "title": "Bad Request", "detail": "Validation error: 'github.com/redhat-openshift-ecosystem/openshift-preflight' version '1.9.1' is not supported. Supported versions are: ['1.9.2', '1.9.4']", "status": 400, "trace_id": "0xa1aabed1b8c70960041f62de7632cfb4"}
```


* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if there is one).
* [ ] Update docs/release-notes/release-notes-template.md if your changes should be included in the release notes for the next release.
