### PR TITLE
CLOUDP-244166: [skunkworks] refactor backup schedules to use indexers

### DIFF
--- a/pkg/api/v1/common/common.go
+++ b/pkg/api/v1/common/common.go
@@ -34,6 +34,10 @@ type ResourceRefNamespaced struct {
 	Namespace string `json:"namespace"`
 }
 
+func (rn ResourceRefNamespaced) IsEmpty() bool {
+	return rn.Name == "" && rn.Namespace == ""
+}
+
 func (rn ResourceRefNamespaced) Key() string {
 	return rn.Name + "|" + rn.Namespace
 }

--- a/pkg/controller/atlasdeployment/backup.go
+++ b/pkg/controller/atlasdeployment/backup.go
@@ -51,7 +51,7 @@ func (r *AtlasDeploymentReconciler) ensureBackupScheduleAndPolicy(
 		r.Log.Debugf("watched backup schedule and policy resources: %v\r\n", r.DeprecatedResourceWatcher.WatchedResourcesSnapshot())
 	}()
 
-	bSchedule, err := r.ensureBackupSchedule(service, deployment, &resourcesToWatch)
+	bSchedule, err := r.ensureBackupSchedule(service, deployment)
 	if err != nil {
 		return err
 	}
@@ -67,7 +67,6 @@ func (r *AtlasDeploymentReconciler) ensureBackupScheduleAndPolicy(
 func (r *AtlasDeploymentReconciler) ensureBackupSchedule(
 	service *workflow.Context,
 	deployment *akov2.AtlasDeployment,
-	resourcesToWatch *[]watch.WatchedObject,
 ) (*akov2.AtlasBackupSchedule, error) {
 	backupScheduleRef := deployment.Spec.BackupScheduleRef.GetObject(deployment.Namespace)
 	bSchedule := &akov2.AtlasBackupSchedule{}
@@ -116,8 +115,6 @@ func (r *AtlasDeploymentReconciler) ensureBackupSchedule(
 		r.Log.Errorw("failed to update BackupSchedule object", "error", err)
 		return nil, err
 	}
-
-	*resourcesToWatch = append(*resourcesToWatch, watch.WatchedObject{ResourceKind: bSchedule.Kind, Resource: *backupScheduleRef})
 
 	return bSchedule, nil
 }

--- a/pkg/indexer/atlasbackupschedules.go
+++ b/pkg/indexer/atlasbackupschedules.go
@@ -1,0 +1,45 @@
+package indexer
+
+import (
+	"go.uber.org/zap"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	akov2 "github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/api/v1"
+)
+
+const (
+	AtlasDeploymentByBackupScheduleIndex = ".spec.backupScheduleRef"
+)
+
+type AtlasDeploymentByBackupScheduleIndexer struct {
+	logger *zap.SugaredLogger
+}
+
+func NewAtlasBackupScheduleToDeploymentIndex(logger *zap.Logger) *AtlasDeploymentByBackupScheduleIndexer {
+	return &AtlasDeploymentByBackupScheduleIndexer{
+		logger: logger.Named(AtlasDeploymentByBackupScheduleIndex).Sugar(),
+	}
+}
+
+func (*AtlasDeploymentByBackupScheduleIndexer) Object() client.Object {
+	return &akov2.AtlasDeployment{}
+}
+
+func (*AtlasDeploymentByBackupScheduleIndexer) Name() string {
+	return AtlasDeploymentByBackupScheduleIndex
+}
+
+func (a *AtlasDeploymentByBackupScheduleIndexer) Keys(object client.Object) []string {
+	deployment, ok := object.(*akov2.AtlasDeployment)
+	if !ok {
+		a.logger.Errorf("expected *akov2.AtlasDeployment but got %T", object)
+		return nil
+	}
+
+	if deployment.Spec.BackupScheduleRef.IsEmpty() {
+		return nil
+	}
+
+	return []string{deployment.Spec.BackupScheduleRef.GetObject(deployment.Namespace).String()}
+}

--- a/pkg/indexer/atlasbackupschedules_test.go
+++ b/pkg/indexer/atlasbackupschedules_test.go
@@ -1,0 +1,63 @@
+package indexer
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap/zaptest"
+
+	akov2 "github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/api/v1"
+	"github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/api/v1/common"
+)
+
+func TestAtlasDeploymentByBackupScheduleIndexer(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		object   client.Object
+		wantKeys []string
+	}{
+		{
+			name:     "should return nil on wrong type",
+			object:   &akov2.AtlasProject{},
+			wantKeys: nil,
+		},
+		{
+			name:     "should return nil when there are no references",
+			object:   &akov2.AtlasDeployment{},
+			wantKeys: nil,
+		},
+		{
+			name: "should return nil when there is an empty reference",
+			object: &akov2.AtlasDeployment{
+				Spec: akov2.AtlasDeploymentSpec{
+					BackupScheduleRef: common.ResourceRefNamespaced{},
+				},
+			},
+			wantKeys: nil,
+		},
+		{
+			name: "should return a key when there is a reference",
+			object: &akov2.AtlasDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "bar",
+				},
+				Spec: akov2.AtlasDeploymentSpec{
+					BackupScheduleRef: common.ResourceRefNamespaced{
+						Name: "baz",
+					},
+				},
+			},
+			wantKeys: []string{"bar/baz"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			indexer := NewAtlasBackupScheduleToDeploymentIndex(zaptest.NewLogger(t))
+			keys := indexer.Keys(tc.object)
+			assert.Equal(t, tc.wantKeys, keys)
+		})
+	}
+}

--- a/pkg/indexer/indexer.go
+++ b/pkg/indexer/indexer.go
@@ -24,6 +24,7 @@ func RegisterAll(ctx context.Context, mgr manager.Manager, logger *zap.Logger) e
 		NewAtlasStreamConnectionBySecretIndexer(logger),
 		NewAtlasDeploymentBySearchIndexIndexer(logger),
 		NewAtlasStreamInstanceByConnectionIndexer(logger),
+		NewAtlasBackupScheduleToDeploymentIndex(logger),
 	)
 }
 


### PR DESCRIPTION
This is a first iteration on converting existing resource watcher implementations in favour of indexers.

Here, we are converting backup schedules to trigger events on deployments via indexers rather than via the deprecated resource watcher.