### PR TITLE
Have better hygiene of e2e leftovers

### DIFF
--- a/.github/actions/gen-install-scripts/action.yml
+++ b/.github/actions/gen-install-scripts/action.yml
@@ -8,7 +8,7 @@ inputs:
     description: "Version of the Operator"
     required: true
   ENV:
-    description: "Kustomize patch name (enviroment configuration patch)"
+    description: "Kustomize patch name (environment configuration patch)"
     required: true
 runs:
   using: 'docker'

--- a/.gitignore
+++ b/.gitignore
@@ -34,8 +34,8 @@ tags
 testbin/
 
 # don't include generated files from e2e tests
-test/helper/e2e/data/gen/
-output/
+test/e2e/data/
+test/e2e/output/
 
 node_modules
 tmp/

--- a/Makefile
+++ b/Makefile
@@ -498,3 +498,5 @@ gen-sdlc-checklist: envsubst docker-sbom ## Generate the SDLC checklist
 .PHONY: clear-e2e-leftovers
 clear-e2e-leftovers: ## Clear the e2e test leftovers quickly
 	git restore bundle* config deploy
+	cd helm-charts && git restore .
+	git submodule update helm-charts

--- a/output/keep-directory.txt
+++ b/output/keep-directory.txt
@@ -1,1 +1,0 @@
-This file exists so the output directory exists in git (but we don't want the generated artefacts)

--- a/test/e2e/helm_chart_test.go
+++ b/test/e2e/helm_chart_test.go
@@ -52,20 +52,20 @@ var _ = Describe("HELM charts", Ordered, func() {
 				Expect(err).Should(BeNil())
 				namespaceDeploymentJSON, err := json.MarshalIndent(namespaceDeployment, "", "  ")
 				Expect(err).Should(BeNil())
-				utils.SaveToFile("namespace-deployment.json", namespaceDeploymentJSON)
+				utils.SaveToFile("output/namespace-deployment.json", namespaceDeploymentJSON)
 
 				pod, err := k8s.GetAllDeploymentPods("mongodb-atlas-operator", data.Resources.Namespace)
 				Expect(err).Should(BeNil())
 				podJSON, err := json.MarshalIndent(pod, "", "  ")
 				Expect(err).Should(BeNil())
-				utils.SaveToFile("namespace-pod.json", podJSON)
+				utils.SaveToFile("output/namespace-pod.json", podJSON)
 
 				bytes, err := k8s.GetPodLogsByDeployment("mongodb-atlas-operator", config.DefaultOperatorNS, corev1.PodLogOptions{})
 				if err != nil {
 					GinkgoWriter.Write([]byte(err.Error()))
 				}
 				utils.SaveToFile(
-					fmt.Sprintf("../../output/%s/operator-logs-default.txt", data.Resources.Namespace),
+					fmt.Sprintf("output/%s/operator-logs-default.txt", data.Resources.Namespace),
 					bytes,
 				)
 				bytes, err = k8s.GetPodLogsByDeployment("mongodb-atlas-operator", data.Resources.Namespace, corev1.PodLogOptions{})
@@ -73,7 +73,7 @@ var _ = Describe("HELM charts", Ordered, func() {
 					GinkgoWriter.Write([]byte(err.Error()))
 				}
 				utils.SaveToFile(
-					fmt.Sprintf("../../output/%s/operator-logs.txt", data.Resources.Namespace),
+					fmt.Sprintf("output/%s/operator-logs.txt", data.Resources.Namespace),
 					bytes,
 				)
 				actions.SaveProjectsToFile(data.Context, data.K8SClient, data.Resources.Namespace)

--- a/test/helper/e2e/actions/steps.go
+++ b/test/helper/e2e/actions/steps.go
@@ -206,7 +206,7 @@ func SaveProjectsToFile(ctx context.Context, k8sClient client.Client, ns string)
 	if err != nil {
 		return fmt.Errorf("error getting project list: %w", err)
 	}
-	path := fmt.Sprintf("../../output/%s/%s.yaml", ns, "projects")
+	path := fmt.Sprintf("output/%s/%s.yaml", ns, "projects")
 	err = utils.SaveToFile(path, yaml)
 	if err != nil {
 		return fmt.Errorf("error saving projects to file: %w", err)
@@ -219,7 +219,7 @@ func SaveTeamsToFile(ctx context.Context, k8sClient client.Client, ns string) er
 	if err != nil {
 		return fmt.Errorf("error getting team list: %w", err)
 	}
-	path := fmt.Sprintf("../../output/%s/%s.yaml", ns, "teams")
+	path := fmt.Sprintf("output/%s/%s.yaml", ns, "teams")
 	err = utils.SaveToFile(path, yaml)
 	if err != nil {
 		return fmt.Errorf("error saving teams to file: %w", err)
@@ -232,7 +232,7 @@ func SaveDeploymentsToFile(ctx context.Context, k8sClient client.Client, ns stri
 	if err != nil {
 		return fmt.Errorf("error getting deployment list: %w", err)
 	}
-	path := fmt.Sprintf("../../output/%s/%s.yaml", ns, "deployments")
+	path := fmt.Sprintf("output/%s/%s.yaml", ns, "deployments")
 	err = utils.SaveToFile(path, yaml)
 	if err != nil {
 		return fmt.Errorf("error saving deployments to file: %w", err)
@@ -245,7 +245,7 @@ func SaveUsersToFile(ctx context.Context, k8sClient client.Client, ns string) er
 	if err != nil {
 		return fmt.Errorf("error getting user list: %w", err)
 	}
-	path := fmt.Sprintf("../../output/%s/%s.yaml", ns, "users")
+	path := fmt.Sprintf("output/%s/%s.yaml", ns, "users")
 	err = utils.SaveToFile(path, yaml)
 	if err != nil {
 		return fmt.Errorf("error saving users to file: %w", err)
@@ -260,7 +260,7 @@ func SaveTestAppLogs(input model.UserInputs) {
 		Expect(err).ToNot(HaveOccurred())
 
 		utils.SaveToFile(
-			fmt.Sprintf("../../output/%s/testapp-logs-%s.txt", input.Namespace, user.Spec.Username),
+			fmt.Sprintf("output/%s/testapp-logs-%s.txt", input.Namespace, user.Spec.Username),
 			bytes,
 		)
 	}

--- a/test/helper/e2e/config/config.go
+++ b/test/helper/e2e/config/config.go
@@ -41,5 +41,8 @@ const (
 	AzureRegionEU = "northeurope"
 
 	// GCP
-	FileNameSAGCP = "../../output/gcp_service_account.json"
+	FileNameSAGCP = "output/gcp_service_account.json"
+
+	// X509 auth test PEM key
+	PEMCertFileName = "output/x509cert.pem"
 )

--- a/test/helper/e2e/k8s/pod_logs.go
+++ b/test/helper/e2e/k8s/pod_logs.go
@@ -9,7 +9,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	"sigs.k8s.io/controller-runtime/pkg/client/config"
+	k8scfg "sigs.k8s.io/controller-runtime/pkg/client/config"
 )
 
 func GetPodLogsByDeployment(deploymentName, deploymentNS string, options corev1.PodLogOptions) ([]byte, error) {
@@ -24,7 +24,7 @@ func GetPodLogsByDeployment(deploymentName, deploymentNS string, options corev1.
 }
 
 func GetPodLogs(options corev1.PodLogOptions, ns string, podName string) ([]byte, error) {
-	cfg, err := config.GetConfig()
+	cfg, err := k8scfg.GetConfig()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get config: %w", err)
 	}
@@ -50,7 +50,7 @@ func GetPodLogs(options corev1.PodLogOptions, ns string, podName string) ([]byte
 }
 
 func GetAllDeploymentPods(deploymentName, deploymentNS string) ([]corev1.Pod, error) {
-	cfg, err := config.GetConfig()
+	cfg, err := k8scfg.GetConfig()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get config: %w", err)
 	}
@@ -75,7 +75,7 @@ func GetAllDeploymentPods(deploymentName, deploymentNS string) ([]corev1.Pod, er
 }
 
 func GetDeployment(deploymentName, deploymentNS string) (*appsv1.Deployment, error) {
-	cfg, err := config.GetConfig()
+	cfg, err := k8scfg.GetConfig()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get config: %w", err)
 	}


### PR DESCRIPTION
TL;DR:

- Make e2e clear rule also restore the helm chart repo.
- Move some generated e2e tests to properly `.gitgnored` paths.

Context:
When running locally, e2e tests will leave some git tracked files modified or create new files on non git-ignored paths.

This is counter-ergonomic and even dangerous. I have been saved from uploading secrets to GitHub by the GitHub secret hook more than once, when I inadvertently included e2e generated files in my PR changes.

This change does not fix the root cause but is part of a series to incrementally fix the issue, which has several components.Because `e2e tests` are:

- Generally not well behaved in where they generate files, they tend to leave them directly in the test dir at `test/e2e` or on some other directory that is not part of any path defined in `.gitignore`.

- Make changes to the helm chart in place before helm chart tests, rather than copying the helm chart somewhere else, on a `.gitignored` path, and applying needed changes there instead, using the resulting copy rather than the original path.

- Update the `bundle.Dockerfile` as well as directories `bundle/`, `config/` and `deploy`. This is somehow related to the fact that many of these files are only updated at release time, rather than as soon as code changes actually imply them. In any case, e2e tests should not rely on making those changes in place, if at all. My hypothesis is we might want to remove `scripts/int_local.sh` & `scripts/e2e_local.sh` completely, make the CI call `make e2e` and `make int-test` directly and ensure each test is responsible for setting up all its required environment, rather than relying on a script to do so. 
  - For instance, all e2e test asume CRDs are installed, but this is problematic for helm chart e2e tests, which should do the CRD install themselves. Right now we hack it by removing CRDs before the helm charts test, but it should be the other way around, install only as needed.

BUT, all this is better done in smaller incremental steps, so for now we add some small improvements.

### All Submissions:

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
