### PR TITLE
[DO NOT MERGE] Translation Layer Template

### DIFF
--- a/internal/translation/resource/fake/fake.go
+++ b/internal/translation/resource/fake/fake.go
@@ -1,0 +1,42 @@
+package fake
+
+import (
+	"context"
+
+	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/translation/resource"
+)
+
+type FakeResource struct {
+	GetResourceFn    func(ctx context.Context, id string) (*resource.Resource, error)
+	CreateResourceFn func(ctx context.Context, resource *resource.Resource) (*resource.Resource, error)
+	DeleteResourceFn func(ctx context.Context, id string) error
+	UpdateResourceFn func(ctx context.Context, resource *resource.Resource) (*resource.Resource, error)
+}
+
+func (frs *FakeResource) GetIndex(ctx context.Context, id string) (*resource.Resource, error) {
+	if frs.GetResourceFn == nil {
+		panic("unimplemented")
+	}
+	return frs.GetResourceFn(ctx, id)
+}
+
+func (frs *FakeResource) CreateIndex(ctx context.Context, resource *resource.Resource) (*resource.Resource, error) {
+	if frs.CreateResourceFn == nil {
+		panic("unimplemented")
+	}
+	return frs.CreateResourceFn(ctx, resource)
+}
+
+func (frs *FakeResource) DeleteIndex(ctx context.Context, id string) error {
+	if frs.DeleteResourceFn == nil {
+		panic("unimplemented")
+	}
+	return frs.DeleteResourceFn(ctx, id)
+}
+
+func (frs *FakeResource) UpdateIndex(ctx context.Context, resource *resource.Resource) (*resource.Resource, error) {
+	if frs.UpdateResourceFn == nil {
+		panic("unimplemented")
+	}
+	return frs.UpdateResourceFn(ctx, resource)
+}

--- a/internal/translation/resource/resource.go
+++ b/internal/translation/resource/resource.go
@@ -1,0 +1,52 @@
+// Package resource contains internal type for the Atlas Resource
+package resource
+
+// Resource is the internal representation of the Atlas Resource managed here
+type Resource struct {
+	// TODO: (DELETE ME) replace with the actual CRD struct and extra fields
+	// akov2.AtlasResource
+	// Some extra fields, like projectID or secrets,
+	// anything needed but not directly attached in the CRD
+}
+
+// GetID sample
+// TODO: (DELETE ME) replace with the actual CRD struct and extra fields
+func (s *Resource) GetID() string {
+	//return pointer.GetOrDefault(s.ID, "")
+	panic("unimplemented")
+}
+
+// NewResource creates an internal type from the CRD struct and fields
+func NewResource( /* resource *akov2.Resource, ...*/ ) *Resource {
+	return &Resource{
+		// AtlasResource:                resource,
+		// ...
+	}
+}
+
+// fromAtlas is an internal conversion function from atlas to internal type
+func fromAtlas( /*resource admin.Resource*/ ) (*Resource, error) {
+	/*
+		...
+		return &Resource{
+			// ...
+		}, errors.Join(errs...)
+	*/
+	panic("unimplemented")
+}
+
+// Normalize prepares Resource for internal type  comparisons to work flawlessly
+func (s *Resource) Normalize() (*Resource, error) {
+	panic("unimplemented")
+}
+
+// toAtlas is an internal conversion to get the atlas type equivalent value
+func (s *Resource) toAtlas() /* *admin.Resource, */ error {
+	/*
+		...
+		return &admin.Resource{
+			// ...
+		}, errors.Join(errs...)
+	*/
+	panic("unimplemented")
+}

--- a/internal/translation/resource/resource_test.go
+++ b/internal/translation/resource/resource_test.go
@@ -1,0 +1,17 @@
+// package for unit testing test conversions
+package resource
+
+// TODO: (DELETE ME) this can be "package resource_test" for testing only public facing
+// functions or conversions such as Normalize, NewResource, etc
+// To test internals "package resource" is required
+
+// TODO: (DELETE ME) NOTE contract test do NOT go here, they have their own
+// folder and test from outside the package
+
+import (
+	"testing"
+)
+
+func TestNewResource(t *testing.T) {
+	// ...
+}

--- a/internal/translation/resource/resourcesvc.go
+++ b/internal/translation/resource/resourcesvc.go
@@ -1,0 +1,138 @@
+package resource
+
+import (
+	"context"
+
+	"go.uber.org/zap"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/translation"
+	"github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/controller/atlas"
+)
+
+// TODO: (DELETE ME) Add here any errors that need to be identified by consumers of this layer
+var (
+// // ErrNotFound means an resource is missing
+// ErrNotFound = fmt.Errorf("not found")
+)
+
+// ResourceService is the interface that consumers use and can mock
+type ResourceService interface {
+	// TODO: (DELETE ME) this are all fake, actual interface might ot be a clear CRUD like this
+	GetResource(ctx context.Context, id string) (*Resource, error)
+	CreateResource(ctx context.Context, resource *Resource) (*Resource, error)
+	DeleteResource(ctx context.Context, id string) error
+	UpdateResource(ctx context.Context, resource *Resource) (*Resource, error)
+}
+
+// ProductionResources is the production implementation for the above ResourceService
+type ProductionResources struct {
+	// Wraps an SDK interface (DO NOT EMBED)
+	// Eg:
+	// resourceAPI admin.AtlasResourceApi
+}
+
+func NewAtlasDatabaseUsersService(ctx context.Context, provider atlas.Provider, secretRef *types.NamespacedName, log *zap.SugaredLogger) (*ProductionResources, error) {
+	/*client*/ _, err := translation.NewVersionedClient(ctx, provider, secretRef, log)
+	if err != nil {
+		return nil, err
+	}
+	return NewProductionResources( /*client.AtlasResourceApi*/ ), nil
+}
+
+func NewProductionResources( /*api admin.AtlasResourceApi*/ ) *ProductionResources {
+	return &ProductionResources{ /*resourceAPI: api*/ }
+}
+
+func (r *ProductionResources) GetResource(ctx context.Context, id string) (*Resource, error) {
+	// 1. Call API
+	// resp, httpResp, err := si.resourceAPI.GetAtlasResource(ctx, id).Execute()
+
+	// 2. Convert Error as needed
+	/*
+		if err != nil {
+			if httpResp.StatusCode == http.StatusNotFound {
+				return nil, errors.Join(err, ErrNotFound)
+			}
+			return nil, err
+		}
+	*/
+
+	// 3. Convert the reply from Atlas (convert error as needed) & return
+	/*stateInAtlas*/
+	_, _ = fromAtlas( /* *resp */ )
+	/*
+		if err != nil {
+			return nil, err
+		}
+		return stateInAtlas, nil
+	*/
+	panic("unimplemented")
+}
+
+func (r *ProductionResources) CreateResource(ctx context.Context, resource *Resource) (*Resource, error) {
+	// 1. Convert to Atlas
+	/*atlasResource*/
+	_ = resource.toAtlas()
+	// 2. Call API
+	//resp, httpResp, err := si.resourceAPI.CreateResource(ctx, atlasResource).Execute()
+	// 3. Convert Error as needed
+	/*
+		if err != nil {
+			...
+			return nil, err
+		}
+	*/
+	// 4. Convert the reply from Atlas (convert error as needed) & return
+	/*
+		akoResource, err := fromAtlas(*resp)
+		if err != nil {
+			...
+			return nil, err
+		}
+		return akoResource, nil
+	*/
+	panic("unimplemented")
+}
+
+func (r *ProductionResources) DeleteResource(ctx context.Context, id string) error {
+	// 1. Call API
+	// _, resp, err := si.resourceAPI.DeleteResource(ctx, id).Execute()
+	// 2. Convert Error as needed
+	/*
+		if err != nil {
+			...
+			return err
+		}
+		return nil
+	*/
+	panic("unimplemented")
+}
+
+func (r *ProductionResources) UpdateResource(ctx context.Context, resource *Resource) (*Resource, error) {
+	// TODO: (DELETE ME) Update tends to be almost just like create
+	// 1. Convert to Atlas
+	/*atlasResource, err := resource.toAtlas()
+	if err != nil {
+		return nil, err
+	}*/
+	// 2. Call API
+	// resp, httpResp, err := si.resourceAPI.UpdateResource(ctx, atlasResource).Execute()
+	// 3. Convert Error as needed
+	/*
+		if err != nil {
+			...
+			return nil, err
+		}
+	*/
+	// 4. Convert the reply from Atlas (convert error as needed) & return
+	/*
+		akoResource, err := fromAtlas(*resp)
+		if err != nil {
+			...
+			return nil, err
+		}
+		return akoResource, nil
+	*/
+	panic("unimplemented")
+}

--- a/test/contract/resource/resource_test.go
+++ b/test/contract/resource/resource_test.go
@@ -1,0 +1,49 @@
+package auditing
+
+import (
+	"context"
+	_ "embed"
+	"log"
+	"testing"
+	"time"
+
+	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/translation/resource"
+	"github.com/mongodb/mongodb-atlas-kubernetes/v2/test/helper/control"
+	"github.com/mongodb/mongodb-atlas-kubernetes/v2/test/helper/launcher" // TODO: (DELETE ME) Launcher should be in place soon, before the template is used
+
+	"github.com/stretchr/testify/assert"
+)
+
+//go:embed test.yml
+var testYml string
+
+const (
+	testVersion = "2.1.0"
+)
+
+// TestMain prepares the tests for Atlas API calls
+// Tests are skipped unless env var AKO_CONTRACT_TEST is set (to protect unit tests)
+// Cleanup is skipped with SKIP_CLEANUP if we want to iterate faster locally
+func TestMain(m *testing.M) {
+	if !control.Enabled("AKO_CONTRACT_TEST") {
+		log.Printf("Skipping contract test as AKO_CONTRACT_TEST is unset")
+		return
+	}
+	l := launcher.NewFromEnv(testVersion)
+	l.Launch(
+		testYml,
+		launcher.WaitReady("atlasprojects/my-project", 30*time.Second))
+	if !control.Enabled("SKIP_CLEANUP") { // allow to reuse Atlas resources for local tests
+		defer l.Cleanup()
+	}
+	m.Run()
+}
+
+func TestGetResource(t *testing.T) {
+	ctx := context.Background()
+	rs := resource.NewProductionResources( /*something*/ )
+
+	assert.PanicsWithValue(t, "unimplemented", func() {
+		rs.GetResource(ctx, "some-id")
+	})
+}

--- a/test/contract/resource/test.yml
+++ b/test/contract/resource/test.yml
@@ -1,0 +1,6 @@
+apiVersion: atlas.mongodb.com/v1
+kind: AtlasProject
+metadata:
+  name: my-project
+spec:
+  name: Test Atlas Operator Project


### PR DESCRIPTION
This is an example template that can help understand the gist of a translation layer, or even be used as a starting point to implement a translation layer for a new resource or refactor an existing one.

Translation layer public interface:
- An resource interface with the operations the reconciliation would need to do on the resource.
  - All arguments and return types are internal and or Kubernetes CRDs.
- A way to create the internal version of the resource from the CRD and some attachments, like secrets, etc.
- A way to normalize the resource internal type defined in Kubernetes to allow it to be compered with the same type converted from Atlas.
- Optionally, the comparison function of internal resource types might also be defined in the translation layer.

Key features:
- The translation layer completely encapsulates the Atlas API interactions:
  - No **Atlas API calls are exposed elsewhere** in the code.
  - No **Atlas API data types are used or imported anywhere else** in the code. Nothing else imports the Atlas SDK.
- The translation layer is an **internal package**, not exposed to operator consumers.
  - Adding a translation layer does not affect the rest of the codebase util it is used.
- The translation layer allows for easy Contract Testing of each of the API endpoints encapsulated.
  - This enables easy Atlas behavior verification up front, even before the reconcilation state machine is coded.
- Other than that, unit testing of the type conversions, normalization and comparisons is also to be expected within this layer.

### All Submissions:

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
