### PR TITLE
CLOUDP-250918: Add test to reproduce issue #1515

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -176,6 +176,10 @@ jobs:
             "deletion-protection",
             "atlas-search-nodes",
             "atlas-search-index",
+            "cache-watch",
+            "reconcile-all",
+            "reconcile-one",
+            "reconcile-two",
           ]
     steps:
       - name: Get repo files from cache

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -141,7 +141,7 @@ func main() {
 	// globalPredicates should be used for general controller Predicates
 	// that should be applied to all controllers in order to limit the
 	// resources they receive events for.
-	predicateNamespaces := controller.NamespacesForGlobalPredicate(config.WatchedNamespaces)
+	predicateNamespaces := controller.NamespacesOrAllPredicate(config.WatchedNamespaces)
 	globalPredicates := []predicate.Predicate{
 		watch.CommonPredicates(),                             // ignore spurious changes. status changes etc.
 		watch.SelectNamespacesPredicate(predicateNamespaces), // select only desired namespaces

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -334,8 +334,8 @@ func parseConfiguration() Config {
 
 	// dev note: we pass the watched namespace as the env variable to use the Kubernetes Downward API. Unfortunately
 	// there is no way to use it for container arguments
-	watchedNamespace := os.Getenv("WATCH_NAMESPACE")
-	if strings.TrimSpace(watchedNamespace) != "" {
+	watchedNamespace := strings.TrimSpace(os.Getenv("WATCH_NAMESPACE"))
+	if watchedNamespace != "" {
 		config.WatchedNamespaces = make(map[string]bool)
 		for _, namespace := range strings.Split(watchedNamespace, ",") {
 			namespace = strings.TrimSpace(namespace)

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -28,3 +28,11 @@ func CustomLabelSelectorCacheBuilder(obj client.Object, labelsSelector labels.Se
 		return cache.New(config, opts)
 	}
 }
+
+func NamespacesForGlobalPredicate(namespaceMap map[string]bool) map[string]bool {
+	if len(namespaceMap) > 0 {
+		return namespaceMap
+	}
+	// if no namespaces where specified it must check all namespaces
+	return map[string]bool{cache.AllNamespaces: true}
+}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -29,7 +29,7 @@ func CustomLabelSelectorCacheBuilder(obj client.Object, labelsSelector labels.Se
 	}
 }
 
-func NamespacesForGlobalPredicate(namespaceMap map[string]bool) map[string]bool {
+func NamespacesOrAllPredicate(namespaceMap map[string]bool) map[string]bool {
 	if len(namespaceMap) > 0 {
 		return namespaceMap
 	}

--- a/test/e2e/cache_watch_test.go
+++ b/test/e2e/cache_watch_test.go
@@ -1,0 +1,308 @@
+package e2e_test
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/featureflags"
+	"github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/api"
+	akov2 "github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/api/v1"
+	"github.com/mongodb/mongodb-atlas-kubernetes/v2/test/helper/conditions"
+	"github.com/mongodb/mongodb-atlas-kubernetes/v2/test/helper/e2e/config"
+	"github.com/mongodb/mongodb-atlas-kubernetes/v2/test/helper/e2e/data"
+	"github.com/mongodb/mongodb-atlas-kubernetes/v2/test/helper/e2e/k8s"
+	"github.com/mongodb/mongodb-atlas-kubernetes/v2/test/helper/e2e/model"
+	"github.com/mongodb/mongodb-atlas-kubernetes/v2/test/helper/e2e/utils"
+)
+
+var _ = Describe("Kubernetes cache watch test:", Label("cache-watch"), func() {
+	DescribeTable("Cache gets", Label("watch-gets"),
+		func(name string, namespaceIndexesToWatch []int, expectedNamespaceFound []bool) {
+			testData := model.DataProvider(
+				fmt.Sprintf("cache-%s", name),
+				model.NewEmptyAtlasKeyType().UseDefaultFullAccess(),
+				30008,
+				[]func(*model.TestDataProvider){},
+			)
+			namespaces := setupNamespaces(testData, name, len(expectedNamespaceFound))
+			defer clearNamespaces(testData, namespaces)
+			setupSecrets(testData, namespaces)
+			defer clearSecrets(testData, namespaces)
+
+			mgrHandle := setupManager(testData, namespaces, namespaceIndexesToWatch)
+			defer mgrHandle.stop()
+
+			By("Using the manager cache to get all secrets in all namespaces and checking the expected results", func() {
+				cache := mgrHandle.mgr.GetCache()
+				for i, ns := range namespaces {
+					secret := &corev1.Secret{}
+					err := cache.Get(testData.Context, types.NamespacedName{Name: config.DefaultOperatorGlobalKey, Namespace: ns}, secret)
+					if expectedNamespaceFound[i] {
+						Expect(err).To(Succeed())
+					} else {
+						Expect(err).NotTo(Succeed())
+						Expect(err.Error()).To(ContainSubstring("because of unknown namespace for the cache"))
+					}
+				}
+			})
+		},
+		Entry("From all namespaces when no namespace config is set", Label("gets-all"),
+			"gets-all", []int{}, []bool{true, true, true}),
+		Entry("One namespace when only one namespace is configured", Label("gets-one"),
+			"gets-one", []int{0}, []bool{true, false, false}),
+		Entry("Two namespaces when only those two are configured", Label("gets-two"),
+			"gets-two", []int{0, 1}, []bool{true, true, false}),
+	)
+
+	DescribeTable("Cache lists", Label("watch-lists"),
+		func(name string, namespaceIndexesToWatch []int, expectedNamespaceFound []bool) {
+			testData := model.DataProvider(
+				fmt.Sprintf("cache-%s", name),
+				model.NewEmptyAtlasKeyType().UseDefaultFullAccess(),
+				30009,
+				[]func(*model.TestDataProvider){},
+			)
+			namespaces := setupNamespaces(testData, name, len(expectedNamespaceFound))
+			defer clearNamespaces(testData, namespaces)
+			setupSecrets(testData, namespaces)
+			defer clearSecrets(testData, namespaces)
+
+			mgrHandle := setupManager(testData, namespaces, namespaceIndexesToWatch)
+			defer mgrHandle.stop()
+
+			By("Using the manager cache to list all secrets in all namespaces and checking the expected results", func() {
+				cache := mgrHandle.mgr.GetCache()
+				for i, ns := range namespaces {
+					secrets := &corev1.SecretList{}
+					err := cache.List(testData.Context, secrets, &client.ListOptions{Namespace: ns})
+					if expectedNamespaceFound[i] {
+						Expect(err).To(Succeed())
+					} else {
+						Expect(err).NotTo(Succeed())
+						Expect(err.Error()).To(ContainSubstring("because of unknown namespace for the cache"))
+					}
+				}
+			})
+		},
+		Entry("From all namespaces when no namespace config is set", Label("list-all"),
+			"list-all", []int{}, []bool{true, true, true}),
+		Entry("One namespace when only one namespace is configured", Label("list-one"),
+			"list-one", []int{0}, []bool{true, false, false}),
+		Entry("Two namespaces when only those two are configured", Label("list-two"),
+			"list-two", []int{0, 1}, []bool{true, true, false}),
+	)
+})
+
+// Reconcile tests cannot be run all at once, there are races between:
+//
+// - A reader goroutine from the Kubernetes event watcher.
+//  See https://github.com/kubernetes/client-go/blob/52e5651101edcb2ecd8463ffdc281053cf6e63d4/tools/record/event.go#L395
+//
+// - A writer AddToScheme on test client helper code.
+//   See `test/helper/e2e/k8s.CreateNewClient()`
+
+var _ = Describe("Reconciles test:", func() {
+	DescribeTable("Reconciles",
+		func(name string, namespaceIndexesToWatch []int, expectedNamespaceFound []bool) {
+			testData := model.DataProvider(
+				name,
+				model.NewEmptyAtlasKeyType().UseDefaultFullAccess(),
+				30010,
+				[]func(*model.TestDataProvider){},
+			)
+			namespaces := setupNamespaces(testData, name, len(expectedNamespaceFound))
+			defer clearNamespaces(testData, namespaces)
+			setupSecrets(testData, namespaces)
+			defer clearSecrets(testData, namespaces)
+
+			mgrHandle := setupManager(testData, namespaces, namespaceIndexesToWatch)
+			defer mgrHandle.stop()
+
+			By("Launching an atlas project on each namespace, expect only listened namespaces to update status", func() {
+				projectNames := make([]string, len(expectedNamespaceFound))
+				for i, ns := range namespaces {
+					project := data.DefaultProject()
+					By("Create project", func() {
+						project.Name = utils.RandomName(fmt.Sprintf("test-project-%s-ns%d", name, i))
+						project.Namespace = ns
+						project.Spec.Name = "" // Set empty name to force validation error
+						projectNames[i] = project.Name
+
+						Expect(testData.K8SClient.Create(context.Background(), project)).ToNot(HaveOccurred())
+					})
+
+					prj := &akov2.AtlasProject{}
+					By("Wait project to be present in Kubernetes", func() {
+						Eventually(func(g Gomega) bool {
+							return g.Expect(
+								testData.K8SClient.Get(testData.Context,
+									types.NamespacedName{Name: project.Name, Namespace: ns}, prj),
+							).To(Succeed())
+						}).WithTimeout(time.Minute).Should(BeTrue())
+					})
+
+					if expectedNamespaceFound[i] {
+						expectedCondition := api.Condition{
+							Type:    "ProjectReady",
+							Status:  "False",
+							Reason:  "ProjectNotCreatedInAtlas",
+							Message: "projectName is invalid because must be set",
+						}
+						By("Verify Kubernetes status got the expected error", func() {
+							Eventually(func(g Gomega) bool {
+								g.Expect(
+									testData.K8SClient.Get(testData.Context,
+										types.NamespacedName{Name: project.Name, Namespace: ns}, prj),
+								).To(Succeed())
+								match, err := ContainElement(conditions.MatchCondition(expectedCondition)).Match(prj.GetStatus().GetConditions())
+								g.Expect(err).To(Succeed())
+								return match
+							}).WithPolling(time.Second).WithTimeout(time.Minute).Should(BeTrue())
+						})
+					} else {
+						expectedObservedGeneration := prj.Status.ObservedGeneration
+						verifications := 0
+						By("Verify Kubernetes status remains untouched", func() {
+							Eventually(func(g Gomega) bool {
+								g.Expect(
+									testData.K8SClient.Get(testData.Context,
+										types.NamespacedName{Name: project.Name, Namespace: ns}, prj),
+								).To(Succeed())
+								if prj.Status.Common.ObservedGeneration == expectedObservedGeneration {
+									verifications += 1
+
+								}
+								return verifications > 15
+							}).WithPolling(time.Second).WithTimeout(40 * time.Second).Should(BeTrue())
+						})
+					}
+					By("Delete project", func() {
+						Expect(testData.K8SClient.Delete(context.Background(), project)).ToNot(HaveOccurred())
+					})
+				}
+			})
+		},
+		Entry("All namespaces when no namespace config is set", Label("reconcile-all"),
+			"reconcile-all", []int{}, []bool{true, true, true}),
+		Entry("One namespace when only one namespace is configured", Label("reconcile-one"),
+			"reconcile-one", []int{0}, []bool{true, false, false}),
+		Entry("Two namespaces when only those two are configured", Label("reconcile-two"),
+			"reconcile-two", []int{0, 1}, []bool{true, true, false}),
+	)
+})
+
+func setupNamespaces(testData *model.TestDataProvider, name string, size int) []string {
+	namespaces := make([]string, size)
+	By("Setting up test namespaces (and wait for them to be created)", func() {
+		for i := 0; i < size; i++ {
+			namespaces[i] = utils.RandomName(fmt.Sprintf("%s-ns%d", name, i))
+			Expect(k8s.CreateNamespace(testData.Context, testData.K8SClient, namespaces[i])).To(Succeed())
+		}
+		for _, ns := range namespaces {
+			Eventually(func(g Gomega) bool {
+				namespace := &corev1.Namespace{}
+				return g.Expect(
+					testData.K8SClient.Get(testData.Context, types.NamespacedName{Name: ns}, namespace),
+				).To(Succeed())
+			}).WithTimeout(time.Minute).Should(BeTrue())
+		}
+	})
+	return namespaces
+}
+
+func setupSecrets(testData *model.TestDataProvider, namespaces []string) {
+	By("Setting up test secrets, one on each namespace (and wait for them)", func() {
+		for _, ns := range namespaces {
+			k8s.CreateDefaultSecret(testData.Context, testData.K8SClient, config.DefaultOperatorGlobalKey, ns)
+		}
+		for _, ns := range namespaces {
+			Eventually(func(g Gomega) bool {
+				secret := &corev1.Secret{}
+				return g.Expect(
+					testData.K8SClient.Get(testData.Context, types.NamespacedName{
+						Name: config.DefaultOperatorGlobalKey, Namespace: ns}, secret),
+				).To(Succeed())
+			}).WithTimeout(time.Minute).Should(BeTrue())
+		}
+	})
+}
+
+func setupManager(testData *model.TestDataProvider, namespaces []string, namespaceIndexesToWatch []int) *managerHandle {
+	mgrHandle := managerHandle{}
+	mgrCtx, cancelFn := context.WithCancel(context.Background())
+	mgrHandle.cancelFn = cancelFn
+	By("Setting up the manager in the first namespace to watch on the given namespaces", func() {
+		managerConfig := &k8s.Config{
+			GlobalAPISecret: client.ObjectKey{
+				Namespace: namespaces[0],
+				Name:      config.DefaultOperatorGlobalKey,
+			},
+			FeatureFlags: featureflags.NewFeatureFlags(func() []string { return []string{} }),
+		}
+		watchedNamespaces := map[string]bool{}
+		for _, idx := range namespaceIndexesToWatch {
+			watchedNamespaces[namespaces[idx]] = true
+		}
+		if len(watchedNamespaces) > 0 {
+			managerConfig.WatchedNamespaces = watchedNamespaces
+		}
+		var err error
+		mgrHandle.mgr, err = k8s.BuildManager(managerConfig)
+		Expect(err).NotTo(HaveOccurred())
+
+		mgrHandle.wg.Add(1)
+		go func(ctx context.Context) {
+			defer mgrHandle.wg.Done()
+			err := mgrHandle.mgr.Start(ctx)
+			Expect(err).NotTo(HaveOccurred())
+		}(mgrCtx)
+	})
+
+	By("wait for cache to be started", func() {
+		// the first namespace should always be cache-accessible
+		cache := mgrHandle.mgr.GetCache()
+		Eventually(func(g Gomega) bool {
+			namespace := &corev1.Namespace{}
+			return g.Expect(
+				cache.Get(testData.Context, types.NamespacedName{Name: namespaces[0]}, namespace),
+			).To(Succeed())
+		}).WithTimeout(time.Minute).Should(BeTrue())
+	})
+	return &mgrHandle
+}
+
+type managerHandle struct {
+	mgr      manager.Manager
+	wg       sync.WaitGroup
+	cancelFn context.CancelFunc
+}
+
+func (mgrHandle *managerHandle) stop() {
+	mgrHandle.cancelFn()
+	mgrHandle.wg.Wait()
+}
+
+func clearSecrets(testData *model.TestDataProvider, namespaces []string) {
+	By("Clearing the secrets", func() {
+		for _, ns := range namespaces {
+			Expect(k8s.DeleteKey(testData.Context, testData.K8SClient, config.DefaultOperatorGlobalKey, ns)).To(Succeed())
+		}
+	})
+}
+
+func clearNamespaces(testData *model.TestDataProvider, namespaces []string) {
+	By("Clearing namespaces", func() {
+		for _, ns := range namespaces {
+			Expect(k8s.DeleteNamespace(testData.Context, testData.K8SClient, ns)).To(Succeed())
+		}
+	})
+}

--- a/test/e2e/cache_watch_test.go
+++ b/test/e2e/cache_watch_test.go
@@ -69,16 +69,16 @@ var _ = Describe("Kubernetes cache watch test:", Label("cache-watch"), func() {
 			wantToFind:      []string{"ns1", "ns2", "ns3"},
 		}),
 
-		Entry("One namespace when only one namespace is configured", Label("gets-all"), &tc{
+		Entry("One namespace when only one namespace is configured", Label("gets-one"), &tc{
 			namespaces:      []string{"ns1", "ns2", "ns3"},
 			watchNamespaces: []string{"ns1"},
 			wantToFind:      []string{"ns1"},
 		}),
 
-		Entry("Two namespaces when only those two are configured", Label("gets-all"), &tc{
+		Entry("Two namespaces when only those two are configured", Label("gets-two"), &tc{
 			namespaces:      []string{"ns1", "ns2", "ns3"},
-			watchNamespaces: []string{"ns1", "n2"},
-			wantToFind:      []string{"ns1", "n2"},
+			watchNamespaces: []string{"ns1", "ns2"},
+			wantToFind:      []string{"ns1", "ns2"},
 		}),
 	)
 
@@ -129,8 +129,8 @@ var _ = Describe("Kubernetes cache watch test:", Label("cache-watch"), func() {
 
 		Entry("Two namespaces when only those two are configured", Label("list-two"), &tc{
 			namespaces:      []string{"ns1", "ns2", "ns3"},
-			watchNamespaces: []string{"ns1", "n2"},
-			wantToFind:      []string{"ns1", "n2"},
+			watchNamespaces: []string{"ns1", "ns2"},
+			wantToFind:      []string{"ns1", "ns2"},
 		}),
 	)
 })
@@ -241,8 +241,8 @@ var _ = Describe("Reconciles test:", func() {
 
 		Entry("Two namespaces when only those two are configured", Label("reconcile-two"), &tc{
 			namespaces:      []string{"ns1", "ns2", "ns3"},
-			watchNamespaces: []string{"ns1", "n2"},
-			wantToFind:      []string{"ns1", "n2"},
+			watchNamespaces: []string{"ns1", "ns2"},
+			wantToFind:      []string{"ns1", "ns2"},
 		}),
 	)
 })

--- a/test/e2e/cache_watch_test.go
+++ b/test/e2e/cache_watch_test.go
@@ -10,6 +10,7 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
@@ -21,32 +22,38 @@ import (
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/test/helper/e2e/data"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/test/helper/e2e/k8s"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/test/helper/e2e/model"
-	"github.com/mongodb/mongodb-atlas-kubernetes/v2/test/helper/e2e/utils"
 )
+
+type tc struct {
+	namespaces      []string
+	watchNamespaces []string
+	wantToFind      []string
+}
 
 var _ = Describe("Kubernetes cache watch test:", Label("cache-watch"), func() {
 	DescribeTable("Cache gets", Label("watch-gets"),
-		func(name string, namespaceIndexesToWatch []int, expectedNamespaceFound []bool) {
+		func(ctx context.Context, testCase *tc) {
 			testData := model.DataProvider(
-				fmt.Sprintf("cache-%s", name),
+				fmt.Sprintf("cache-%s", CurrentSpecReport().LeafNodeLabels[0]),
 				model.NewEmptyAtlasKeyType().UseDefaultFullAccess(),
 				30008,
 				[]func(*model.TestDataProvider){},
 			)
-			namespaces := setupNamespaces(testData, name, len(expectedNamespaceFound))
-			defer clearNamespaces(testData, namespaces)
-			setupSecrets(testData, namespaces)
-			defer clearSecrets(testData, namespaces)
+			namespaces := setupNamespaces(ctx, testData, testCase.namespaces...)
+			defer clearNamespaces(ctx, testData, namespaces)
+			setupSecrets(ctx, testData, namespaces)
+			defer clearSecrets(ctx, testData, namespaces)
 
-			mgrHandle := setupManager(testData, namespaces, namespaceIndexesToWatch)
-			defer mgrHandle.stop()
+			mgr, stop := setupManager(ctx, namespaces, testCase.watchNamespaces)
+			defer stop()
 
+			wantToFindSet := sets.NewString(testCase.wantToFind...)
 			By("Using the manager cache to get all secrets in all namespaces and checking the expected results", func() {
-				cache := mgrHandle.mgr.GetCache()
-				for i, ns := range namespaces {
-					secret := &corev1.Secret{}
-					err := cache.Get(testData.Context, types.NamespacedName{Name: config.DefaultOperatorGlobalKey, Namespace: ns}, secret)
-					if expectedNamespaceFound[i] {
+				cache := mgr.GetCache()
+				for _, ns := range namespaces {
+					err := cache.Get(ctx, types.NamespacedName{Name: config.DefaultOperatorGlobalKey, Namespace: ns.GetName()}, &corev1.Secret{})
+
+					if wantToFindSet.Has(ns.GetGenerateName()) {
 						Expect(err).To(Succeed())
 					} else {
 						Expect(err).NotTo(Succeed())
@@ -55,36 +62,50 @@ var _ = Describe("Kubernetes cache watch test:", Label("cache-watch"), func() {
 				}
 			})
 		},
-		Entry("From all namespaces when no namespace config is set", Label("gets-all"),
-			"gets-all", []int{}, []bool{true, true, true}),
-		Entry("One namespace when only one namespace is configured", Label("gets-one"),
-			"gets-one", []int{0}, []bool{true, false, false}),
-		Entry("Two namespaces when only those two are configured", Label("gets-two"),
-			"gets-two", []int{0, 1}, []bool{true, true, false}),
+
+		Entry("From all namespaces when no namespace config is set", Label("gets-all"), &tc{
+			namespaces:      []string{"ns1", "ns2", "ns3"},
+			watchNamespaces: nil,
+			wantToFind:      []string{"ns1", "ns2", "ns3"},
+		}),
+
+		Entry("One namespace when only one namespace is configured", Label("gets-all"), &tc{
+			namespaces:      []string{"ns1", "ns2", "ns3"},
+			watchNamespaces: []string{"ns1"},
+			wantToFind:      []string{"ns1"},
+		}),
+
+		Entry("Two namespaces when only those two are configured", Label("gets-all"), &tc{
+			namespaces:      []string{"ns1", "ns2", "ns3"},
+			watchNamespaces: []string{"ns1", "n2"},
+			wantToFind:      []string{"ns1", "n2"},
+		}),
 	)
 
 	DescribeTable("Cache lists", Label("watch-lists"),
-		func(name string, namespaceIndexesToWatch []int, expectedNamespaceFound []bool) {
+		func(ctx context.Context, testCase *tc) {
 			testData := model.DataProvider(
-				fmt.Sprintf("cache-%s", name),
+				fmt.Sprintf("cache-%s", CurrentSpecReport().LeafNodeLabels[0]),
 				model.NewEmptyAtlasKeyType().UseDefaultFullAccess(),
 				30009,
 				[]func(*model.TestDataProvider){},
 			)
-			namespaces := setupNamespaces(testData, name, len(expectedNamespaceFound))
-			defer clearNamespaces(testData, namespaces)
-			setupSecrets(testData, namespaces)
-			defer clearSecrets(testData, namespaces)
 
-			mgrHandle := setupManager(testData, namespaces, namespaceIndexesToWatch)
-			defer mgrHandle.stop()
+			namespaces := setupNamespaces(ctx, testData, testCase.namespaces...)
+			defer clearNamespaces(ctx, testData, namespaces)
+			setupSecrets(ctx, testData, namespaces)
+			defer clearSecrets(ctx, testData, namespaces)
 
+			mgr, stop := setupManager(ctx, namespaces, testCase.watchNamespaces)
+			defer stop()
+
+			wantToFindSet := sets.NewString(testCase.wantToFind...)
 			By("Using the manager cache to list all secrets in all namespaces and checking the expected results", func() {
-				cache := mgrHandle.mgr.GetCache()
-				for i, ns := range namespaces {
-					secrets := &corev1.SecretList{}
-					err := cache.List(testData.Context, secrets, &client.ListOptions{Namespace: ns})
-					if expectedNamespaceFound[i] {
+				cache := mgr.GetCache()
+				for _, ns := range namespaces {
+					err := cache.List(ctx, &corev1.SecretList{}, &client.ListOptions{Namespace: ns.GetName()})
+
+					if wantToFindSet.Has(ns.GetGenerateName()) {
 						Expect(err).To(Succeed())
 					} else {
 						Expect(err).NotTo(Succeed())
@@ -93,12 +114,24 @@ var _ = Describe("Kubernetes cache watch test:", Label("cache-watch"), func() {
 				}
 			})
 		},
-		Entry("From all namespaces when no namespace config is set", Label("list-all"),
-			"list-all", []int{}, []bool{true, true, true}),
-		Entry("One namespace when only one namespace is configured", Label("list-one"),
-			"list-one", []int{0}, []bool{true, false, false}),
-		Entry("Two namespaces when only those two are configured", Label("list-two"),
-			"list-two", []int{0, 1}, []bool{true, true, false}),
+
+		Entry("From all namespaces when no namespace config is set", Label("list-all"), &tc{
+			namespaces:      []string{"ns1", "ns2", "ns3"},
+			watchNamespaces: nil,
+			wantToFind:      []string{"ns1", "ns2", "ns3"},
+		}),
+
+		Entry("One namespace when only one namespace is configured", Label("list-one"), &tc{
+			namespaces:      []string{"ns1", "ns2", "ns3"},
+			watchNamespaces: []string{"ns1"},
+			wantToFind:      []string{"ns1"},
+		}),
+
+		Entry("Two namespaces when only those two are configured", Label("list-two"), &tc{
+			namespaces:      []string{"ns1", "ns2", "ns3"},
+			watchNamespaces: []string{"ns1", "n2"},
+			wantToFind:      []string{"ns1", "n2"},
+		}),
 	)
 })
 
@@ -112,45 +145,47 @@ var _ = Describe("Kubernetes cache watch test:", Label("cache-watch"), func() {
 
 var _ = Describe("Reconciles test:", func() {
 	DescribeTable("Reconciles",
-		func(name string, namespaceIndexesToWatch []int, expectedNamespaceFound []bool) {
+		func(ctx context.Context, testCase *tc) {
 			testData := model.DataProvider(
-				name,
+				fmt.Sprintf("reconcile-%s", CurrentSpecReport().LeafNodeLabels[0]),
 				model.NewEmptyAtlasKeyType().UseDefaultFullAccess(),
 				30010,
 				[]func(*model.TestDataProvider){},
 			)
-			namespaces := setupNamespaces(testData, name, len(expectedNamespaceFound))
-			defer clearNamespaces(testData, namespaces)
-			setupSecrets(testData, namespaces)
-			defer clearSecrets(testData, namespaces)
+			namespaces := setupNamespaces(ctx, testData, testCase.namespaces...)
+			defer clearNamespaces(ctx, testData, namespaces)
+			setupSecrets(ctx, testData, namespaces)
+			defer clearSecrets(ctx, testData, namespaces)
 
-			mgrHandle := setupManager(testData, namespaces, namespaceIndexesToWatch)
-			defer mgrHandle.stop()
+			_, stop := setupManager(ctx, namespaces, testCase.watchNamespaces)
+			defer stop()
 
 			By("Launching an atlas project on each namespace, expect only listened namespaces to update status", func() {
-				projectNames := make([]string, len(expectedNamespaceFound))
+				projectNames := make([]string, len(namespaces))
+				wantToFindSet := sets.NewString(testCase.wantToFind...)
+
 				for i, ns := range namespaces {
 					project := data.DefaultProject()
 					By("Create project", func() {
-						project.Name = utils.RandomName(fmt.Sprintf("test-project-%s-ns%d", name, i))
-						project.Namespace = ns
+						project.Name = ""
+						project.GenerateName = "test-project-" + CurrentSpecReport().LeafNodeLabels[0]
+						project.Namespace = ns.GetName()
 						project.Spec.Name = "" // Set empty name to force validation error
-						projectNames[i] = project.Name
-
 						Expect(testData.K8SClient.Create(context.Background(), project)).ToNot(HaveOccurred())
+						projectNames[i] = project.Name
 					})
 
 					prj := &akov2.AtlasProject{}
 					By("Wait project to be present in Kubernetes", func() {
 						Eventually(func(g Gomega) bool {
 							return g.Expect(
-								testData.K8SClient.Get(testData.Context,
-									types.NamespacedName{Name: project.Name, Namespace: ns}, prj),
+								testData.K8SClient.Get(ctx,
+									types.NamespacedName{Name: project.Name, Namespace: ns.GetName()}, prj),
 							).To(Succeed())
 						}).WithTimeout(time.Minute).Should(BeTrue())
 					})
 
-					if expectedNamespaceFound[i] {
+					if wantToFindSet.Has(ns.GetGenerateName()) {
 						expectedCondition := api.Condition{
 							Type:    "ProjectReady",
 							Status:  "False",
@@ -160,8 +195,8 @@ var _ = Describe("Reconciles test:", func() {
 						By("Verify Kubernetes status got the expected error", func() {
 							Eventually(func(g Gomega) bool {
 								g.Expect(
-									testData.K8SClient.Get(testData.Context,
-										types.NamespacedName{Name: project.Name, Namespace: ns}, prj),
+									testData.K8SClient.Get(ctx,
+										types.NamespacedName{Name: project.Name, Namespace: ns.GetName()}, prj),
 								).To(Succeed())
 								match, err := ContainElement(conditions.MatchCondition(expectedCondition)).Match(prj.GetStatus().GetConditions())
 								g.Expect(err).To(Succeed())
@@ -174,8 +209,8 @@ var _ = Describe("Reconciles test:", func() {
 						By("Verify Kubernetes status remains untouched", func() {
 							Eventually(func(g Gomega) bool {
 								g.Expect(
-									testData.K8SClient.Get(testData.Context,
-										types.NamespacedName{Name: project.Name, Namespace: ns}, prj),
+									testData.K8SClient.Get(ctx,
+										types.NamespacedName{Name: project.Name, Namespace: ns.GetName()}, prj),
 								).To(Succeed())
 								if prj.Status.Common.ObservedGeneration == expectedObservedGeneration {
 									verifications += 1
@@ -186,123 +221,140 @@ var _ = Describe("Reconciles test:", func() {
 						})
 					}
 					By("Delete project", func() {
-						Expect(testData.K8SClient.Delete(context.Background(), project)).ToNot(HaveOccurred())
+						Expect(testData.K8SClient.Delete(ctx, project)).ToNot(HaveOccurred())
 					})
 				}
 			})
 		},
-		Entry("All namespaces when no namespace config is set", Label("reconcile-all"),
-			"reconcile-all", []int{}, []bool{true, true, true}),
-		Entry("One namespace when only one namespace is configured", Label("reconcile-one"),
-			"reconcile-one", []int{0}, []bool{true, false, false}),
-		Entry("Two namespaces when only those two are configured", Label("reconcile-two"),
-			"reconcile-two", []int{0, 1}, []bool{true, true, false}),
+
+		Entry("All namespaces when no namespace config is set", Label("reconcile-all"), &tc{
+			namespaces:      []string{"ns1", "ns2", "ns3"},
+			watchNamespaces: nil,
+			wantToFind:      []string{"ns1", "ns2", "ns3"},
+		}),
+
+		Entry("One namespace when only one namespace is configured", Label("reconcile-one"), &tc{
+			namespaces:      []string{"ns1", "ns2", "ns3"},
+			watchNamespaces: []string{"ns1"},
+			wantToFind:      []string{"ns1"},
+		}),
+
+		Entry("Two namespaces when only those two are configured", Label("reconcile-two"), &tc{
+			namespaces:      []string{"ns1", "ns2", "ns3"},
+			watchNamespaces: []string{"ns1", "n2"},
+			wantToFind:      []string{"ns1", "n2"},
+		}),
 	)
 })
 
-func setupNamespaces(testData *model.TestDataProvider, name string, size int) []string {
-	namespaces := make([]string, size)
+func setupNamespaces(ctx context.Context, testData *model.TestDataProvider, generateNames ...string) []*corev1.Namespace {
+	result := make([]*corev1.Namespace, 0, len(generateNames))
 	By("Setting up test namespaces (and wait for them to be created)", func() {
-		for i := 0; i < size; i++ {
-			namespaces[i] = utils.RandomName(fmt.Sprintf("%s-ns%d", name, i))
-			Expect(k8s.CreateNamespace(testData.Context, testData.K8SClient, namespaces[i])).To(Succeed())
+		for i := 0; i < len(generateNames); i++ {
+			namespace, err := k8s.CreateRandomNamespace(ctx, testData.K8SClient, generateNames[i])
+			Expect(err).To(BeNil())
+			result = append(result, namespace)
 		}
-		for _, ns := range namespaces {
+		for _, ns := range result {
 			Eventually(func(g Gomega) bool {
 				namespace := &corev1.Namespace{}
 				return g.Expect(
-					testData.K8SClient.Get(testData.Context, types.NamespacedName{Name: ns}, namespace),
+					testData.K8SClient.Get(ctx, types.NamespacedName{Name: ns.GetName()}, namespace),
 				).To(Succeed())
 			}).WithTimeout(time.Minute).Should(BeTrue())
 		}
 	})
-	return namespaces
+	return result
 }
 
-func setupSecrets(testData *model.TestDataProvider, namespaces []string) {
+func setupSecrets(ctx context.Context, testData *model.TestDataProvider, namespaces []*corev1.Namespace) {
 	By("Setting up test secrets, one on each namespace (and wait for them)", func() {
 		for _, ns := range namespaces {
-			k8s.CreateDefaultSecret(testData.Context, testData.K8SClient, config.DefaultOperatorGlobalKey, ns)
+			k8s.CreateDefaultSecret(ctx, testData.K8SClient, config.DefaultOperatorGlobalKey, ns.GetName())
 		}
 		for _, ns := range namespaces {
 			Eventually(func(g Gomega) bool {
 				secret := &corev1.Secret{}
 				return g.Expect(
-					testData.K8SClient.Get(testData.Context, types.NamespacedName{
-						Name: config.DefaultOperatorGlobalKey, Namespace: ns}, secret),
+					testData.K8SClient.Get(ctx, types.NamespacedName{
+						Name: config.DefaultOperatorGlobalKey, Namespace: ns.GetName()}, secret),
 				).To(Succeed())
 			}).WithTimeout(time.Minute).Should(BeTrue())
 		}
 	})
 }
 
-func setupManager(testData *model.TestDataProvider, namespaces []string, namespaceIndexesToWatch []int) *managerHandle {
-	mgrHandle := managerHandle{}
-	mgrCtx, cancelFn := context.WithCancel(context.Background())
-	mgrHandle.cancelFn = cancelFn
+type stopper func()
+
+func setupManager(ctx context.Context, namespaces []*corev1.Namespace, wantToWatch []string) (manager.Manager, stopper) {
+	var (
+		wg  sync.WaitGroup
+		mgr manager.Manager
+	)
+
+	wantToWatchSet := sets.NewString(wantToWatch...)
+	watchedNamespaces := make(map[string]bool)
+	for _, ns := range namespaces {
+		if wantToWatchSet.Has(ns.GetGenerateName()) {
+			watchedNamespaces[ns.GetName()] = true
+		}
+	}
+
+	mgrCtx, cancelFn := context.WithCancel(ctx)
 	By("Setting up the manager in the first namespace to watch on the given namespaces", func() {
 		managerConfig := &k8s.Config{
 			GlobalAPISecret: client.ObjectKey{
-				Namespace: namespaces[0],
+				Namespace: namespaces[0].GetName(),
 				Name:      config.DefaultOperatorGlobalKey,
 			},
 			FeatureFlags: featureflags.NewFeatureFlags(func() []string { return []string{} }),
 		}
-		watchedNamespaces := map[string]bool{}
-		for _, idx := range namespaceIndexesToWatch {
-			watchedNamespaces[namespaces[idx]] = true
-		}
+
 		if len(watchedNamespaces) > 0 {
 			managerConfig.WatchedNamespaces = watchedNamespaces
 		}
+
 		var err error
-		mgrHandle.mgr, err = k8s.BuildManager(managerConfig)
+		mgr, err = k8s.BuildManager(managerConfig)
 		Expect(err).NotTo(HaveOccurred())
 
-		mgrHandle.wg.Add(1)
+		wg.Add(1)
 		go func(ctx context.Context) {
-			defer mgrHandle.wg.Done()
-			err := mgrHandle.mgr.Start(ctx)
+			defer wg.Done()
+			err := mgr.Start(ctx)
 			Expect(err).NotTo(HaveOccurred())
 		}(mgrCtx)
 	})
 
 	By("wait for cache to be started", func() {
 		// the first namespace should always be cache-accessible
-		cache := mgrHandle.mgr.GetCache()
 		Eventually(func(g Gomega) bool {
-			namespace := &corev1.Namespace{}
 			return g.Expect(
-				cache.Get(testData.Context, types.NamespacedName{Name: namespaces[0]}, namespace),
+				mgr.GetCache().Get(ctx, types.NamespacedName{Name: namespaces[0].GetName()}, &corev1.Namespace{}),
 			).To(Succeed())
 		}).WithTimeout(time.Minute).Should(BeTrue())
 	})
-	return &mgrHandle
+
+	stopper := func() {
+		cancelFn()
+		wg.Wait()
+	}
+
+	return mgr, stopper
 }
 
-type managerHandle struct {
-	mgr      manager.Manager
-	wg       sync.WaitGroup
-	cancelFn context.CancelFunc
-}
-
-func (mgrHandle *managerHandle) stop() {
-	mgrHandle.cancelFn()
-	mgrHandle.wg.Wait()
-}
-
-func clearSecrets(testData *model.TestDataProvider, namespaces []string) {
+func clearSecrets(ctx context.Context, testData *model.TestDataProvider, namespaces []*corev1.Namespace) {
 	By("Clearing the secrets", func() {
 		for _, ns := range namespaces {
-			Expect(k8s.DeleteKey(testData.Context, testData.K8SClient, config.DefaultOperatorGlobalKey, ns)).To(Succeed())
+			Expect(k8s.DeleteKey(ctx, testData.K8SClient, config.DefaultOperatorGlobalKey, ns.GetName())).To(Succeed())
 		}
 	})
 }
 
-func clearNamespaces(testData *model.TestDataProvider, namespaces []string) {
+func clearNamespaces(ctx context.Context, testData *model.TestDataProvider, namespaces []*corev1.Namespace) {
 	By("Clearing namespaces", func() {
 		for _, ns := range namespaces {
-			Expect(k8s.DeleteNamespace(testData.Context, testData.K8SClient, ns)).To(Succeed())
+			Expect(k8s.DeleteNamespace(ctx, testData.K8SClient, ns.GetName())).To(Succeed())
 		}
 	})
 }

--- a/test/e2e/db_users_oidc_test.go
+++ b/test/e2e/db_users_oidc_test.go
@@ -73,7 +73,6 @@ var _ = Describe("Operator to run db-user with the OIDC feature flags", Ordered,
 					Namespace: config.DefaultOperatorNS,
 					Name:      config.DefaultOperatorGlobalKey,
 				},
-				Namespace:    config.DefaultOperatorNS,
 				FeatureFlags: featureflags.NewFeatureFlags(func() []string { return []string{} }),
 			})
 			Expect(err).NotTo(HaveOccurred())

--- a/test/e2e/db_users_test.go
+++ b/test/e2e/db_users_test.go
@@ -85,11 +85,6 @@ var _ = Describe("Operator watch all namespace should create connection secrets 
 					Namespace: config.DefaultOperatorNS,
 					Name:      config.DefaultOperatorGlobalKey,
 				},
-				Namespace: config.DefaultOperatorNS,
-				WatchedNamespaces: map[string]bool{
-					config.DefaultOperatorNS: true,
-					secondNamespace:          true,
-				},
 				FeatureFlags: featureflags.NewFeatureFlags(func() []string { return []string{} }),
 			})
 			Expect(err).NotTo(HaveOccurred())

--- a/test/helper/e2e/actions/deploy/deploy_operator.go
+++ b/test/helper/e2e/actions/deploy/deploy_operator.go
@@ -30,7 +30,6 @@ func MultiNamespaceOperator(data *model.TestDataProvider, watchNamespace []strin
 			watchNamespaceMap[ns] = true
 		}
 		mgr, err := k8s.BuildManager(&k8s.Config{
-			Namespace: config.DefaultOperatorNS,
 			GlobalAPISecret: client.ObjectKey{
 				Namespace: config.DefaultOperatorNS,
 				Name:      config.DefaultOperatorGlobalKey,

--- a/test/helper/e2e/actions/project_flow.go
+++ b/test/helper/e2e/actions/project_flow.go
@@ -43,7 +43,6 @@ func ProjectCreationFlow(userData *model.TestDataProvider) {
 func PrepareOperatorConfigurations(userData *model.TestDataProvider) manager.Manager {
 	CreateNamespaceAndSecrets(userData)
 	mgr, err := k8s.BuildManager(&k8s.Config{
-		Namespace: userData.Resources.Namespace,
 		WatchedNamespaces: map[string]bool{
 			userData.Resources.Namespace: true,
 		},

--- a/test/helper/e2e/k8s/k8s.go
+++ b/test/helper/e2e/k8s/k8s.go
@@ -185,6 +185,21 @@ func CreateNamespace(ctx context.Context, k8sClient client.Client, ns string) er
 	return nil
 }
 
+func CreateRandomNamespace(ctx context.Context, k8sClient client.Client, generateName string) (*corev1.Namespace, error) {
+	namespace := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: generateName,
+		},
+	}
+	err := k8sClient.Create(ctx, namespace)
+	if err != nil {
+		if !k8serrors.IsAlreadyExists(err) {
+			return nil, err
+		}
+	}
+	return namespace, nil
+}
+
 func CreateRandomUserSecret(ctx context.Context, k8sClient client.Client, name, ns string) error {
 	secret, _ := password.Generate(10, 3, 0, false, false)
 	return CreateUserSecret(ctx, k8sClient, secret, name, ns)

--- a/test/helper/e2e/k8s/operator.go
+++ b/test/helper/e2e/k8s/operator.go
@@ -108,7 +108,7 @@ func BuildManager(initCfg *Config) (manager.Manager, error) {
 	// globalPredicates should be used for general controller Predicates
 	// that should be applied to all controllers in order to limit the
 	// resources they receive events for.
-	predicateNamespaces := controller.NamespacesForGlobalPredicate(config.WatchedNamespaces)
+	predicateNamespaces := controller.NamespacesOrAllPredicate(config.WatchedNamespaces)
 	globalPredicates := []predicate.Predicate{
 		watch.CommonPredicates(),                             // ignore spurious changes. status changes etc.
 		watch.SelectNamespacesPredicate(predicateNamespaces), // select only desired namespaces


### PR DESCRIPTION
This is a bugfix for namespace watching filtering setup in both `main` and the `e2e` tests. The bug was discovered by issue #1515. The mistake came to be a mixture of controller runtime changing the manager setup and the operator code having a special case for watching a single namespace.

The fix consists of:
1. A new set of tests that detect the issue:
  - Test the cache gets, list and reconciles to access 3 namespaces when:
    - No namespaces were configured, meaning all 3 namespaces are accessible.
    - One namespace was configured, meaning only that namespace is accessible.
    - Two namespaces were configured, meaning two are accesible and the other is not.
2. The actual fix in `main` and `e2e` code:
  - Do not treat the single namespace as a special case.
  - Do not even get a "default namespace" in config at all.
  - Remove any default list of namespaces to watch, so that config sets it up clean.
  - Ensure the global predicate defaults to All Namespaces when no watched namespaces were setup.
  - Remove the `e2e` logic coming from a reflection on for the `WATCH_NAMESPACE` environment variable in `main`. It was not only useless but also introducing part of the bug in tests.

Note the reconcile test cases need to be run on separate processes because they are thread unsafe otherwise. See [CLOUDP-251767: Race conditions within e2e helper code](https://jira.mongodb.org/browse/CLOUDP-251767) for more info, but the gist of it is a AddToScheme being run on each test Kubernetes client initialisation, which clashes with the client event watcher.

Close detail ( T )
Cloud Services
Race conditions within e2e helper code
 
closes #1515 

### All Submissions:

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [X] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if there is one).