### PR TITLE
CLOUDP-244907: Fix e2e signal handler sharing

### DIFF
--- a/test/helper/e2e/k8s/operator.go
+++ b/test/helper/e2e/k8s/operator.go
@@ -43,7 +43,10 @@ import (
 
 var setupSignalHandlerOnce sync.Once
 
-var signalCancelledCtx context.Context
+var (
+  setupSignalHandlerOnce sync.Once
+  signalCancelledCtx context.Context
+)
 
 func BuildManager(initCfg *Config) (manager.Manager, error) {
 	scheme := runtime.NewScheme()

--- a/test/helper/e2e/k8s/operator.go
+++ b/test/helper/e2e/k8s/operator.go
@@ -41,11 +41,9 @@ import (
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/indexer"
 )
 
-var setupSignalHandlerOnce sync.Once
-
 var (
-  setupSignalHandlerOnce sync.Once
-  signalCancelledCtx context.Context
+	setupSignalHandlerOnce sync.Once
+	signalCancelledCtx     context.Context
 )
 
 func BuildManager(initCfg *Config) (manager.Manager, error) {


### PR DESCRIPTION
Most `e2e` tests configure one manager instance per test table case. There is no clean up between tests and, even if there was, that would be problematic with concurrent execution.

But the end of the matter is that `SetupSignalHandler` is designed to be called only once per binary:

```go
func SetupSignalHandler() context.Context {
	close(onlyOneSignalHandler) // panics when called twice
```

So this change fixes some locally reproduced panics with the `alert_config_test.go`.

The fix is basically ensure all manager will share the same context source for canceling.

Related to CLOUDP-244907

---
### All Submissions:

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
