### PR TITLE
CLOUDP-251760: Sort regionConfigs to avoid bad diffs

### DIFF
--- a/pkg/controller/atlasdeployment/advanced_deployment.go
+++ b/pkg/controller/atlasdeployment/advanced_deployment.go
@@ -184,7 +184,13 @@ func sortReplicationSpecs(spec akov2.AdvancedDeploymentSpec) akov2.AdvancedDeplo
 	})
 	for _, r := range spec.ReplicationSpecs {
 		slices.SortFunc(r.RegionConfigs, func(a, b *akov2.AdvancedRegionConfig) int {
-			return strings.Compare(a.RegionName, b.RegionName)
+			if !(*a.Priority == *b.Priority) {
+				return *a.Priority - *b.Priority
+			} else if !strings.EqualFold(a.ProviderName, b.ProviderName) {
+				return strings.Compare(a.ProviderName, b.ProviderName)
+			} else {
+				return strings.Compare(a.RegionName, b.RegionName)
+			}
 		})
 	}
 	return spec

--- a/pkg/controller/atlasdeployment/advanced_deployment.go
+++ b/pkg/controller/atlasdeployment/advanced_deployment.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"slices"
 	"strings"
 
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/api"
@@ -171,7 +172,22 @@ func MergedAdvancedDeployment(atlasDeploymentAsAtlas mongodbatlas.AdvancedCluste
 	atlasDeployment.MongoDBVersion = ""
 	mergedDeployment.MongoDBVersion = ""
 
+	atlasDeployment = sortReplicationSpecs(atlasDeployment)
+	mergedDeployment = sortReplicationSpecs(mergedDeployment)
+
 	return
+}
+
+func sortReplicationSpecs(spec akov2.AdvancedDeploymentSpec) akov2.AdvancedDeploymentSpec {
+	slices.SortFunc(spec.ReplicationSpecs, func(a, b *akov2.AdvancedReplicationSpec) int {
+		return strings.Compare(a.ZoneName, b.ZoneName)
+	})
+	for _, r := range spec.ReplicationSpecs {
+		slices.SortFunc(r.RegionConfigs, func(a, b *akov2.AdvancedRegionConfig) int {
+			return strings.Compare(a.RegionName, b.RegionName)
+		})
+	}
+	return spec
 }
 
 func IsFreeTierAdvancedDeployment(deployment *mongodbatlas.AdvancedCluster) bool {

--- a/pkg/controller/atlasdeployment/advanced_deployment_test.go
+++ b/pkg/controller/atlasdeployment/advanced_deployment_test.go
@@ -155,7 +155,25 @@ func TestAdvancedDeploymentsEqual(t *testing.T) {
 				RegionName:   "US_WEST_2",
 			},
 			{
-				ElectableSpecs: &akov2.Specs{
+				ReadOnlySpecs: &akov2.Specs{
+					InstanceSize: "M30",
+					NodeCount:    pointer.MakePtr(2),
+				},
+				Priority:     pointer.MakePtr(0),
+				ProviderName: "GCP",
+				RegionName:   "US_WEST_2",
+			},
+			{
+				AnalyticsSpecs: &akov2.Specs{
+					InstanceSize: "M30",
+					NodeCount:    pointer.MakePtr(2),
+				},
+				Priority:     pointer.MakePtr(0),
+				ProviderName: "AWS",
+				RegionName:   "CA_CENTRAL_1",
+			},
+			{
+				AnalyticsSpecs: &akov2.Specs{
 					InstanceSize: "M10",
 					NodeCount:    pointer.MakePtr(4),
 				},
@@ -163,14 +181,23 @@ func TestAdvancedDeploymentsEqual(t *testing.T) {
 					InstanceSize: "M30",
 					NodeCount:    pointer.MakePtr(2),
 				},
-				Priority:     pointer.MakePtr(5),
+				Priority:     pointer.MakePtr(0),
 				ProviderName: "AWS",
-				RegionName:   "CA_CENTRAL_1",
+				RegionName:   "US_WEST_2",
 			},
 		}
 
 		atlasDeployment := makeDefaultAtlasSpec()
 		atlasDeployment.ReplicationSpecs[0].RegionConfigs = []*mongodbatlas.AdvancedRegionConfig{
+			{
+				AnalyticsSpecs: &mongodbatlas.Specs{
+					InstanceSize: "M30",
+					NodeCount:    pointer.MakePtr(2),
+				},
+				Priority:     pointer.MakePtr(0),
+				ProviderName: "AWS",
+				RegionName:   "CA_CENTRAL_1",
+			},
 			{
 				ElectableSpecs: &mongodbatlas.Specs{
 					InstanceSize: "M10",
@@ -181,7 +208,7 @@ func TestAdvancedDeploymentsEqual(t *testing.T) {
 				RegionName:   "US_EAST_1",
 			},
 			{
-				ElectableSpecs: &mongodbatlas.Specs{
+				AnalyticsSpecs: &mongodbatlas.Specs{
 					InstanceSize: "M10",
 					NodeCount:    pointer.MakePtr(4),
 				},
@@ -189,9 +216,18 @@ func TestAdvancedDeploymentsEqual(t *testing.T) {
 					InstanceSize: "M30",
 					NodeCount:    pointer.MakePtr(2),
 				},
-				Priority:     pointer.MakePtr(5),
+				Priority:     pointer.MakePtr(0),
 				ProviderName: "AWS",
-				RegionName:   "CA_CENTRAL_1",
+				RegionName:   "US_WEST_2",
+			},
+			{
+				ReadOnlySpecs: &mongodbatlas.Specs{
+					InstanceSize: "M30",
+					NodeCount:    pointer.MakePtr(2),
+				},
+				Priority:     pointer.MakePtr(0),
+				ProviderName: "GCP",
+				RegionName:   "US_WEST_2",
 			},
 			{
 				ElectableSpecs: &mongodbatlas.Specs{

--- a/pkg/controller/atlasdeployment/advanced_deployment_test.go
+++ b/pkg/controller/atlasdeployment/advanced_deployment_test.go
@@ -210,7 +210,6 @@ func TestAdvancedDeploymentsEqual(t *testing.T) {
 		logger, _ := zap.NewProduction()
 		areEqual, _ := AdvancedDeploymentsEqual(logger.Sugar(), &merged, &atlas)
 		assert.True(t, areEqual, "Deployments should be the same")
-
 	})
 }
 


### PR DESCRIPTION
Bug from help ticket. This occurs in 2.1 (as reported) and in 2.3/main. This fix just sorts the slices present in the advanced deployment spec to avoid the diff mistakenly finding differences and repeatedly reconciling, spamming PATCH requests to Atlas every ~10s that had no effect.

Replication spec's Zone Name and Region config's Region Name must be unique, so we are safe to sort by them.

### All Submissions:

* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if there is one).
* [ ] Update docs/release-notes/release-notes-template.md if your changes should be included in the release notes for the next release.
