### PR TITLE
CLOUDP-239190: Upload SBOM lite files to Silk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,6 +108,8 @@ RUN_YAML= # Set to the YAML to run when calling make run
 LOCAL_IMAGE=mongodb-atlas-kubernetes-operator:compiled
 CONTAINER_SPEC=.spec.template.spec.containers[0]
 
+SILK_ASSET_GROUP="atlas-kubernetes-operator"
+
 .DEFAULT_GOAL := help
 .PHONY: help
 help: ## Show this help screen
@@ -555,3 +557,8 @@ test-all-in-one: prepare-all-in-one install-credentials ## Test the deploy/all-i
 	| yq 'select(.kind == "Deployment") | $(CONTAINER_SPEC).image="$(LOCAL_IMAGE)"' \
 	| yq 'select(.kind == "Deployment") | $(CONTAINER_SPEC).args[0]="--atlas-domain=$(ATLAS_DOMAIN)"' \
 	| kubectl apply -f -
+.PHONY: upload-sbom-to-silk
+upload-sbom-to-silk: ## Upload a give SBOM (lite) to Silk
+	@ARTIFACTORY_USERNAME=$(ARTIFACTORY_USERNAME) ARTIFACTORY_PASSWORD=$(ARTIFACTORY_PASSWORD) \
+	SILK_CLIENT_ID=$(SILK_CLIENT_ID) SILK_CLIENT_SECRET=$(SILK_CLIENT_SECRET) \
+	SILK_ASSET_GROUP=$(SILK_ASSET_GROUP) ./scripts/upload-to-silk.sh $(SBOM_JSON_FILE)

--- a/scripts/upload-to-silk.sh
+++ b/scripts/upload-to-silk.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Constants
+registry=artifactory.corp.mongodb.com/release-tools-container-registry-local
+silkbomb_img="${registry}/silkbomb:1.0"
+platform=linux/amd64
+
+# Arguments
+sbom_lite_json=$1
+
+# Environment inputs
+artifactory_usr="${ARTIFACTORY_USERNAME}"
+artifactory_pwd="${ARTIFACTORY_PASSWORD}"
+client_id="${SILK_CLIENT_ID}"
+client_secret="${SILK_CLIENT_SECRET}"
+asset_group="${SILK_ASSET_GROUP}"
+
+# Compute paths to map within silkbomb docker container
+relative_dir=$(dirname docs/releases/v2.2.2/linux-amd64.sbom.json)
+dir=$(cd "${relative_dir}" && pwd)
+
+# Login to docker registry
+echo "${artifactory_pwd}" |docker login "${registry}" -u "${artifactory_usr}" --password-stdin
+
+# Upload
+docker run --platform="${platform}" -it --rm -v "${PWD}":/pwd -v "${dir}":"/${relative_dir}" \
+  -e SILK_CLIENT_ID="${client_id}" -e SILK_CLIENT_SECRET="${client_secret}" \
+  "${silkbomb_img}" upload --silk_asset_group "${asset_group}" --sbom_in "/${sbom_lite_json}"
+echo "${sbom_lite_json} uploaded to Silk"


### PR DESCRIPTION
Adds `make upload-sbom-to-silk SBOM_JSON_FILE=...json` to upload SBOM lite files to Silk.

---
### Test
```
% make upload-sbom-to-silk SBOM_JSON_FILE=docs/releases/v2.2.2/linux-arm64.sbom.json   
...

Login Succeeded
...
docs/releases/v2.2.2/linux-arm64.sbom.json uploaded to Silk
```
---
### All Submissions:

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
