### PR TITLE
CLOUDP-251999: [skunkworks] add "atlas" CRD category and short names

### DIFF
--- a/config/crd/bases/atlas.mongodb.com_atlasbackupcompliancepolicies.yaml
+++ b/config/crd/bases/atlas.mongodb.com_atlasbackupcompliancepolicies.yaml
@@ -18,7 +18,11 @@ spec:
     singular: atlasbackupcompliancepolicy
   scope: Namespaced
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    name: v1
     schema:
       openAPIV3Schema:
         description: AtlasBackupCompliancePolicy defines the desired state of a compliance

--- a/config/crd/bases/atlas.mongodb.com_atlasbackuppolicies.yaml
+++ b/config/crd/bases/atlas.mongodb.com_atlasbackuppolicies.yaml
@@ -8,13 +8,21 @@ metadata:
 spec:
   group: atlas.mongodb.com
   names:
+    categories:
+    - atlas
     kind: AtlasBackupPolicy
     listKind: AtlasBackupPolicyList
     plural: atlasbackuppolicies
+    shortNames:
+    - abp
     singular: atlasbackuppolicy
   scope: Namespaced
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    name: v1
     schema:
       openAPIV3Schema:
         description: AtlasBackupPolicy is the Schema for the atlasbackuppolicies API

--- a/config/crd/bases/atlas.mongodb.com_atlasbackupschedules.yaml
+++ b/config/crd/bases/atlas.mongodb.com_atlasbackupschedules.yaml
@@ -8,13 +8,21 @@ metadata:
 spec:
   group: atlas.mongodb.com
   names:
+    categories:
+    - atlas
     kind: AtlasBackupSchedule
     listKind: AtlasBackupScheduleList
     plural: atlasbackupschedules
+    shortNames:
+    - abs
     singular: atlasbackupschedule
   scope: Namespaced
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    name: v1
     schema:
       openAPIV3Schema:
         description: AtlasBackupSchedule is the Schema for the atlasbackupschedules

--- a/config/crd/bases/atlas.mongodb.com_atlasdatabaseusers.yaml
+++ b/config/crd/bases/atlas.mongodb.com_atlasdatabaseusers.yaml
@@ -8,15 +8,25 @@ metadata:
 spec:
   group: atlas.mongodb.com
   names:
+    categories:
+    - atlas
     kind: AtlasDatabaseUser
     listKind: AtlasDatabaseUserList
     plural: atlasdatabaseusers
+    shortNames:
+    - adu
     singular: atlasdatabaseuser
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
     - jsonPath: .spec.name
       name: Name
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .spec.username
+      name: Username
       type: string
     name: v1
     schema:

--- a/config/crd/bases/atlas.mongodb.com_atlasdatafederations.yaml
+++ b/config/crd/bases/atlas.mongodb.com_atlasdatafederations.yaml
@@ -8,15 +8,22 @@ metadata:
 spec:
   group: atlas.mongodb.com
   names:
+    categories:
+    - atlas
     kind: AtlasDataFederation
     listKind: AtlasDataFederationList
     plural: atlasdatafederations
+    shortNames:
+    - adf
     singular: atlasdatafederation
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
     - jsonPath: .spec.name
       name: Name
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
       type: string
     name: v1
     schema:

--- a/config/crd/bases/atlas.mongodb.com_atlasdeployments.yaml
+++ b/config/crd/bases/atlas.mongodb.com_atlasdeployments.yaml
@@ -8,13 +8,27 @@ metadata:
 spec:
   group: atlas.mongodb.com
   names:
+    categories:
+    - atlas
     kind: AtlasDeployment
     listKind: AtlasDeploymentList
     plural: atlasdeployments
+    shortNames:
+    - ad
     singular: atlasdeployment
   scope: Namespaced
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.stateName
+      name: Atlas State
+      type: string
+    - jsonPath: .status.mongoDBVersion
+      name: MongoDB Version
+      type: string
+    name: v1
     schema:
       openAPIV3Schema:
         description: AtlasDeployment is the Schema for the atlasdeployments API

--- a/config/crd/bases/atlas.mongodb.com_atlasfederatedauths.yaml
+++ b/config/crd/bases/atlas.mongodb.com_atlasfederatedauths.yaml
@@ -8,13 +8,21 @@ metadata:
 spec:
   group: atlas.mongodb.com
   names:
+    categories:
+    - atlas
     kind: AtlasFederatedAuth
     listKind: AtlasFederatedAuthList
     plural: atlasfederatedauths
+    shortNames:
+    - afa
     singular: atlasfederatedauth
   scope: Namespaced
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    name: v1
     schema:
       openAPIV3Schema:
         description: AtlasFederatedAuth is the Schema for the Atlasfederatedauth API

--- a/config/crd/bases/atlas.mongodb.com_atlasprojects.yaml
+++ b/config/crd/bases/atlas.mongodb.com_atlasprojects.yaml
@@ -8,15 +8,25 @@ metadata:
 spec:
   group: atlas.mongodb.com
   names:
+    categories:
+    - atlas
     kind: AtlasProject
     listKind: AtlasProjectList
     plural: atlasprojects
+    shortNames:
+    - ap
     singular: atlasproject
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
     - jsonPath: .spec.name
-      name: Name
+      name: Atlas Name
+      type: string
+    - jsonPath: .status.id
+      name: Atlas ID
       type: string
     name: v1
     schema:

--- a/config/crd/bases/atlas.mongodb.com_atlassearchindexconfigs.yaml
+++ b/config/crd/bases/atlas.mongodb.com_atlassearchindexconfigs.yaml
@@ -8,13 +8,21 @@ metadata:
 spec:
   group: atlas.mongodb.com
   names:
+    categories:
+    - atlas
     kind: AtlasSearchIndexConfig
     listKind: AtlasSearchIndexConfigList
     plural: atlassearchindexconfigs
+    shortNames:
+    - asic
     singular: atlassearchindexconfig
   scope: Namespaced
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    name: v1
     schema:
       openAPIV3Schema:
         description: AtlasSearchIndexConfig is the Schema for the AtlasSearchIndexConfig

--- a/config/crd/bases/atlas.mongodb.com_atlasstreamconnections.yaml
+++ b/config/crd/bases/atlas.mongodb.com_atlasstreamconnections.yaml
@@ -8,13 +8,21 @@ metadata:
 spec:
   group: atlas.mongodb.com
   names:
+    categories:
+    - atlas
     kind: AtlasStreamConnection
     listKind: AtlasStreamConnectionList
     plural: atlasstreamconnections
+    shortNames:
+    - asc
     singular: atlasstreamconnection
   scope: Namespaced
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    name: v1
     schema:
       openAPIV3Schema:
         description: AtlasStreamConnection is the Schema for the atlasstreamconnections

--- a/config/crd/bases/atlas.mongodb.com_atlasstreaminstances.yaml
+++ b/config/crd/bases/atlas.mongodb.com_atlasstreaminstances.yaml
@@ -8,15 +8,25 @@ metadata:
 spec:
   group: atlas.mongodb.com
   names:
+    categories:
+    - atlas
     kind: AtlasStreamInstance
     listKind: AtlasStreamInstanceList
     plural: atlasstreaminstances
+    shortNames:
+    - asi
     singular: atlasstreaminstance
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
     - jsonPath: .spec.name
       name: Name
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.id
+      name: Atlas ID
       type: string
     name: v1
     schema:

--- a/config/crd/bases/atlas.mongodb.com_atlasteams.yaml
+++ b/config/crd/bases/atlas.mongodb.com_atlasteams.yaml
@@ -8,15 +8,25 @@ metadata:
 spec:
   group: atlas.mongodb.com
   names:
+    categories:
+    - atlas
     kind: AtlasTeam
     listKind: AtlasTeamList
     plural: atlasteams
+    shortNames:
+    - at
     singular: atlasteam
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
     - jsonPath: .spec.name
       name: Name
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.id
+      name: Atlas ID
       type: string
     name: v1
     schema:

--- a/pkg/api/v1/atlasbackupcompliancepolicy_types.go
+++ b/pkg/api/v1/atlasbackupcompliancepolicy_types.go
@@ -21,6 +21,7 @@ func init() {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:categories=atlas,shortName=abcp
+// +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
 type AtlasBackupCompliancePolicy struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/api/v1/atlasbackuppolicy_types.go
+++ b/pkg/api/v1/atlasbackuppolicy_types.go
@@ -41,9 +41,14 @@ type AtlasBackupPolicyItem struct {
 
 var _ api.AtlasCustomResource = &AtlasBackupPolicy{}
 
-// AtlasBackupPolicy is the Schema for the atlasbackuppolicies API
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:resource:categories=atlas,shortName=abp
+// +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
+//
+// AtlasBackupPolicy is the Schema for the atlasbackuppolicies API
+//
+//nolint:stylecheck
 type AtlasBackupPolicy struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/api/v1/atlasbackupschedule_types.go
+++ b/pkg/api/v1/atlasbackupschedule_types.go
@@ -88,9 +88,14 @@ type CopySetting struct {
 
 var _ api.AtlasCustomResource = &AtlasBackupSchedule{}
 
-// AtlasBackupSchedule is the Schema for the atlasbackupschedules API
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:resource:categories=atlas,shortName=abs
+// +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
+//
+// AtlasBackupSchedule is the Schema for the atlasbackupschedules API
+//
+//nolint:stylecheck
 type AtlasBackupSchedule struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/api/v1/atlasdatabaseuser_types.go
+++ b/pkg/api/v1/atlasdatabaseuser_types.go
@@ -117,8 +117,11 @@ var _ api.AtlasCustomResource = &AtlasDatabaseUser{}
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:object:root=true
 // +kubebuilder:printcolumn:name="Name",type=string,JSONPath=`.spec.name`
+// +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
+// +kubebuilder:printcolumn:name="Username",type=string,JSONPath=`.spec.username`
 // +kubebuilder:subresource:status
 // +groupName:=atlas.mongodb.com
+// +kubebuilder:resource:categories=atlas,shortName=adu
 
 // AtlasDatabaseUser is the Schema for the Atlas Database User API
 type AtlasDatabaseUser struct {

--- a/pkg/api/v1/atlasdatafederation_types.go
+++ b/pkg/api/v1/atlasdatafederation_types.go
@@ -131,8 +131,10 @@ var _ api.AtlasCustomResource = &AtlasDataFederation{}
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:object:root=true
 // +kubebuilder:printcolumn:name="Name",type=string,JSONPath=`.spec.name`
+// +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
 // +kubebuilder:subresource:status
 // +groupName:=atlas.mongodb.com
+// +kubebuilder:resource:categories=atlas,shortName=adf
 
 // AtlasDataFederation is the Schema for the Atlas Data Federation API
 type AtlasDataFederation struct {

--- a/pkg/api/v1/atlasdeployment_types.go
+++ b/pkg/api/v1/atlasdeployment_types.go
@@ -532,6 +532,10 @@ var _ api.AtlasCustomResource = &AtlasDeployment{}
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
+// +kubebuilder:printcolumn:name="Atlas State",type=string,JSONPath=`.status.stateName`
+// +kubebuilder:printcolumn:name="MongoDB Version",type=string,JSONPath=`.status.mongoDBVersion`
+// +kubebuilder:resource:categories=atlas,shortName=ad
 
 // AtlasDeployment is the Schema for the atlasdeployments API
 type AtlasDeployment struct {

--- a/pkg/api/v1/atlasfederatedauth_types.go
+++ b/pkg/api/v1/atlasfederatedauth_types.go
@@ -107,10 +107,15 @@ type RoleAssignment struct {
 
 var _ api.AtlasCustomResource = &AtlasFederatedAuth{}
 
-// AtlasFederatedAuth is the Schema for the Atlasfederatedauth API
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:resource:categories=atlas,shortName=afa
+// +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
+//
+// AtlasFederatedAuth is the Schema for the Atlasfederatedauth API
+//
+//nolint:stylecheck
 type AtlasFederatedAuth struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/api/v1/atlasproject_types.go
+++ b/pkg/api/v1/atlasproject_types.go
@@ -164,9 +164,12 @@ var _ api.AtlasCustomResource = &AtlasProject{}
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:object:root=true
-// +kubebuilder:printcolumn:name="Name",type=string,JSONPath=`.spec.name`
+// +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
+// +kubebuilder:printcolumn:name="Atlas Name",type=string,JSONPath=`.spec.name`
+// +kubebuilder:printcolumn:name="Atlas ID",type=string,JSONPath=`.status.id`
 // +kubebuilder:subresource:status
 // +groupName:=atlas.mongodb.com
+// +kubebuilder:resource:categories=atlas,shortName=ap
 
 // AtlasProject is the Schema for the atlasprojects API
 type AtlasProject struct {

--- a/pkg/api/v1/atlassearchindexconfig_types.go
+++ b/pkg/api/v1/atlassearchindexconfig_types.go
@@ -12,10 +12,15 @@ func init() {
 	SchemeBuilder.Register(&AtlasSearchIndexConfig{}, &AtlasSearchIndexConfigList{})
 }
 
-// AtlasSearchIndexConfig is the Schema for the AtlasSearchIndexConfig API
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:resource:categories=atlas,shortName=asic
+// +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
+//
+// AtlasSearchIndexConfig is the Schema for the AtlasSearchIndexConfig API
+//
+//nolint:stylecheck
 type AtlasSearchIndexConfig struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/api/v1/atlasstreamconnection_types.go
+++ b/pkg/api/v1/atlasstreamconnection_types.go
@@ -64,6 +64,8 @@ type StreamsKafkaSecurity struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+//+kubebuilder:resource:categories=atlas,shortName=asc
+// +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
 
 // AtlasStreamConnection is the Schema for the atlasstreamconnections API
 type AtlasStreamConnection struct {

--- a/pkg/api/v1/atlasstreaminstance_types.go
+++ b/pkg/api/v1/atlasstreaminstance_types.go
@@ -39,6 +39,9 @@ type Config struct {
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
 //+kubebuilder:printcolumn:name="Name",type=string,JSONPath=`.spec.name`
+// +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
+// +kubebuilder:printcolumn:name="Atlas ID",type=string,JSONPath=`.status.id`
+// +kubebuilder:resource:categories=atlas,shortName=asi
 
 // AtlasStreamInstance is the Schema for the atlasstreaminstances API
 type AtlasStreamInstance struct {

--- a/pkg/api/v1/atlasteam_types.go
+++ b/pkg/api/v1/atlasteam_types.go
@@ -29,7 +29,10 @@ var _ api.AtlasCustomResource = &AtlasTeam{}
 
 // +kubebuilder:object:root=true
 // +kubebuilder:printcolumn:name="Name",type=string,JSONPath=`.spec.name`
+// +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
+// +kubebuilder:printcolumn:name="Atlas ID",type=string,JSONPath=`.status.id`
 // +kubebuilder:subresource:status
+// +kubebuilder:resource:categories=atlas,shortName=at
 
 // AtlasTeam is the Schema for the Atlas Teams API
 type AtlasTeam struct {


### PR DESCRIPTION
This adds a `kubectl get atlas` to be able to retrieve all atlas resources:

```
$ kubectl get atlas -A
NAMESPACE   NAME                                            AGE
ns-search   atlasdeployment.atlas.mongodb.com/search-test   9s

NAMESPACE   NAME                                        NAME
ns-search   atlasproject.atlas.mongodb.com/my-project   atlas-search-test

NAMESPACE   NAME                                                                       AGE
ns-search   atlassearchindexconfig.atlas.mongodb.com/test-search-index-config          8s
ns-search   atlassearchindexconfig.atlas.mongodb.com/test-search-index-config-simple   8s
```

Additionally, this introduces short names for our CRDs:
```
NAME                              SHORTNAMES
atlasbackuppolicies               abp
atlasbackupschedules              abs
atlasdatabaseusers                adu
atlasdatafederations              adf
atlasdeployments                  ad
atlasfederatedauths               afa
atlasprojects                     ap
atlassearchindexconfigs           asic
atlasstreamconnections            asc
atlasstreaminstances              asi
atlasteams                        at
```

This can be used as a shortcut to i.e. list all Atlas Deployments like so:
```
$ kubectl get ad -A
NAMESPACE   NAME          AGE
ns-search   search-test   52s
```
