### PR TITLE
Support empty fields for new SDK

### DIFF
--- a/internal/pointer/pointer.go
+++ b/internal/pointer/pointer.go
@@ -27,3 +27,12 @@ func GetOrDefault[T any](ptr *T, defaultValue T) T {
 func MakePtr[T any](value T) *T {
 	return &value
 }
+
+// MakePtrOrNil returns a pointer only when value is not empty.
+// Otherwise Atlas versioned API interprets a pointer to an empty value as not empty.
+func MakePtrOrNil[T comparable](value T) *T {
+	if value == *new(T) {
+		return nil
+	}
+	return &value
+}


### PR DESCRIPTION
New SDK empty fields are expected to be nullified in the JSON data. Using just `pointer.MakePtr()` will just make those fields pointers to an empty string, which the API interprets as NOT empty.

This fix has been proven necessary by PoC at #1543 to avoid such confusion with the API.

### All Submissions:

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
