### PR TITLE
Test all-in-one.yaml from make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -539,7 +539,7 @@ local-docker-build:
 
 .PHONY: yq
 yq:
-	go install github.com/mikefarah/yq/v4@latest
+	which yq || go install github.com/mikefarah/yq/v4@latest
 
 .PHONY: prepare-all-in-one
 prepare-all-in-one: yq local-docker-build run-kind


### PR DESCRIPTION
Now `make test-all-in-one` will just try out `deploy/all-in-one.yaml`. This should be run on the release branch before approval at least while this test is not yet automated.

Piggy backs on `make run` for getting their credentials.

---
### Test

```go
% make test-all-in-one                             
...
deployment.apps/mongodb-atlas-operator configured
```
---

### All Submissions:

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
