### PR TITLE
CLOUDP-244166: [skunkworks] backup policies indexer

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -157,7 +157,6 @@ func main() {
 		Client:                      mgr.GetClient(),
 		Log:                         logger.Named("controllers").Named("AtlasDeployment").Sugar(),
 		Scheme:                      mgr.GetScheme(),
-		DeprecatedResourceWatcher:   watch.NewDeprecatedResourceWatcher(),
 		GlobalPredicates:            globalPredicates,
 		EventRecorder:               mgr.GetEventRecorderFor("AtlasDeployment"),
 		AtlasProvider:               atlasProvider,

--- a/pkg/controller/atlasdeployment/atlasdeployment_controller.go
+++ b/pkg/controller/atlasdeployment/atlasdeployment_controller.go
@@ -50,14 +50,12 @@ import (
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/controller/customresource"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/controller/statushandler"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/controller/validate"
-	"github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/controller/watch"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/controller/workflow"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/indexer"
 )
 
 // AtlasDeploymentReconciler reconciles an AtlasDeployment object
 type AtlasDeploymentReconciler struct {
-	watch.DeprecatedResourceWatcher
 	Client                      client.Client
 	Log                         *zap.SugaredLogger
 	Scheme                      *runtime.Scheme
@@ -117,7 +115,6 @@ func (r *AtlasDeploymentReconciler) Reconcile(context context.Context, req ctrl.
 	log.Infow("-> Starting AtlasDeployment reconciliation", "spec", deployment.Spec, "status", deployment.Status)
 	defer func() {
 		statushandler.Update(workflowCtx, r.Client, r.EventRecorder, deployment)
-		r.EnsureMultiplesResourcesAreWatched(req.NamespacedName, log, workflowCtx.ListResourcesToWatch()...)
 	}()
 
 	resourceVersionIsValid := customresource.ValidateResourceVersion(workflowCtx, deployment, r.Log)

--- a/pkg/controller/atlasdeployment/atlasdeployment_controller_test.go
+++ b/pkg/controller/atlasdeployment/atlasdeployment_controller_test.go
@@ -1151,7 +1151,7 @@ func TestFindDeploymentsForBackupPolicy(t *testing.T) {
 			testScheme := runtime.NewScheme()
 			assert.NoError(t, akov2.AddToScheme(testScheme))
 			backupScheduleIndexer := indexer.NewAtlasBackupScheduleByBackupPolicyIndexer(zaptest.NewLogger(t))
-			deploymentIndexer := indexer.NewAtlasBackupScheduleToDeploymentIndex(zaptest.NewLogger(t))
+			deploymentIndexer := indexer.NewAtlasDeploymentByBackupScheduleIndexer(zaptest.NewLogger(t))
 			k8sClient := fake.NewClientBuilder().
 				WithScheme(testScheme).
 				WithObjects(tc.initObjs...).
@@ -1217,7 +1217,7 @@ func TestFindDeploymentsForBackupSchedule(t *testing.T) {
 			testScheme := runtime.NewScheme()
 			assert.NoError(t, akov2.AddToScheme(testScheme))
 			backupScheduleIndexer := indexer.NewAtlasBackupScheduleByBackupPolicyIndexer(zaptest.NewLogger(t))
-			deploymentIndexer := indexer.NewAtlasBackupScheduleToDeploymentIndex(zaptest.NewLogger(t))
+			deploymentIndexer := indexer.NewAtlasDeploymentByBackupScheduleIndexer(zaptest.NewLogger(t))
 			k8sClient := fake.NewClientBuilder().
 				WithScheme(testScheme).
 				WithObjects(tc.initObjs...).

--- a/pkg/controller/atlasdeployment/atlasdeployment_controller_test.go
+++ b/pkg/controller/atlasdeployment/atlasdeployment_controller_test.go
@@ -54,7 +54,6 @@ import (
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/api/v1/status"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/controller/atlas"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/controller/customresource"
-	"github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/controller/watch"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/controller/workflow"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/indexer"
 )
@@ -970,7 +969,6 @@ func TestReconciliation(t *testing.T) {
 	}
 
 	reconciler := &AtlasDeploymentReconciler{
-		DeprecatedResourceWatcher:   watch.NewDeprecatedResourceWatcher(),
 		Client:                      k8sClient,
 		Log:                         logger,
 		AtlasProvider:               atlasProvider,

--- a/pkg/controller/atlasdeployment/atlasdeployment_controller_test.go
+++ b/pkg/controller/atlasdeployment/atlasdeployment_controller_test.go
@@ -21,9 +21,12 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"reflect"
 	"regexp"
 	"testing"
 	"time"
+
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -472,7 +475,7 @@ func TestCleanupBindings(t *testing.T) {
 		require.NoError(t, r.Client.Create(context.Background(), schedule))
 
 		// test ensureBackupPolicy and cleanup
-		_, err := r.ensureBackupPolicy(&workflow.Context{Context: context.Background()}, schedule, &[]watch.WatchedObject{})
+		_, err := r.ensureBackupPolicy(&workflow.Context{Context: context.Background()}, schedule)
 		require.NoError(t, err)
 		require.NoError(t, r.cleanupBindings(context.Background(), deployment))
 
@@ -509,7 +512,7 @@ func TestCleanupBindings(t *testing.T) {
 		require.NoError(t, r.Client.Create(context.Background(), schedule))
 
 		// test cleanup
-		_, err := r.ensureBackupPolicy(&workflow.Context{Context: context.Background()}, schedule, &[]watch.WatchedObject{})
+		_, err := r.ensureBackupPolicy(&workflow.Context{Context: context.Background()}, schedule)
 		require.NoError(t, err)
 		require.NoError(t, r.cleanupBindings(context.Background(), deployment))
 
@@ -554,9 +557,9 @@ func TestCleanupBindings(t *testing.T) {
 		}
 
 		// test cleanup
-		_, err := r.ensureBackupPolicy(&workflow.Context{Context: context.Background()}, schedule, &[]watch.WatchedObject{})
+		_, err := r.ensureBackupPolicy(&workflow.Context{Context: context.Background()}, schedule)
 		require.NoError(t, err)
-		_, err = r.ensureBackupPolicy(&workflow.Context{Context: context.Background()}, schedule2, &[]watch.WatchedObject{})
+		_, err = r.ensureBackupPolicy(&workflow.Context{Context: context.Background()}, schedule2)
 		require.NoError(t, err)
 		require.NoError(t, r.cleanupBindings(context.Background(), deployment))
 
@@ -1088,4 +1091,149 @@ func TestFindDeploymentsForSearchIndexConfig(t *testing.T) {
 			requests,
 		)
 	})
+}
+
+func TestFindDeploymentsForBackupPolicy(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		obj      client.Object
+		initObjs []client.Object
+		want     []reconcile.Request
+	}{
+		{
+			name: "wrong type",
+			obj:  &akov2.AtlasProject{},
+			want: nil,
+		},
+		{
+			name: "transitive dependency",
+			obj: &akov2.AtlasBackupPolicy{
+				ObjectMeta: metav1.ObjectMeta{Name: "some-policy", Namespace: "ns1"},
+			},
+			initObjs: []client.Object{
+				&akov2.AtlasBackupSchedule{
+					ObjectMeta: metav1.ObjectMeta{Name: "some-schedule", Namespace: "ns2"},
+					Spec: akov2.AtlasBackupScheduleSpec{
+						PolicyRef: common.ResourceRefNamespaced{Name: "some-policy", Namespace: "ns1"},
+					},
+				},
+				&akov2.AtlasBackupSchedule{
+					ObjectMeta: metav1.ObjectMeta{Name: "some-schedule2", Namespace: "ns2"},
+					Spec: akov2.AtlasBackupScheduleSpec{
+						PolicyRef: common.ResourceRefNamespaced{Name: "some-policy", Namespace: "ns1"},
+					},
+				},
+				&akov2.AtlasDeployment{
+					ObjectMeta: metav1.ObjectMeta{Name: "some-deployment", Namespace: "ns3"},
+					Spec: akov2.AtlasDeploymentSpec{
+						BackupScheduleRef: common.ResourceRefNamespaced{Name: "some-schedule", Namespace: "ns2"},
+					},
+				},
+				&akov2.AtlasDeployment{
+					ObjectMeta: metav1.ObjectMeta{Name: "some-deployment2", Namespace: "ns4"},
+					Spec: akov2.AtlasDeploymentSpec{
+						BackupScheduleRef: common.ResourceRefNamespaced{Name: "some-schedule", Namespace: "ns2"},
+					},
+				},
+				&akov2.AtlasDeployment{
+					ObjectMeta: metav1.ObjectMeta{Name: "some-deployment3", Namespace: "ns5"},
+					Spec: akov2.AtlasDeploymentSpec{
+						BackupScheduleRef: common.ResourceRefNamespaced{Name: "some-schedule2", Namespace: "ns2"},
+					},
+				},
+			},
+			want: []reconcile.Request{
+				{NamespacedName: types.NamespacedName{Name: "some-deployment", Namespace: "ns3"}},
+				{NamespacedName: types.NamespacedName{Name: "some-deployment2", Namespace: "ns4"}},
+				{NamespacedName: types.NamespacedName{Name: "some-deployment3", Namespace: "ns5"}},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			testScheme := runtime.NewScheme()
+			assert.NoError(t, akov2.AddToScheme(testScheme))
+			backupScheduleIndexer := indexer.NewAtlasBackupScheduleByBackupPolicyIndexer(zaptest.NewLogger(t))
+			deploymentIndexer := indexer.NewAtlasBackupScheduleToDeploymentIndex(zaptest.NewLogger(t))
+			k8sClient := fake.NewClientBuilder().
+				WithScheme(testScheme).
+				WithObjects(tc.initObjs...).
+				WithIndex(backupScheduleIndexer.Object(), backupScheduleIndexer.Name(), backupScheduleIndexer.Keys).
+				WithIndex(deploymentIndexer.Object(), deploymentIndexer.Name(), deploymentIndexer.Keys).
+				Build()
+			reconciler := &AtlasDeploymentReconciler{
+				Log:    zaptest.NewLogger(t).Sugar(),
+				Client: k8sClient,
+			}
+			got := reconciler.findDeploymentsForBackupPolicy(context.Background(), tc.obj)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("want reconcile requests: %v, got %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFindDeploymentsForBackupSchedule(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		obj      client.Object
+		initObjs []client.Object
+		want     []reconcile.Request
+	}{
+		{
+			name: "wrong type",
+			obj:  &akov2.AtlasProject{},
+			want: nil,
+		},
+		{
+			name: "transitive dependency",
+			obj: &akov2.AtlasBackupSchedule{
+				ObjectMeta: metav1.ObjectMeta{Name: "some-schedule", Namespace: "ns2"},
+			},
+			initObjs: []client.Object{
+				&akov2.AtlasDeployment{
+					ObjectMeta: metav1.ObjectMeta{Name: "some-deployment", Namespace: "ns3"},
+					Spec: akov2.AtlasDeploymentSpec{
+						BackupScheduleRef: common.ResourceRefNamespaced{Name: "some-schedule", Namespace: "ns2"},
+					},
+				},
+				&akov2.AtlasDeployment{
+					ObjectMeta: metav1.ObjectMeta{Name: "some-deployment2", Namespace: "ns4"},
+					Spec: akov2.AtlasDeploymentSpec{
+						BackupScheduleRef: common.ResourceRefNamespaced{Name: "some-schedule", Namespace: "ns2"},
+					},
+				},
+				&akov2.AtlasDeployment{
+					ObjectMeta: metav1.ObjectMeta{Name: "some-deployment3", Namespace: "ns5"},
+					Spec: akov2.AtlasDeploymentSpec{
+						BackupScheduleRef: common.ResourceRefNamespaced{Name: "some-schedule2", Namespace: "ns2"},
+					},
+				},
+			},
+			want: []reconcile.Request{
+				{NamespacedName: types.NamespacedName{Name: "some-deployment", Namespace: "ns3"}},
+				{NamespacedName: types.NamespacedName{Name: "some-deployment2", Namespace: "ns4"}},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			testScheme := runtime.NewScheme()
+			assert.NoError(t, akov2.AddToScheme(testScheme))
+			backupScheduleIndexer := indexer.NewAtlasBackupScheduleByBackupPolicyIndexer(zaptest.NewLogger(t))
+			deploymentIndexer := indexer.NewAtlasBackupScheduleToDeploymentIndex(zaptest.NewLogger(t))
+			k8sClient := fake.NewClientBuilder().
+				WithScheme(testScheme).
+				WithObjects(tc.initObjs...).
+				WithIndex(backupScheduleIndexer.Object(), backupScheduleIndexer.Name(), backupScheduleIndexer.Keys).
+				WithIndex(deploymentIndexer.Object(), deploymentIndexer.Name(), deploymentIndexer.Keys).
+				Build()
+			reconciler := &AtlasDeploymentReconciler{
+				Log:    zaptest.NewLogger(t).Sugar(),
+				Client: k8sClient,
+			}
+			got := reconciler.findDeploymentsForBackupSchedule(context.Background(), tc.obj)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("want reconcile requests: %v, got %v", got, tc.want)
+			}
+		})
+	}
 }

--- a/pkg/controller/atlasdeployment/backup.go
+++ b/pkg/controller/atlasdeployment/backup.go
@@ -56,7 +56,7 @@ func (r *AtlasDeploymentReconciler) ensureBackupScheduleAndPolicy(
 		return err
 	}
 
-	bPolicy, err := r.ensureBackupPolicy(service, bSchedule, &resourcesToWatch)
+	bPolicy, err := r.ensureBackupPolicy(service, bSchedule)
 	if err != nil {
 		return err
 	}
@@ -119,11 +119,7 @@ func (r *AtlasDeploymentReconciler) ensureBackupSchedule(
 	return bSchedule, nil
 }
 
-func (r *AtlasDeploymentReconciler) ensureBackupPolicy(
-	service *workflow.Context,
-	bSchedule *akov2.AtlasBackupSchedule,
-	resourcesToWatch *[]watch.WatchedObject,
-) (*akov2.AtlasBackupPolicy, error) {
+func (r *AtlasDeploymentReconciler) ensureBackupPolicy(service *workflow.Context, bSchedule *akov2.AtlasBackupSchedule) (*akov2.AtlasBackupPolicy, error) {
 	bPolicyRef := *bSchedule.Spec.PolicyRef.GetObject(bSchedule.Namespace)
 	bPolicy := &akov2.AtlasBackupPolicy{}
 	err := r.Client.Get(service.Context, bPolicyRef, bPolicy)
@@ -168,8 +164,6 @@ func (r *AtlasDeploymentReconciler) ensureBackupPolicy(
 		r.Log.Errorw("failed to update BackupPolicy object", "error", err)
 		return nil, err
 	}
-
-	*resourcesToWatch = append(*resourcesToWatch, watch.WatchedObject{ResourceKind: bPolicy.Kind, Resource: bPolicyRef})
 
 	return bPolicy, nil
 }

--- a/pkg/controller/atlasdeployment/backup.go
+++ b/pkg/controller/atlasdeployment/backup.go
@@ -14,7 +14,6 @@ import (
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/kube"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/api/v1/status"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/controller/customresource"
-	"github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/controller/watch"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/controller/workflow"
 
 	"go.mongodb.org/atlas/mongodbatlas"
@@ -44,12 +43,6 @@ func (r *AtlasDeploymentReconciler) ensureBackupScheduleAndPolicy(
 	if !isEnabled {
 		return fmt.Errorf("can not proceed with backup configuration. Backups are not enabled for cluster %s", deployment.GetDeploymentName())
 	}
-
-	resourcesToWatch := []watch.WatchedObject{}
-	defer func() {
-		service.AddResourcesToWatch(resourcesToWatch...)
-		r.Log.Debugf("watched backup schedule and policy resources: %v\r\n", r.DeprecatedResourceWatcher.WatchedResourcesSnapshot())
-	}()
 
 	bSchedule, err := r.ensureBackupSchedule(service, deployment)
 	if err != nil {

--- a/pkg/indexer/atlasbackuppolicies.go
+++ b/pkg/indexer/atlasbackuppolicies.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	AtlasBackupScheduleByBackupPolicyIndex = "spec.policyRef"
+	AtlasBackupScheduleByBackupPolicyIndex = "atlasbackupschedule.spec.policyRef"
 )
 
 type AtlasBackupScheduleByBackupPolicyIndexer struct {

--- a/pkg/indexer/atlasbackuppolicies.go
+++ b/pkg/indexer/atlasbackuppolicies.go
@@ -1,3 +1,4 @@
+//nolint:dupl
 package indexer
 
 import (

--- a/pkg/indexer/atlasbackuppolicies.go
+++ b/pkg/indexer/atlasbackuppolicies.go
@@ -1,0 +1,43 @@
+package indexer
+
+import (
+	akov2 "github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/api/v1"
+	"go.uber.org/zap"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	AtlasBackupScheduleByBackupPolicyIndex = "spec.policyRef"
+)
+
+type AtlasBackupScheduleByBackupPolicyIndexer struct {
+	logger *zap.SugaredLogger
+}
+
+func NewAtlasBackupScheduleByBackupPolicyIndexer(logger *zap.Logger) *AtlasBackupScheduleByBackupPolicyIndexer {
+	return &AtlasBackupScheduleByBackupPolicyIndexer{
+		logger: logger.Named(AtlasBackupScheduleByBackupPolicyIndex).Sugar(),
+	}
+}
+
+func (*AtlasBackupScheduleByBackupPolicyIndexer) Object() client.Object {
+	return &akov2.AtlasBackupSchedule{}
+}
+
+func (*AtlasBackupScheduleByBackupPolicyIndexer) Name() string {
+	return AtlasBackupScheduleByBackupPolicyIndex
+}
+
+func (a *AtlasBackupScheduleByBackupPolicyIndexer) Keys(object client.Object) []string {
+	schedule, ok := object.(*akov2.AtlasBackupSchedule)
+	if !ok {
+		a.logger.Errorf("expected *akov2.AtlasBackupSchedule but got %T", object)
+		return nil
+	}
+
+	if schedule.Spec.PolicyRef.IsEmpty() {
+		return nil
+	}
+
+	return []string{schedule.Spec.PolicyRef.GetObject(schedule.Namespace).String()}
+}

--- a/pkg/indexer/atlasbackuppolicies.go
+++ b/pkg/indexer/atlasbackuppolicies.go
@@ -1,9 +1,10 @@
 package indexer
 
 import (
-	akov2 "github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/api/v1"
 	"go.uber.org/zap"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	akov2 "github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/api/v1"
 )
 
 const (

--- a/pkg/indexer/atlasbackuppolicies_test.go
+++ b/pkg/indexer/atlasbackuppolicies_test.go
@@ -1,0 +1,62 @@
+package indexer
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	akov2 "github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/api/v1"
+	"github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/api/v1/common"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap/zaptest"
+)
+
+func TestAtlasBackupScheduleByBackupPolicyIndexer(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		object   client.Object
+		wantKeys []string
+	}{
+		{
+			name:     "should return nil on wrong type",
+			object:   &akov2.AtlasProject{},
+			wantKeys: nil,
+		},
+		{
+			name:     "should return nil when there are no references",
+			object:   &akov2.AtlasBackupSchedule{},
+			wantKeys: nil,
+		},
+		{
+			name: "should return nil when there is an empty reference",
+			object: &akov2.AtlasBackupSchedule{
+				Spec: akov2.AtlasBackupScheduleSpec{
+					PolicyRef: common.ResourceRefNamespaced{},
+				},
+			},
+			wantKeys: nil,
+		},
+		{
+			name: "should return a key when there is a reference",
+			object: &akov2.AtlasBackupSchedule{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "bar",
+				},
+				Spec: akov2.AtlasBackupScheduleSpec{
+					PolicyRef: common.ResourceRefNamespaced{
+						Name: "baz",
+					},
+				},
+			},
+			wantKeys: []string{"bar/baz"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			indexer := NewAtlasBackupScheduleByBackupPolicyIndexer(zaptest.NewLogger(t))
+			keys := indexer.Keys(tc.object)
+			assert.Equal(t, tc.wantKeys, keys)
+		})
+	}
+}

--- a/pkg/indexer/atlasbackuppolicies_test.go
+++ b/pkg/indexer/atlasbackuppolicies_test.go
@@ -1,3 +1,4 @@
+//nolint:dupl
 package indexer
 
 import (

--- a/pkg/indexer/atlasbackuppolicies_test.go
+++ b/pkg/indexer/atlasbackuppolicies_test.go
@@ -3,13 +3,13 @@ package indexer
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap/zaptest"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	akov2 "github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/api/v1"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/api/v1/common"
-	"github.com/stretchr/testify/assert"
-	"go.uber.org/zap/zaptest"
 )
 
 func TestAtlasBackupScheduleByBackupPolicyIndexer(t *testing.T) {

--- a/pkg/indexer/atlasbackupschedules.go
+++ b/pkg/indexer/atlasbackupschedules.go
@@ -1,3 +1,4 @@
+//nolint:dupl
 package indexer
 
 import (

--- a/pkg/indexer/atlasbackupschedules.go
+++ b/pkg/indexer/atlasbackupschedules.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	AtlasDeploymentByBackupScheduleIndex = ".spec.backupScheduleRef"
+	AtlasDeploymentByBackupScheduleIndex = "atlasdeployment.spec.backupScheduleRef"
 )
 
 type AtlasDeploymentByBackupScheduleIndexer struct {

--- a/pkg/indexer/atlasbackupschedules.go
+++ b/pkg/indexer/atlasbackupschedules.go
@@ -16,7 +16,7 @@ type AtlasDeploymentByBackupScheduleIndexer struct {
 	logger *zap.SugaredLogger
 }
 
-func NewAtlasBackupScheduleToDeploymentIndex(logger *zap.Logger) *AtlasDeploymentByBackupScheduleIndexer {
+func NewAtlasDeploymentByBackupScheduleIndexer(logger *zap.Logger) *AtlasDeploymentByBackupScheduleIndexer {
 	return &AtlasDeploymentByBackupScheduleIndexer{
 		logger: logger.Named(AtlasDeploymentByBackupScheduleIndex).Sugar(),
 	}

--- a/pkg/indexer/atlasbackupschedules_test.go
+++ b/pkg/indexer/atlasbackupschedules_test.go
@@ -1,13 +1,13 @@
+//nolint:dupl
 package indexer
 
 import (
 	"testing"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap/zaptest"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	akov2 "github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/api/v1"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/api/v1/common"

--- a/pkg/indexer/atlasbackupschedules_test.go
+++ b/pkg/indexer/atlasbackupschedules_test.go
@@ -55,7 +55,7 @@ func TestAtlasDeploymentByBackupScheduleIndexer(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			indexer := NewAtlasBackupScheduleToDeploymentIndex(zaptest.NewLogger(t))
+			indexer := NewAtlasDeploymentByBackupScheduleIndexer(zaptest.NewLogger(t))
 			keys := indexer.Keys(tc.object)
 			assert.Equal(t, tc.wantKeys, keys)
 		})

--- a/pkg/indexer/atlassearchindexconfigs.go
+++ b/pkg/indexer/atlassearchindexconfigs.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	AtlasDeploymentBySearchIndexIndex = ".spec.deploymentSpec.searchIndexes"
+	AtlasDeploymentBySearchIndexIndex = "atlasdeployment.spec.deploymentSpec.searchIndexes"
 )
 
 type AtlasDeploymentBySearchIndexIndexer struct {

--- a/pkg/indexer/atlasstreamconnections.go
+++ b/pkg/indexer/atlasstreamconnections.go
@@ -8,7 +8,7 @@ import (
 )
 
 // nolint:gosec,stylecheck
-const AtlasStreamConnectionBySecretIndex = ".spec.kafkaConfig"
+const AtlasStreamConnectionBySecretIndex = "atlasstreamconnection.spec.kafkaConfig"
 
 type AtlasStreamConnectionBySecretIndexer struct {
 	logger *zap.SugaredLogger

--- a/pkg/indexer/atlasstreaminstances.go
+++ b/pkg/indexer/atlasstreaminstances.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	AtlasStreamInstanceByConnectionIndex = ".spec.connectionRegistry"
+	AtlasStreamInstanceByConnectionIndex = "atlasstreaminstance.spec.connectionRegistry"
 )
 
 type AtlasStreamInstanceByConnectionIndexer struct {

--- a/pkg/indexer/indexer.go
+++ b/pkg/indexer/indexer.go
@@ -25,6 +25,7 @@ func RegisterAll(ctx context.Context, mgr manager.Manager, logger *zap.Logger) e
 		NewAtlasDeploymentBySearchIndexIndexer(logger),
 		NewAtlasStreamInstanceByConnectionIndexer(logger),
 		NewAtlasBackupScheduleToDeploymentIndex(logger),
+		NewAtlasBackupScheduleByBackupPolicyIndexer(logger),
 	)
 }
 

--- a/pkg/indexer/indexer.go
+++ b/pkg/indexer/indexer.go
@@ -21,11 +21,11 @@ type Indexer interface {
 func RegisterAll(ctx context.Context, mgr manager.Manager, logger *zap.Logger) error {
 	logger = logger.Named("indexer")
 	return Register(ctx, mgr,
-		NewAtlasStreamConnectionBySecretIndexer(logger),
-		NewAtlasDeploymentBySearchIndexIndexer(logger),
-		NewAtlasStreamInstanceByConnectionIndexer(logger),
-		NewAtlasBackupScheduleToDeploymentIndex(logger),
 		NewAtlasBackupScheduleByBackupPolicyIndexer(logger),
+		NewAtlasDeploymentByBackupScheduleIndexer(logger),
+		NewAtlasDeploymentBySearchIndexIndexer(logger),
+		NewAtlasStreamConnectionBySecretIndexer(logger),
+		NewAtlasStreamInstanceByConnectionIndexer(logger),
 	)
 }
 

--- a/test/helper/e2e/k8s/operator.go
+++ b/test/helper/e2e/k8s/operator.go
@@ -121,7 +121,6 @@ func BuildManager(initCfg *Config) (manager.Manager, error) {
 		Client:                      mgr.GetClient(),
 		Log:                         logger.Named("controllers").Named("AtlasDeployment").Sugar(),
 		Scheme:                      mgr.GetScheme(),
-		DeprecatedResourceWatcher:   watch.NewDeprecatedResourceWatcher(),
 		GlobalPredicates:            globalPredicates,
 		EventRecorder:               mgr.GetEventRecorderFor("AtlasDeployment"),
 		AtlasProvider:               atlasProvider,

--- a/test/int/clusterwide/integration_suite_test.go
+++ b/test/int/clusterwide/integration_suite_test.go
@@ -155,12 +155,11 @@ var _ = BeforeSuite(func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		err = (&atlasdeployment.AtlasDeploymentReconciler{
-			Client:                    k8sManager.GetClient(),
-			Log:                       logger.Named("controllers").Named("AtlasDeployment").Sugar(),
-			DeprecatedResourceWatcher: watch.NewDeprecatedResourceWatcher(),
-			EventRecorder:             k8sManager.GetEventRecorderFor("AtlasDeployment"),
-			AtlasProvider:             atlasProvider,
-			GlobalPredicates:          globalPredicates,
+			Client:           k8sManager.GetClient(),
+			Log:              logger.Named("controllers").Named("AtlasDeployment").Sugar(),
+			EventRecorder:    k8sManager.GetEventRecorderFor("AtlasDeployment"),
+			AtlasProvider:    atlasProvider,
+			GlobalPredicates: globalPredicates,
 		}).SetupWithManager(k8sManager)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/test/int/integration_suite_test.go
+++ b/test/int/integration_suite_test.go
@@ -250,7 +250,6 @@ func prepareControllers(deletionProtection bool) (*corev1.Namespace, context.Can
 	err = (&atlasdeployment.AtlasDeploymentReconciler{
 		Client:                      k8sManager.GetClient(),
 		Log:                         logger.Named("controllers").Named("AtlasDeployment").Sugar(),
-		DeprecatedResourceWatcher:   watch.NewDeprecatedResourceWatcher(),
 		GlobalPredicates:            globalPredicates,
 		EventRecorder:               k8sManager.GetEventRecorderFor("AtlasDeployment"),
 		AtlasProvider:               atlasProvider,


### PR DESCRIPTION
This completely removes the resource watcher from the deployment controller.

### All Submissions:

* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if there is one).
* [ ] Update docs/release-notes/release-notes-template.md if your changes should be included in the release notes for the next release.
