### PR TITLE
[skunkworks] centralize indexers

### DIFF
--- a/pkg/controller/atlasdeployment/atlasdeployment_controller.go
+++ b/pkg/controller/atlasdeployment/atlasdeployment_controller.go
@@ -528,7 +528,7 @@ func (r *AtlasDeploymentReconciler) findDeploymentsForSearchIndexConfig(ctx cont
 	deployments := &akov2.AtlasDeploymentList{}
 	listOps := &client.ListOptions{
 		FieldSelector: fields.OneTermEqualSelector(
-			indexer.AtlasSearchIndexToDeploymentRegistry,
+			indexer.AtlasDeploymentBySearchIndexIndex,
 			client.ObjectKeyFromObject(searchIndexConfig).String(),
 		),
 	}

--- a/pkg/controller/atlasdeployment/atlasdeployment_controller_test.go
+++ b/pkg/controller/atlasdeployment/atlasdeployment_controller_test.go
@@ -1053,13 +1053,14 @@ func TestFindDeploymentsForSearchIndexConfig(t *testing.T) {
 		}
 		testScheme := runtime.NewScheme()
 		assert.NoError(t, akov2.AddToScheme(testScheme))
+		deploymentIndexer := indexer.NewAtlasDeploymentBySearchIndexIndexer(zaptest.NewLogger(t))
 		k8sClient := fake.NewClientBuilder().
 			WithScheme(testScheme).
 			WithObjects(connection, instance1, instance2).
 			WithIndex(
-				&akov2.AtlasDeployment{},
-				indexer.AtlasSearchIndexToDeploymentRegistry,
-				indexer.AtlasSearchIndexKeysToDeployment(zaptest.NewLogger(t).Sugar()),
+				deploymentIndexer.Object(),
+				deploymentIndexer.Name(),
+				deploymentIndexer.Keys,
 			).
 			Build()
 		reconciler := &AtlasDeploymentReconciler{

--- a/pkg/controller/atlassearchindexconfig/atlassearchindexconfig_controller.go
+++ b/pkg/controller/atlassearchindexconfig/atlassearchindexconfig_controller.go
@@ -74,7 +74,7 @@ func (r *AtlasSearchIndexConfigReconciler) Reconcile(ctx context.Context, req ct
 	deployments := &akov2.AtlasDeploymentList{}
 	listOps := &client.ListOptions{
 		FieldSelector: fields.OneTermEqualSelector(
-			indexer.AtlasSearchIndexToDeploymentRegistry,
+			indexer.AtlasDeploymentBySearchIndexIndex,
 			client.ObjectKeyFromObject(atlasSearchIndexConfig).String(),
 		),
 	}
@@ -93,11 +93,6 @@ func (r *AtlasSearchIndexConfigReconciler) Reconcile(ctx context.Context, req ct
 }
 
 func (r *AtlasSearchIndexConfigReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
-	err := indexer.NewAtlasSearchIndexConfigsToDeploymentIndex(ctx, r.Log, mgr.GetFieldIndexer())
-	if err != nil {
-		return err
-	}
-
 	return ctrl.NewControllerManagedBy(mgr).
 		Named("AtlasSearchIndexConfig").
 		For(&akov2.AtlasSearchIndexConfig{}, builder.WithPredicates(r.GlobalPredicates...)).

--- a/pkg/controller/atlassearchindexconfig/atlassearchindexconfig_controller_test.go
+++ b/pkg/controller/atlassearchindexconfig/atlassearchindexconfig_controller_test.go
@@ -200,14 +200,15 @@ func TestAtlasSearchIndexConfigReconciler_Reconcile(t *testing.T) {
 		}
 		testScheme := runtime.NewScheme()
 		assert.NoError(t, akov2.AddToScheme(testScheme))
+		deploymentIndexer := indexer.NewAtlasDeploymentBySearchIndexIndexer(zaptest.NewLogger(t))
 		k8sClient := fake.NewClientBuilder().
 			WithScheme(testScheme).
 			WithObjects(searchIndexConfig).
 			WithStatusSubresource(searchIndexConfig).
 			WithIndex(
-				&akov2.AtlasDeployment{},
-				indexer.AtlasSearchIndexToDeploymentRegistry,
-				indexer.AtlasSearchIndexKeysToDeployment(zaptest.NewLogger(t).Sugar()),
+				deploymentIndexer.Object(),
+				deploymentIndexer.Name(),
+				deploymentIndexer.Keys,
 			).
 			WithInterceptorFuncs(interceptor.Funcs{List: func(ctx context.Context, client client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
 				return errors.New("failed to list instances")
@@ -285,14 +286,15 @@ func TestAtlasSearchIndexConfigReconciler_Reconcile(t *testing.T) {
 		}
 		testScheme := runtime.NewScheme()
 		assert.NoError(t, akov2.AddToScheme(testScheme))
+		deploymentIndexer := indexer.NewAtlasDeploymentBySearchIndexIndexer(zaptest.NewLogger(t))
 		k8sClient := fake.NewClientBuilder().
 			WithScheme(testScheme).
 			WithObjects(searchIndexConfig, atlasDeployment).
 			WithStatusSubresource(searchIndexConfig).
 			WithIndex(
-				&akov2.AtlasDeployment{},
-				indexer.AtlasSearchIndexToDeploymentRegistry,
-				indexer.AtlasSearchIndexKeysToDeployment(zaptest.NewLogger(t).Sugar()),
+				deploymentIndexer.Object(),
+				deploymentIndexer.Name(),
+				deploymentIndexer.Keys,
 			).
 			Build()
 
@@ -339,14 +341,15 @@ func TestAtlasSearchIndexConfigReconciler_Reconcile(t *testing.T) {
 		}
 		testScheme := runtime.NewScheme()
 		assert.NoError(t, akov2.AddToScheme(testScheme))
+		deploymentIndexer := indexer.NewAtlasDeploymentBySearchIndexIndexer(zaptest.NewLogger(t))
 		k8sClient := fake.NewClientBuilder().
 			WithScheme(testScheme).
 			WithObjects(searchIndexConfig).
 			WithStatusSubresource(searchIndexConfig).
 			WithIndex(
-				&akov2.AtlasDeployment{},
-				indexer.AtlasSearchIndexToDeploymentRegistry,
-				indexer.AtlasSearchIndexKeysToDeployment(zaptest.NewLogger(t).Sugar()),
+				deploymentIndexer.Object(),
+				deploymentIndexer.Name(),
+				deploymentIndexer.Keys,
 			).
 			Build()
 

--- a/pkg/controller/atlasstream/atlasstream_connection_controller.go
+++ b/pkg/controller/atlasstream/atlasstream_connection_controller.go
@@ -76,7 +76,7 @@ func (r *AtlasStreamsConnectionReconciler) ensureAtlasStreamConnection(ctx conte
 	streamInstances := &akov2.AtlasStreamInstanceList{}
 	listOps := &client.ListOptions{
 		FieldSelector: fields.OneTermEqualSelector(
-			indexer.AtlasStreamInstancesByConnectionRegistry,
+			indexer.AtlasStreamInstanceByConnectionIndex,
 			client.ObjectKeyFromObject(akoStreamConnection).String(),
 		),
 	}
@@ -93,11 +93,6 @@ func (r *AtlasStreamsConnectionReconciler) ensureAtlasStreamConnection(ctx conte
 }
 
 func (r *AtlasStreamsConnectionReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
-	err := indexer.NewAtlasStreamConnectionsBySecretIndex(ctx, r.Log, mgr.GetFieldIndexer())
-	if err != nil {
-		return err
-	}
-
 	return ctrl.NewControllerManagedBy(mgr).
 		Named("AtlasStreamConnection").
 		For(&akov2.AtlasStreamConnection{}, builder.WithPredicates(r.GlobalPredicates...)).

--- a/pkg/controller/atlasstream/atlasstream_connection_controller_test.go
+++ b/pkg/controller/atlasstream/atlasstream_connection_controller_test.go
@@ -220,14 +220,15 @@ func TestEnsureAtlasStreamConnection(t *testing.T) {
 		}
 		testScheme := runtime.NewScheme()
 		assert.NoError(t, akov2.AddToScheme(testScheme))
+		streamInstanceIndexer := indexer.NewAtlasStreamInstanceByConnectionIndexer(zaptest.NewLogger(t))
 		k8sClient := fake.NewClientBuilder().
 			WithScheme(testScheme).
 			WithObjects(streamConnection).
 			WithStatusSubresource(streamConnection).
 			WithIndex(
-				&akov2.AtlasStreamInstance{},
-				indexer.AtlasStreamInstancesByConnectionRegistry,
-				indexer.AtlasStreamInstancesByConnectionRegistryIndices(zaptest.NewLogger(t).Sugar()),
+				streamInstanceIndexer.Object(),
+				streamInstanceIndexer.Name(),
+				streamInstanceIndexer.Keys,
 			).
 			WithInterceptorFuncs(interceptor.Funcs{List: func(ctx context.Context, client client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
 				return errors.New("failed to list instances")
@@ -302,14 +303,15 @@ func TestEnsureAtlasStreamConnection(t *testing.T) {
 		}
 		testScheme := runtime.NewScheme()
 		assert.NoError(t, akov2.AddToScheme(testScheme))
+		streamInstanceIndexer := indexer.NewAtlasStreamInstanceByConnectionIndexer(zaptest.NewLogger(t))
 		k8sClient := fake.NewClientBuilder().
 			WithScheme(testScheme).
 			WithObjects(streamInstance, streamConnection).
 			WithStatusSubresource(streamConnection).
 			WithIndex(
-				&akov2.AtlasStreamInstance{},
-				indexer.AtlasStreamInstancesByConnectionRegistry,
-				indexer.AtlasStreamInstancesByConnectionRegistryIndices(zaptest.NewLogger(t).Sugar()),
+				streamInstanceIndexer.Object(),
+				streamInstanceIndexer.Name(),
+				streamInstanceIndexer.Keys,
 			).
 			Build()
 
@@ -360,14 +362,15 @@ func TestEnsureAtlasStreamConnection(t *testing.T) {
 		}
 		testScheme := runtime.NewScheme()
 		assert.NoError(t, akov2.AddToScheme(testScheme))
+		streamInstanceIndexer := indexer.NewAtlasStreamInstanceByConnectionIndexer(zaptest.NewLogger(t))
 		k8sClient := fake.NewClientBuilder().
 			WithScheme(testScheme).
 			WithObjects(streamConnection).
 			WithStatusSubresource(streamConnection).
 			WithIndex(
-				&akov2.AtlasStreamInstance{},
-				indexer.AtlasStreamInstancesByConnectionRegistry,
-				indexer.AtlasStreamInstancesByConnectionRegistryIndices(zaptest.NewLogger(t).Sugar()),
+				streamInstanceIndexer.Object(),
+				streamInstanceIndexer.Name(),
+				streamInstanceIndexer.Keys,
 			).
 			Build()
 

--- a/pkg/controller/atlasstream/atlasstream_instance_controller.go
+++ b/pkg/controller/atlasstream/atlasstream_instance_controller.go
@@ -134,11 +134,6 @@ func hasChanged(streamInstance *akov2.AtlasStreamInstance, atlasStreamInstance *
 }
 
 func (r *AtlasStreamsInstanceReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
-	err := indexer.NewAtlasStreamInstancesByConnectionRegistryIndex(ctx, r.Log, mgr.GetFieldIndexer())
-	if err != nil {
-		return err
-	}
-
 	return ctrl.NewControllerManagedBy(mgr).
 		Named("AtlasStreamInstance").
 		For(&akov2.AtlasStreamInstance{}, builder.WithPredicates(r.GlobalPredicates...)).
@@ -165,7 +160,7 @@ func (r *AtlasStreamsInstanceReconciler) findStreamInstancesForStreamConnection(
 	atlasStreamInstances := &akov2.AtlasStreamInstanceList{}
 	listOps := &client.ListOptions{
 		FieldSelector: fields.OneTermEqualSelector(
-			indexer.AtlasStreamInstancesByConnectionRegistry,
+			indexer.AtlasStreamInstanceByConnectionIndex,
 			client.ObjectKeyFromObject(streamConnection).String(),
 		),
 	}
@@ -203,7 +198,7 @@ func (r *AtlasStreamsInstanceReconciler) findStreamInstancesForSecret(ctx contex
 	connections := &akov2.AtlasStreamConnectionList{}
 	listOps := &client.ListOptions{
 		FieldSelector: fields.OneTermEqualSelector(
-			indexer.AtlasStreamConnectionBySecret,
+			indexer.AtlasStreamConnectionBySecretIndex,
 			client.ObjectKeyFromObject(secret).String(),
 		),
 	}

--- a/pkg/controller/atlasstream/atlasstream_instance_controller_test.go
+++ b/pkg/controller/atlasstream/atlasstream_instance_controller_test.go
@@ -1033,13 +1033,14 @@ func TestFindStreamInstancesForStreamConnection(t *testing.T) {
 		}
 		testScheme := runtime.NewScheme()
 		assert.NoError(t, akov2.AddToScheme(testScheme))
+		streamInstanceIndexer := indexer.NewAtlasStreamInstanceByConnectionIndexer(zaptest.NewLogger(t))
 		k8sClient := fake.NewClientBuilder().
 			WithScheme(testScheme).
 			WithObjects(connection, instance1, instance2).
 			WithIndex(
-				&akov2.AtlasStreamInstance{},
-				indexer.AtlasStreamInstancesByConnectionRegistry,
-				indexer.AtlasStreamInstancesByConnectionRegistryIndices(zaptest.NewLogger(t).Sugar()),
+				streamInstanceIndexer.Object(),
+				streamInstanceIndexer.Name(),
+				streamInstanceIndexer.Keys,
 			).
 			Build()
 		reconciler := &AtlasStreamsInstanceReconciler{
@@ -1129,18 +1130,20 @@ func TestFindStreamInstancesForSecret(t *testing.T) {
 		testScheme := runtime.NewScheme()
 		assert.NoError(t, akov2.AddToScheme(testScheme))
 		assert.NoError(t, corev1.AddToScheme(testScheme))
+		connectionIndexer := indexer.NewAtlasStreamConnectionBySecretIndexer(zaptest.NewLogger(t))
+		streamInstanceIndexer := indexer.NewAtlasStreamInstanceByConnectionIndexer(zaptest.NewLogger(t))
 		k8sClient := fake.NewClientBuilder().
 			WithScheme(testScheme).
 			WithObjects(secret, connection, instance).
 			WithIndex(
-				&akov2.AtlasStreamInstance{},
-				indexer.AtlasStreamInstancesByConnectionRegistry,
-				indexer.AtlasStreamInstancesByConnectionRegistryIndices(zaptest.NewLogger(t).Sugar()),
+				streamInstanceIndexer.Object(),
+				streamInstanceIndexer.Name(),
+				streamInstanceIndexer.Keys,
 			).
 			WithIndex(
-				&akov2.AtlasStreamConnection{},
-				indexer.AtlasStreamConnectionBySecret,
-				indexer.AtlasStreamConnectionsBySecretIndices(zaptest.NewLogger(t).Sugar()),
+				connectionIndexer.Object(),
+				connectionIndexer.Name(),
+				connectionIndexer.Keys,
 			).
 			Build()
 		reconciler := &AtlasStreamsInstanceReconciler{
@@ -1210,18 +1213,20 @@ func TestFindStreamInstancesForSecret(t *testing.T) {
 		testScheme := runtime.NewScheme()
 		assert.NoError(t, akov2.AddToScheme(testScheme))
 		assert.NoError(t, corev1.AddToScheme(testScheme))
+		connectionIndexer := indexer.NewAtlasStreamConnectionBySecretIndexer(zaptest.NewLogger(t))
+		streamInstanceIndexer := indexer.NewAtlasStreamInstanceByConnectionIndexer(zaptest.NewLogger(t))
 		k8sClient := fake.NewClientBuilder().
 			WithScheme(testScheme).
 			WithObjects(secret, connection, instance).
 			WithIndex(
-				&akov2.AtlasStreamInstance{},
-				indexer.AtlasStreamInstancesByConnectionRegistry,
-				indexer.AtlasStreamInstancesByConnectionRegistryIndices(zaptest.NewLogger(t).Sugar()),
+				streamInstanceIndexer.Object(),
+				streamInstanceIndexer.Name(),
+				streamInstanceIndexer.Keys,
 			).
 			WithIndex(
-				&akov2.AtlasStreamConnection{},
-				indexer.AtlasStreamConnectionBySecret,
-				indexer.AtlasStreamConnectionsBySecretIndices(zaptest.NewLogger(t).Sugar()),
+				connectionIndexer.Object(),
+				connectionIndexer.Name(),
+				connectionIndexer.Keys,
 			).
 			Build()
 		reconciler := &AtlasStreamsInstanceReconciler{
@@ -1315,18 +1320,20 @@ func TestFindStreamInstancesForSecret(t *testing.T) {
 		testScheme := runtime.NewScheme()
 		assert.NoError(t, akov2.AddToScheme(testScheme))
 		assert.NoError(t, corev1.AddToScheme(testScheme))
+		connectionIndexer := indexer.NewAtlasStreamConnectionBySecretIndexer(zaptest.NewLogger(t))
+		streamInstanceIndexer := indexer.NewAtlasStreamInstanceByConnectionIndexer(zaptest.NewLogger(t))
 		k8sClient := fake.NewClientBuilder().
 			WithScheme(testScheme).
 			WithObjects(secret, connection1, connection2, instance).
 			WithIndex(
-				&akov2.AtlasStreamInstance{},
-				indexer.AtlasStreamInstancesByConnectionRegistry,
-				indexer.AtlasStreamInstancesByConnectionRegistryIndices(zaptest.NewLogger(t).Sugar()),
+				streamInstanceIndexer.Object(),
+				streamInstanceIndexer.Name(),
+				streamInstanceIndexer.Keys,
 			).
 			WithIndex(
-				&akov2.AtlasStreamConnection{},
-				indexer.AtlasStreamConnectionBySecret,
-				indexer.AtlasStreamConnectionsBySecretIndices(zaptest.NewLogger(t).Sugar()),
+				connectionIndexer.Object(),
+				connectionIndexer.Name(),
+				connectionIndexer.Keys,
 			).
 			Build()
 		reconciler := &AtlasStreamsInstanceReconciler{

--- a/pkg/indexer/atlassearchindexconfigs.go
+++ b/pkg/indexer/atlassearchindexconfigs.go
@@ -1,57 +1,62 @@
 package indexer
 
 import (
-	"context"
-
 	"go.uber.org/zap"
-
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	akov2 "github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/api/v1"
 )
 
 const (
-	AtlasSearchIndexToDeploymentRegistry = ".spec.deploymentSpec.searchIndexes"
+	AtlasDeploymentBySearchIndexIndex = ".spec.deploymentSpec.searchIndexes"
 )
 
-func NewAtlasSearchIndexConfigsToDeploymentIndex(ctx context.Context, logger *zap.SugaredLogger, idx client.FieldIndexer) error {
-	return idx.IndexField(ctx,
-		&akov2.AtlasDeployment{},
-		AtlasSearchIndexToDeploymentRegistry,
-		AtlasSearchIndexKeysToDeployment(logger.Named("indexers").Named(AtlasSearchIndexToDeploymentRegistry)),
-	)
+type AtlasDeploymentBySearchIndexIndexer struct {
+	logger *zap.SugaredLogger
 }
 
-func AtlasSearchIndexKeysToDeployment(logger *zap.SugaredLogger) client.IndexerFunc {
-	return func(object client.Object) []string {
-		deployment, ok := object.(*akov2.AtlasDeployment)
-		if !ok {
-			logger.Errorf("expected *akov2.AtlasSearchIndexConfig but got %T", object)
-			return nil
-		}
-
-		if deployment.Spec.DeploymentSpec == nil {
-			return nil
-		}
-
-		if len(deployment.Spec.DeploymentSpec.SearchIndexes) == 0 {
-			return nil
-		}
-
-		searchIndexes := deployment.Spec.DeploymentSpec.SearchIndexes
-
-		result := make([]string, 0, len(searchIndexes))
-		for i := range searchIndexes {
-			idx := &searchIndexes[i]
-			if idx.Search == nil {
-				continue
-			}
-
-			// searchIndexConfigKey -> deploymentName
-			searchIndexKey := idx.Search.SearchConfigurationRef.GetObject(deployment.GetNamespace())
-			result = append(result, searchIndexKey.String())
-		}
-
-		return result
+func NewAtlasDeploymentBySearchIndexIndexer(logger *zap.Logger) *AtlasDeploymentBySearchIndexIndexer {
+	return &AtlasDeploymentBySearchIndexIndexer{
+		logger: logger.Named(AtlasDeploymentBySearchIndexIndex).Sugar(),
 	}
+}
+
+func (*AtlasDeploymentBySearchIndexIndexer) Object() client.Object {
+	return &akov2.AtlasDeployment{}
+}
+
+func (*AtlasDeploymentBySearchIndexIndexer) Name() string {
+	return AtlasDeploymentBySearchIndexIndex
+}
+
+func (a *AtlasDeploymentBySearchIndexIndexer) Keys(object client.Object) []string {
+	deployment, ok := object.(*akov2.AtlasDeployment)
+	if !ok {
+		a.logger.Errorf("expected *akov2.AtlasSearchIndexConfig but got %T", object)
+		return nil
+	}
+
+	if deployment.Spec.DeploymentSpec == nil {
+		return nil
+	}
+
+	if len(deployment.Spec.DeploymentSpec.SearchIndexes) == 0 {
+		return nil
+	}
+
+	searchIndexes := deployment.Spec.DeploymentSpec.SearchIndexes
+
+	result := make([]string, 0, len(searchIndexes))
+	for i := range searchIndexes {
+		idx := &searchIndexes[i]
+		if idx.Search == nil {
+			continue
+		}
+
+		// searchIndexConfigKey -> deploymentName
+		searchIndexKey := idx.Search.SearchConfigurationRef.GetObject(deployment.GetNamespace())
+		result = append(result, searchIndexKey.String())
+	}
+
+	return result
 }

--- a/pkg/indexer/atlassearchindexconfigs_test.go
+++ b/pkg/indexer/atlassearchindexconfigs_test.go
@@ -21,9 +21,9 @@ func Test_AtlasSearchIndexKeysToDeployment(t *testing.T) {
 			},
 		}
 
-		indexer := AtlasSearchIndexKeysToDeployment(zaptest.NewLogger(t).Sugar())
-		indexes := indexer(instance)
-		assert.Nil(t, indexes)
+		indexer := NewAtlasDeploymentBySearchIndexIndexer(zaptest.NewLogger(t))
+		keys := indexer.Keys(instance)
+		assert.Nil(t, keys)
 	})
 
 	t.Run("should return indexes slice AtlasSearchIndex is referenced by a Deployment", func(t *testing.T) {
@@ -53,8 +53,8 @@ func Test_AtlasSearchIndexKeysToDeployment(t *testing.T) {
 			},
 		}
 
-		indexer := AtlasSearchIndexKeysToDeployment(zaptest.NewLogger(t).Sugar())
-		indexes := indexer(instance)
+		indexer := NewAtlasDeploymentBySearchIndexIndexer(zaptest.NewLogger(t))
+		keys := indexer.Keys(instance)
 
 		assert.Equal(
 			t,
@@ -62,7 +62,7 @@ func Test_AtlasSearchIndexKeysToDeployment(t *testing.T) {
 				"default/config-1",
 				"default/config-2",
 			},
-			indexes,
+			keys,
 		)
 	})
 }

--- a/pkg/indexer/atlasstreamconnections_test.go
+++ b/pkg/indexer/atlasstreamconnections_test.go
@@ -15,9 +15,9 @@ import (
 func TestAtlasStreamConnectionsBySecretIndices(t *testing.T) {
 	t.Run("should return nil when indexing wrong type object", func(t *testing.T) {
 		core, logs := observer.New(zap.DebugLevel)
-		indexer := AtlasStreamConnectionsBySecretIndices(zap.New(core).Sugar())
-		indexes := indexer(&akov2.AtlasProject{})
-		assert.Nil(t, indexes)
+		indexer := NewAtlasStreamConnectionBySecretIndexer(zap.New(core))
+		keys := indexer.Keys(&akov2.AtlasProject{})
+		assert.Nil(t, keys)
 		assert.Equal(t, 1, logs.Len())
 		assert.Equal(t, zap.ErrorLevel, logs.All()[0].Level)
 		assert.Equal(t, "expected *akov2.AtlasStreamConnection but got *v1.AtlasProject", logs.All()[0].Message)
@@ -31,9 +31,9 @@ func TestAtlasStreamConnectionsBySecretIndices(t *testing.T) {
 			},
 		}
 
-		indexer := AtlasStreamConnectionsBySecretIndices(zaptest.NewLogger(t).Sugar())
-		indexes := indexer(connection)
-		assert.Nil(t, indexes)
+		indexer := NewAtlasStreamConnectionBySecretIndexer(zaptest.NewLogger(t))
+		keys := indexer.Keys(connection)
+		assert.Nil(t, keys)
 	})
 
 	t.Run("should return indexes slice when connection has credentials", func(t *testing.T) {
@@ -52,14 +52,14 @@ func TestAtlasStreamConnectionsBySecretIndices(t *testing.T) {
 			},
 		}
 
-		indexer := AtlasStreamConnectionsBySecretIndices(zaptest.NewLogger(t).Sugar())
-		indexes := indexer(connection)
+		indexer := NewAtlasStreamConnectionBySecretIndexer(zaptest.NewLogger(t))
+		keys := indexer.Keys(connection)
 		assert.Equal(
 			t,
 			[]string{
 				"default/connection-credentials",
 			},
-			indexes,
+			keys,
 		)
 	})
 
@@ -79,14 +79,14 @@ func TestAtlasStreamConnectionsBySecretIndices(t *testing.T) {
 			},
 		}
 
-		indexer := AtlasStreamConnectionsBySecretIndices(zaptest.NewLogger(t).Sugar())
-		indexes := indexer(connection)
+		indexer := NewAtlasStreamConnectionBySecretIndexer(zaptest.NewLogger(t))
+		keys := indexer.Keys(connection)
 		assert.Equal(
 			t,
 			[]string{
 				"default/connection-certificate",
 			},
-			indexes,
+			keys,
 		)
 	})
 
@@ -112,15 +112,15 @@ func TestAtlasStreamConnectionsBySecretIndices(t *testing.T) {
 			},
 		}
 
-		indexer := AtlasStreamConnectionsBySecretIndices(zaptest.NewLogger(t).Sugar())
-		indexes := indexer(connection)
+		indexer := NewAtlasStreamConnectionBySecretIndexer(zaptest.NewLogger(t))
+		keys := indexer.Keys(connection)
 		assert.Equal(
 			t,
 			[]string{
 				"default/connection-credentials",
 				"default/connection-certificate",
 			},
-			indexes,
+			keys,
 		)
 	})
 
@@ -146,15 +146,15 @@ func TestAtlasStreamConnectionsBySecretIndices(t *testing.T) {
 			},
 		}
 
-		indexer := AtlasStreamConnectionsBySecretIndices(zaptest.NewLogger(t).Sugar())
-		indexes := indexer(connection)
+		indexer := NewAtlasStreamConnectionBySecretIndexer(zaptest.NewLogger(t))
+		keys := indexer.Keys(connection)
 		assert.Equal(
 			t,
 			[]string{
 				"default/connection-secrets",
 				"default/connection-secrets",
 			},
-			indexes,
+			keys,
 		)
 	})
 }

--- a/pkg/indexer/atlasstreaminstances_test.go
+++ b/pkg/indexer/atlasstreaminstances_test.go
@@ -18,9 +18,9 @@ func TestAtlasStreamInstancesByConnectionRegistryIndices(t *testing.T) {
 			},
 		}
 
-		indexer := AtlasStreamInstancesByConnectionRegistryIndices(zaptest.NewLogger(t).Sugar())
-		indexes := indexer(instance)
-		assert.Nil(t, indexes)
+		indexer := NewAtlasStreamInstanceByConnectionIndexer(zaptest.NewLogger(t))
+		keys := indexer.Keys(instance)
+		assert.Nil(t, keys)
 	})
 
 	t.Run("should return indexes slice when instance has connections", func(t *testing.T) {
@@ -40,15 +40,15 @@ func TestAtlasStreamInstancesByConnectionRegistryIndices(t *testing.T) {
 			},
 		}
 
-		indexer := AtlasStreamInstancesByConnectionRegistryIndices(zaptest.NewLogger(t).Sugar())
-		indexes := indexer(instance)
+		indexer := NewAtlasStreamInstanceByConnectionIndexer(zaptest.NewLogger(t))
+		keys := indexer.Keys(instance)
 		assert.Equal(
 			t,
 			[]string{
 				"default/conn-1",
 				"default/conn-2",
 			},
-			indexes,
+			keys,
 		)
 	})
 }

--- a/pkg/indexer/indexer.go
+++ b/pkg/indexer/indexer.go
@@ -1,0 +1,40 @@
+package indexer
+
+import (
+	"context"
+	"fmt"
+
+	"go.uber.org/zap"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+type Indexer interface {
+	Object() client.Object
+	Name() string
+	Keys(client.Object) []string
+}
+
+// RegisterAll registers all known indexers to the given manager.
+// It uses the given logger to create a new named "indexer" logger,
+// passing that to each indexer.
+func RegisterAll(ctx context.Context, mgr manager.Manager, logger *zap.Logger) error {
+	logger = logger.Named("indexer")
+	return Register(ctx, mgr,
+		NewAtlasStreamConnectionBySecretIndexer(logger),
+		NewAtlasDeploymentBySearchIndexIndexer(logger),
+		NewAtlasStreamInstanceByConnectionIndexer(logger),
+	)
+}
+
+// Register registers the given indexers to the given manager's field indexer.
+func Register(ctx context.Context, mgr manager.Manager, indexers ...Indexer) error {
+	for _, indexer := range indexers {
+		err := mgr.GetFieldIndexer().IndexField(ctx, indexer.Object(), indexer.Name(), indexer.Keys)
+		if err != nil {
+			return fmt.Errorf("error registering indexer %q: %w", indexer.Name(), err)
+		}
+	}
+
+	return nil
+}

--- a/test/int/integration_suite_test.go
+++ b/test/int/integration_suite_test.go
@@ -54,6 +54,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/controller/atlasproject"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/controller/atlasstream"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/controller/watch"
+	"github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/indexer"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/test/helper/control"
 )
 
@@ -230,6 +231,9 @@ func prepareControllers(deletionProtection bool) (*corev1.Namespace, context.Can
 	featureFlags := featureflags.NewFeatureFlags(os.Environ)
 
 	atlasProvider := atlas.NewProductionProvider(atlasDomain, kube.ObjectKey(namespace.Name, "atlas-operator-api-key"), k8sManager.GetClient())
+
+	err = indexer.RegisterAll(ctx, k8sManager, logger)
+	Expect(err).ToNot(HaveOccurred())
 
 	err = (&atlasproject.AtlasProjectReconciler{
 		Client:                      k8sManager.GetClient(),


### PR DESCRIPTION
This is a proposal to centralise indexing logic.

Currently, indexers are loosely coupled, mostly based on the fact that controller-runtime does not provider any abstraction for it. This PR introduces a lightweight interface `Indexer` which is being used for global registration and client-go mocks.