### PR TITLE
CLOUDP-246312: [skunkworks] remove MarkReconciliationStarted

### DIFF
--- a/pkg/api/v1/atlascustomresource.go
+++ b/pkg/api/v1/atlascustomresource.go
@@ -30,12 +30,7 @@ var _ AtlasCustomResource = &AtlasStreamConnection{}
 var _ AtlasCustomResource = &AtlasSearchIndexConfig{}
 var _ AtlasCustomResource = &AtlasBackupCompliancePolicy{}
 
-// InitCondition initializes the underlying type of the given condition to the given default value
-// if the underlying condition type is unset.
+// InitCondition initializes the underlying type of the given condition to the given default value.
 func InitCondition(resource AtlasCustomResource, defaultCondition api.Condition) []api.Condition {
-	conditions := resource.GetStatus().GetConditions()
-	if !api.HasConditionType(defaultCondition.Type, conditions) {
-		return api.EnsureConditionExists(defaultCondition, conditions)
-	}
-	return conditions
+	return api.EnsureConditionExists(defaultCondition, resource.GetStatus().GetConditions())
 }

--- a/pkg/api/v1/atlascustomresource_test.go
+++ b/pkg/api/v1/atlascustomresource_test.go
@@ -52,7 +52,7 @@ func TestInitCondition(t *testing.T) {
 		want             []api.Condition
 	}{
 		{
-			name: "keep condition",
+			name: "do not keep condition",
 			resource: &resource{
 				conditions: []api.Condition{
 					{Type: api.ReadyType, Status: corev1.ConditionTrue, Message: "untouched"},
@@ -60,7 +60,7 @@ func TestInitCondition(t *testing.T) {
 			},
 			defaultCondition: api.Condition{Type: api.ReadyType, Status: corev1.ConditionFalse, Message: "default"},
 			want: []api.Condition{
-				{Type: api.ReadyType, Status: corev1.ConditionTrue, Message: "untouched"},
+				{Type: api.ReadyType, Status: corev1.ConditionFalse, Message: "default"},
 			},
 		},
 		{

--- a/pkg/controller/atlasdatabaseuser/atlasdatabaseuser_controller.go
+++ b/pkg/controller/atlasdatabaseuser/atlasdatabaseuser_controller.go
@@ -85,7 +85,8 @@ func (r *AtlasDatabaseUserReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		return workflow.OK().ReconcileResult(), nil
 	}
 
-	workflowCtx := customresource.MarkReconciliationStarted(r.Client, databaseUser, log, ctx)
+	conditions := akov2.InitCondition(databaseUser, api.FalseCondition(api.ReadyType))
+	workflowCtx := workflow.NewContext(log, conditions, ctx)
 	log.Infow("-> Starting AtlasDatabaseUser reconciliation", "spec", databaseUser.Spec, "status", databaseUser.Status)
 	if databaseUser.Spec.PasswordSecret != nil {
 		workflowCtx.AddResourcesToWatch(watch.WatchedObject{ResourceKind: "Secret", Resource: *databaseUser.PasswordSecretObjectKey()})

--- a/pkg/controller/atlasdatafederation/datafederation_controller.go
+++ b/pkg/controller/atlasdatafederation/datafederation_controller.go
@@ -74,7 +74,8 @@ func (r *AtlasDataFederationReconciler) Reconcile(context context.Context, req c
 		return workflow.OK().ReconcileResult(), nil
 	}
 
-	ctx := customresource.MarkReconciliationStarted(r.Client, dataFederation, log, context)
+	conditions := akov2.InitCondition(dataFederation, api.FalseCondition(api.ReadyType))
+	ctx := workflow.NewContext(log, conditions, context)
 	log.Infow("-> Starting AtlasDataFederation reconciliation", "spec", dataFederation.Spec, "status", dataFederation.Status)
 	defer statushandler.Update(ctx, r.Client, r.EventRecorder, dataFederation)
 

--- a/pkg/controller/atlasdeployment/atlasdeployment_controller.go
+++ b/pkg/controller/atlasdeployment/atlasdeployment_controller.go
@@ -111,7 +111,8 @@ func (r *AtlasDeploymentReconciler) Reconcile(context context.Context, req ctrl.
 		return workflow.OK().ReconcileResult(), nil
 	}
 
-	workflowCtx := customresource.MarkReconciliationStarted(r.Client, deployment, log, context)
+	conditions := akov2.InitCondition(deployment, api.FalseCondition(api.ReadyType))
+	workflowCtx := workflow.NewContext(log, conditions, context)
 	log.Infow("-> Starting AtlasDeployment reconciliation", "spec", deployment.Spec, "status", deployment.Status)
 	defer func() {
 		statushandler.Update(workflowCtx, r.Client, r.EventRecorder, deployment)

--- a/pkg/controller/atlasdeployment/atlasdeployment_controller_test.go
+++ b/pkg/controller/atlasdeployment/atlasdeployment_controller_test.go
@@ -48,6 +48,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/kube"
 	atlasmock "github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/mocks/atlas"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/pointer"
+	"github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/api"
 	akov2 "github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/api/v1"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/api/v1/common"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/api/v1/status"
@@ -456,7 +457,8 @@ func newTestDeploymentEnv(t *testing.T,
 	r := testDeploymentReconciler(logger, k8sclient, protected)
 
 	prevResult := testPrevResult()
-	workflowCtx := customresource.MarkReconciliationStarted(r.Client, deployment, logger, context.Background())
+	conditions := akov2.InitCondition(deployment, api.FalseCondition(api.ReadyType))
+	workflowCtx := workflow.NewContext(logger, conditions, context.Background())
 	workflowCtx.Client = atlasClient
 	return &testDeploymentEnv{
 		reconciler:  r,

--- a/pkg/controller/atlasfederatedauth/atlasfederated_auth_controller.go
+++ b/pkg/controller/atlasfederatedauth/atlasfederated_auth_controller.go
@@ -65,7 +65,8 @@ func (r *AtlasFederatedAuthReconciler) Reconcile(ctx context.Context, req ctrl.R
 		return workflow.OK().ReconcileResult(), nil
 	}
 
-	workflowCtx := customresource.MarkReconciliationStarted(r.Client, fedauth, log, ctx)
+	conditions := akov2.InitCondition(fedauth, api.FalseCondition(api.ReadyType))
+	workflowCtx := workflow.NewContext(log, conditions, ctx)
 	log.Infow("-> Starting AtlasFederatedAuth reconciliation")
 
 	defer statushandler.Update(workflowCtx, r.Client, r.EventRecorder, fedauth)

--- a/pkg/controller/atlasproject/atlasproject_controller.go
+++ b/pkg/controller/atlasproject/atlasproject_controller.go
@@ -103,7 +103,8 @@ func (r *AtlasProjectReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return workflow.OK().ReconcileResult(), nil
 	}
 
-	workflowCtx := customresource.MarkReconciliationStarted(r.Client, project, log, ctx)
+	conditions := akov2.InitCondition(project, api.FalseCondition(api.ReadyType))
+	workflowCtx := workflow.NewContext(log, conditions, ctx)
 	log.Infow("-> Starting AtlasProject reconciliation", "spec", project.Spec)
 
 	if project.ConnectionSecretObjectKey() != nil {

--- a/pkg/controller/atlasproject/team_reconciler.go
+++ b/pkg/controller/atlasproject/team_reconciler.go
@@ -40,7 +40,8 @@ func (r *AtlasProjectReconciler) teamReconcile(
 			return workflow.OK().ReconcileResult(), nil
 		}
 
-		teamCtx := customresource.MarkReconciliationStarted(r.Client, team, log, ctx)
+		conditions := akov2.InitCondition(team, api.FalseCondition(api.ReadyType))
+		teamCtx := workflow.NewContext(log, conditions, ctx)
 		log.Infow("-> Starting AtlasTeam reconciliation", "spec", team.Spec)
 		defer statushandler.Update(teamCtx, r.Client, r.EventRecorder, team)
 

--- a/pkg/controller/atlasproject/teams.go
+++ b/pkg/controller/atlasproject/teams.go
@@ -10,7 +10,6 @@ import (
 	akov2 "github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/api/v1"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/api/v1/common"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/api/v1/status"
-	"github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/controller/customresource"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/controller/statushandler"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/controller/watch"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/controller/workflow"
@@ -198,7 +197,8 @@ func (r *AtlasProjectReconciler) updateTeamState(ctx *workflow.Context, project 
 	}
 
 	log := r.Log.With("atlasteam", teamRef)
-	teamCtx := customresource.MarkReconciliationStarted(r.Client, team, log, ctx.Context)
+	conditions := akov2.InitCondition(team, api.FalseCondition(api.ReadyType))
+	teamCtx := workflow.NewContext(log, conditions, ctx.Context)
 
 	atlasClient, orgID, err := r.AtlasProvider.Client(teamCtx.Context, project.ConnectionSecretObjectKey(), log)
 	if err != nil {

--- a/pkg/controller/customresource/customresource.go
+++ b/pkg/controller/customresource/customresource.go
@@ -12,7 +12,7 @@ import (
 	"github.com/Masterminds/semver"
 
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/api"
-	"github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/controller/statushandler"
+	akov2 "github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/api/v1"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/controller/workflow"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/version"
 )
@@ -71,18 +71,7 @@ func ValidateResourceVersion(ctx *workflow.Context, resource api.AtlasCustomReso
 	return workflow.OK()
 }
 
-// MarkReconciliationStarted updates the status of the Atlas Resource to indicate that the Operator has started working on it.
-// Internally this will also update the 'observedGeneration' field that notify clients that the resource is being worked on
-func MarkReconciliationStarted(client client.Client, resource api.AtlasCustomResource, log *zap.SugaredLogger, context context.Context) *workflow.Context {
-	updatedConditions := api.EnsureConditionExists(api.FalseCondition(api.ReadyType), resource.GetStatus().GetConditions())
-
-	ctx := workflow.NewContext(log, updatedConditions, context)
-	statushandler.Update(ctx, client, nil, resource)
-
-	return ctx
-}
-
-func IsResourcePolicyKeepOrDefault(resource api.AtlasCustomResource, protectionFlag bool) bool {
+func IsResourcePolicyKeepOrDefault(resource akov2.AtlasCustomResource, protectionFlag bool) bool {
 	if policy, ok := resource.GetAnnotations()[ResourcePolicyAnnotation]; ok {
 		return policy == ResourcePolicyKeep
 	}


### PR DESCRIPTION
`MarkReconciliationStarted` is broken because it executes an update on conditions, setting `Ready=False` at the start of each reconciliation method. At the end of each reconcile method, `Get` and subsequent `Update` can cause an endless loop if local informer caches don't keep up. 

This fixes it by replacing it with an `InitCondition` method which initialises `Ready=False` on the in-memory reconciled object only, leaving persisting the final status update in place.

### All Submissions:

* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if there is one).
* [ ] Update docs/release-notes/release-notes-template.md if your changes should be included in the release notes for the next release.
