### PR TITLE
CLOUDP-251873: Fix 2.3.0 SBOMs and generation script

### DIFF
--- a/docs/releases/v2.3.0/linux_amd64.sbom.json
+++ b/docs/releases/v2.3.0/linux_amd64.sbom.json
@@ -1,0 +1,3105 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.4",
+  "serialNumber": "urn:uuid:514c5c33-b7f4-438c-b5ea-66ac77083f4c",
+  "version": 1,
+  "metadata": {
+    "timestamp": "2024-06-07T12:14:45+02:00",
+    "tools": [
+      {
+        "vendor": "anchore",
+        "name": "syft",
+        "version": "[not provided]"
+      }
+    ],
+    "component": {
+      "bom-ref": "2fbcaaf9a2c588b",
+      "type": "container",
+      "name": "mongodb/mongodb-atlas-kubernetes-operator:2.3.0@sha256:9755b58aed3ca98958d44eeee3cb491be587478ccd57fa9b768f1bfd7db5db92",
+      "version": "sha256:3aa000415f9becd8619a6872eac7ae2d76c4e1b379c484dbc4af59b8a89d1434"
+    }
+  },
+  "components": [
+    {
+      "type": "library",
+      "name": "github.com/Masterminds/semver",
+      "version": "v1.5.0",
+      "cpe": "cpe:2.3:a:Masterminds:semver:v1.5.0:*:*:*:*:*:*:*",
+      "purl": "pkg:golang/github.com/Masterminds/semver@v1.5.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "GolangBinMetadata"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:b98b42999bb47b0a8d7c6dba4236b00fbf2fc529b66b7ff501e7222bc89c3918"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/manager"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "amd64"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.22.1"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww="
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "github.com/beorn7/perks",
+      "version": "v1.0.1",
+      "cpe": "cpe:2.3:a:beorn7:perks:v1.0.1:*:*:*:*:*:*:*",
+      "purl": "pkg:golang/github.com/beorn7/perks@v1.0.1",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "GolangBinMetadata"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:b98b42999bb47b0a8d7c6dba4236b00fbf2fc529b66b7ff501e7222bc89c3918"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/manager"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "amd64"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.22.1"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM="
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "github.com/cespare/xxhash/v2",
+      "version": "v2.2.0",
+      "cpe": "cpe:2.3:a:cespare:xxhash:v2.2.0:*:*:*:*:*:*:*",
+      "purl": "pkg:golang/github.com/cespare/xxhash/v2@v2.2.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "GolangBinMetadata"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:b98b42999bb47b0a8d7c6dba4236b00fbf2fc529b66b7ff501e7222bc89c3918"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/manager"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "amd64"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.22.1"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44="
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "github.com/davecgh/go-spew",
+      "version": "v1.1.1",
+      "cpe": "cpe:2.3:a:davecgh:go-spew:v1.1.1:*:*:*:*:*:*:*",
+      "purl": "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "GolangBinMetadata"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:davecgh:go_spew:v1.1.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:b98b42999bb47b0a8d7c6dba4236b00fbf2fc529b66b7ff501e7222bc89c3918"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/manager"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "amd64"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.22.1"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c="
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "github.com/emicklei/go-restful/v3",
+      "version": "v3.11.0",
+      "cpe": "cpe:2.3:a:emicklei:go-restful:v3.11.0:*:*:*:*:*:*:*",
+      "purl": "pkg:golang/github.com/emicklei/go-restful/v3@v3.11.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "GolangBinMetadata"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:emicklei:go_restful:v3.11.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:b98b42999bb47b0a8d7c6dba4236b00fbf2fc529b66b7ff501e7222bc89c3918"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/manager"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "amd64"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.22.1"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:rAQeMHw1c7zTmncogyy8VvRZwtkmkZ4FxERmMY4rD+g="
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "github.com/evanphx/json-patch/v5",
+      "version": "v5.8.0",
+      "cpe": "cpe:2.3:a:evanphx:json-patch:v5.8.0:*:*:*:*:*:*:*",
+      "purl": "pkg:golang/github.com/evanphx/json-patch/v5@v5.8.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "GolangBinMetadata"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:evanphx:json_patch:v5.8.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:b98b42999bb47b0a8d7c6dba4236b00fbf2fc529b66b7ff501e7222bc89c3918"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/manager"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "amd64"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.22.1"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:lRj6N9Nci7MvzrXuX6HFzU8XjmhPiXPlsKEy1u0KQro="
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "github.com/fsnotify/fsnotify",
+      "version": "v1.7.0",
+      "cpe": "cpe:2.3:a:fsnotify:fsnotify:v1.7.0:*:*:*:*:*:*:*",
+      "purl": "pkg:golang/github.com/fsnotify/fsnotify@v1.7.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "GolangBinMetadata"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:b98b42999bb47b0a8d7c6dba4236b00fbf2fc529b66b7ff501e7222bc89c3918"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/manager"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "amd64"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.22.1"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA="
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "github.com/go-logr/logr",
+      "version": "v1.4.1",
+      "cpe": "cpe:2.3:a:go-logr:logr:v1.4.1:*:*:*:*:*:*:*",
+      "purl": "pkg:golang/github.com/go-logr/logr@v1.4.1",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "GolangBinMetadata"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:go_logr:logr:v1.4.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:go:logr:v1.4.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:b98b42999bb47b0a8d7c6dba4236b00fbf2fc529b66b7ff501e7222bc89c3918"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/manager"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "amd64"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.22.1"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:pKouT5E8xu9zeFC39JXRDukb6JFQPXM5p5I91188VAQ="
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "github.com/go-logr/zapr",
+      "version": "v1.3.0",
+      "cpe": "cpe:2.3:a:go-logr:zapr:v1.3.0:*:*:*:*:*:*:*",
+      "purl": "pkg:golang/github.com/go-logr/zapr@v1.3.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "GolangBinMetadata"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:go_logr:zapr:v1.3.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:go:zapr:v1.3.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:b98b42999bb47b0a8d7c6dba4236b00fbf2fc529b66b7ff501e7222bc89c3918"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/manager"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "amd64"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.22.1"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:XGdV8XW8zdwFiwOA2Dryh1gj2KRQyOOoNmBy4EplIcQ="
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "github.com/go-openapi/jsonpointer",
+      "version": "v0.19.6",
+      "cpe": "cpe:2.3:a:go-openapi:jsonpointer:v0.19.6:*:*:*:*:*:*:*",
+      "purl": "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.6",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "GolangBinMetadata"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:go_openapi:jsonpointer:v0.19.6:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:go:jsonpointer:v0.19.6:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:b98b42999bb47b0a8d7c6dba4236b00fbf2fc529b66b7ff501e7222bc89c3918"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/manager"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "amd64"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.22.1"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:eCs3fxoIi3Wh6vtgmLTOjdhSpiqphQ+DaPn38N2ZdrE="
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "github.com/go-openapi/jsonreference",
+      "version": "v0.20.2",
+      "cpe": "cpe:2.3:a:go-openapi:jsonreference:v0.20.2:*:*:*:*:*:*:*",
+      "purl": "pkg:golang/github.com/go-openapi/jsonreference@v0.20.2",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "GolangBinMetadata"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:go_openapi:jsonreference:v0.20.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:go:jsonreference:v0.20.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:b98b42999bb47b0a8d7c6dba4236b00fbf2fc529b66b7ff501e7222bc89c3918"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/manager"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "amd64"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.22.1"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:3sVjiK66+uXK/6oQ8xgcRKcFgQ5KXa2KvnJRumpMGbE="
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "github.com/go-openapi/swag",
+      "version": "v0.22.3",
+      "cpe": "cpe:2.3:a:go-openapi:swag:v0.22.3:*:*:*:*:*:*:*",
+      "purl": "pkg:golang/github.com/go-openapi/swag@v0.22.3",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "GolangBinMetadata"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:go_openapi:swag:v0.22.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:go:swag:v0.22.3:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:b98b42999bb47b0a8d7c6dba4236b00fbf2fc529b66b7ff501e7222bc89c3918"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/manager"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "amd64"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.22.1"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:yMBqmnQ0gyZvEb/+KzuWZOXgllrXT4SADYbvDaXHv/g="
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "github.com/gogo/protobuf",
+      "version": "v1.3.2",
+      "cpe": "cpe:2.3:a:gogo:protobuf:v1.3.2:*:*:*:*:*:*:*",
+      "purl": "pkg:golang/github.com/gogo/protobuf@v1.3.2",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "GolangBinMetadata"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:b98b42999bb47b0a8d7c6dba4236b00fbf2fc529b66b7ff501e7222bc89c3918"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/manager"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "amd64"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.22.1"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q="
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "github.com/golang/groupcache",
+      "version": "v0.0.0-20210331224755-41bb18bfe9da",
+      "cpe": "cpe:2.3:a:golang:groupcache:v0.0.0-20210331224755-41bb18bfe9da:*:*:*:*:*:*:*",
+      "purl": "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "GolangBinMetadata"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:b98b42999bb47b0a8d7c6dba4236b00fbf2fc529b66b7ff501e7222bc89c3918"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/manager"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "amd64"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.22.1"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:oI5xCqsCo564l8iNU+DwB5epxmsaqB+rhGL0m5jtYqE="
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "github.com/golang/protobuf",
+      "version": "v1.5.4",
+      "cpe": "cpe:2.3:a:golang:protobuf:v1.5.4:*:*:*:*:*:*:*",
+      "purl": "pkg:golang/github.com/golang/protobuf@v1.5.4",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "GolangBinMetadata"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:b98b42999bb47b0a8d7c6dba4236b00fbf2fc529b66b7ff501e7222bc89c3918"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/manager"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "amd64"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.22.1"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek="
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "github.com/google/gnostic-models",
+      "version": "v0.6.8",
+      "cpe": "cpe:2.3:a:google:gnostic-models:v0.6.8:*:*:*:*:*:*:*",
+      "purl": "pkg:golang/github.com/google/gnostic-models@v0.6.8",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "GolangBinMetadata"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:google:gnostic_models:v0.6.8:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:b98b42999bb47b0a8d7c6dba4236b00fbf2fc529b66b7ff501e7222bc89c3918"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/manager"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "amd64"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.22.1"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:yo/ABAfM5IMRsS1VnXjTBvUb61tFIHozhlYvRgGre9I="
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "github.com/google/go-cmp",
+      "version": "v0.6.0",
+      "cpe": "cpe:2.3:a:google:go-cmp:v0.6.0:*:*:*:*:*:*:*",
+      "purl": "pkg:golang/github.com/google/go-cmp@v0.6.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "GolangBinMetadata"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:google:go_cmp:v0.6.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:b98b42999bb47b0a8d7c6dba4236b00fbf2fc529b66b7ff501e7222bc89c3918"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/manager"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "amd64"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.22.1"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI="
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "github.com/google/go-querystring",
+      "version": "v1.1.0",
+      "cpe": "cpe:2.3:a:google:go-querystring:v1.1.0:*:*:*:*:*:*:*",
+      "purl": "pkg:golang/github.com/google/go-querystring@v1.1.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "GolangBinMetadata"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:google:go_querystring:v1.1.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:b98b42999bb47b0a8d7c6dba4236b00fbf2fc529b66b7ff501e7222bc89c3918"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/manager"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "amd64"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.22.1"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8="
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "github.com/google/gofuzz",
+      "version": "v1.2.0",
+      "cpe": "cpe:2.3:a:google:gofuzz:v1.2.0:*:*:*:*:*:*:*",
+      "purl": "pkg:golang/github.com/google/gofuzz@v1.2.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "GolangBinMetadata"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:b98b42999bb47b0a8d7c6dba4236b00fbf2fc529b66b7ff501e7222bc89c3918"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/manager"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "amd64"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.22.1"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0="
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "github.com/google/uuid",
+      "version": "v1.6.0",
+      "cpe": "cpe:2.3:a:google:uuid:v1.6.0:*:*:*:*:*:*:*",
+      "purl": "pkg:golang/github.com/google/uuid@v1.6.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "GolangBinMetadata"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:b98b42999bb47b0a8d7c6dba4236b00fbf2fc529b66b7ff501e7222bc89c3918"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/manager"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "amd64"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.22.1"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0="
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "github.com/imdario/mergo",
+      "version": "v0.3.12",
+      "cpe": "cpe:2.3:a:imdario:mergo:v0.3.12:*:*:*:*:*:*:*",
+      "purl": "pkg:golang/github.com/imdario/mergo@v0.3.12",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "GolangBinMetadata"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:b98b42999bb47b0a8d7c6dba4236b00fbf2fc529b66b7ff501e7222bc89c3918"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/manager"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "amd64"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.22.1"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU="
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "github.com/josharian/intern",
+      "version": "v1.0.0",
+      "cpe": "cpe:2.3:a:josharian:intern:v1.0.0:*:*:*:*:*:*:*",
+      "purl": "pkg:golang/github.com/josharian/intern@v1.0.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "GolangBinMetadata"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:b98b42999bb47b0a8d7c6dba4236b00fbf2fc529b66b7ff501e7222bc89c3918"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/manager"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "amd64"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.22.1"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY="
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "github.com/json-iterator/go",
+      "version": "v1.1.12",
+      "cpe": "cpe:2.3:a:json-iterator:go:v1.1.12:*:*:*:*:*:*:*",
+      "purl": "pkg:golang/github.com/json-iterator/go@v1.1.12",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "GolangBinMetadata"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:json_iterator:go:v1.1.12:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:json:go:v1.1.12:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:b98b42999bb47b0a8d7c6dba4236b00fbf2fc529b66b7ff501e7222bc89c3918"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/manager"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "amd64"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.22.1"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM="
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "github.com/mailru/easyjson",
+      "version": "v0.7.7",
+      "cpe": "cpe:2.3:a:mailru:easyjson:v0.7.7:*:*:*:*:*:*:*",
+      "purl": "pkg:golang/github.com/mailru/easyjson@v0.7.7",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "GolangBinMetadata"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:b98b42999bb47b0a8d7c6dba4236b00fbf2fc529b66b7ff501e7222bc89c3918"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/manager"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "amd64"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.22.1"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0="
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "github.com/matttproud/golang_protobuf_extensions/v2",
+      "version": "v2.0.0",
+      "cpe": "cpe:2.3:a:matttproud:golang-protobuf-extensions:v2.0.0:*:*:*:*:*:*:*",
+      "purl": "pkg:golang/github.com/matttproud/golang_protobuf_extensions/v2@v2.0.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "GolangBinMetadata"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:matttproud:golang_protobuf_extensions:v2.0.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:b98b42999bb47b0a8d7c6dba4236b00fbf2fc529b66b7ff501e7222bc89c3918"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/manager"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "amd64"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.22.1"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:jWpvCLoY8Z/e3VKvlsiIGKtc+UG6U5vzxaoagmhXfyg="
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "github.com/modern-go/concurrent",
+      "version": "v0.0.0-20180306012644-bacd9c7ef1dd",
+      "cpe": "cpe:2.3:a:modern-go:concurrent:v0.0.0-20180306012644-bacd9c7ef1dd:*:*:*:*:*:*:*",
+      "purl": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "GolangBinMetadata"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:modern_go:concurrent:v0.0.0-20180306012644-bacd9c7ef1dd:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:modern:concurrent:v0.0.0-20180306012644-bacd9c7ef1dd:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:b98b42999bb47b0a8d7c6dba4236b00fbf2fc529b66b7ff501e7222bc89c3918"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/manager"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "amd64"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.22.1"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg="
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "github.com/modern-go/reflect2",
+      "version": "v1.0.2",
+      "cpe": "cpe:2.3:a:modern-go:reflect2:v1.0.2:*:*:*:*:*:*:*",
+      "purl": "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "GolangBinMetadata"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:modern_go:reflect2:v1.0.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:modern:reflect2:v1.0.2:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:b98b42999bb47b0a8d7c6dba4236b00fbf2fc529b66b7ff501e7222bc89c3918"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/manager"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "amd64"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.22.1"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M="
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "github.com/mongodb-forks/digest",
+      "version": "v1.1.0",
+      "cpe": "cpe:2.3:a:mongodb-forks:digest:v1.1.0:*:*:*:*:*:*:*",
+      "purl": "pkg:golang/github.com/mongodb-forks/digest@v1.1.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "GolangBinMetadata"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:mongodb_forks:digest:v1.1.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:mongodb:digest:v1.1.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:b98b42999bb47b0a8d7c6dba4236b00fbf2fc529b66b7ff501e7222bc89c3918"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/manager"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "amd64"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.22.1"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:7eUdsR1BtqLv0mdNm4OXs6ddWvR4X2/OsLwdKksrOoc="
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "github.com/mongodb/mongodb-atlas-kubernetes/v2",
+      "version": "(devel)",
+      "cpe": "cpe:2.3:a:mongodb:mongodb-atlas-kubernetes:\\(devel\\):*:*:*:*:*:*:*",
+      "purl": "pkg:golang/github.com/mongodb/mongodb-atlas-kubernetes/v2@(devel)",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "GolangBinMetadata"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:mongodb:mongodb_atlas_kubernetes:\\(devel\\):*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:b98b42999bb47b0a8d7c6dba4236b00fbf2fc529b66b7ff501e7222bc89c3918"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/manager"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "amd64"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.22.1"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "github.com/munnerz/goautoneg",
+      "version": "v0.0.0-20191010083416-a7dc8b61c822",
+      "cpe": "cpe:2.3:a:munnerz:goautoneg:v0.0.0-20191010083416-a7dc8b61c822:*:*:*:*:*:*:*",
+      "purl": "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "GolangBinMetadata"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:b98b42999bb47b0a8d7c6dba4236b00fbf2fc529b66b7ff501e7222bc89c3918"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/manager"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "amd64"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.22.1"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA="
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "github.com/pkg/errors",
+      "version": "v0.9.1",
+      "cpe": "cpe:2.3:a:pkg:errors:v0.9.1:*:*:*:*:*:*:*",
+      "purl": "pkg:golang/github.com/pkg/errors@v0.9.1",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "GolangBinMetadata"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:b98b42999bb47b0a8d7c6dba4236b00fbf2fc529b66b7ff501e7222bc89c3918"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/manager"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "amd64"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.22.1"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4="
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "github.com/prometheus/client_golang",
+      "version": "v1.18.0",
+      "cpe": "cpe:2.3:a:prometheus:client-golang:v1.18.0:*:*:*:*:*:*:*",
+      "purl": "pkg:golang/github.com/prometheus/client_golang@v1.18.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "GolangBinMetadata"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:prometheus:client_golang:v1.18.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:b98b42999bb47b0a8d7c6dba4236b00fbf2fc529b66b7ff501e7222bc89c3918"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/manager"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "amd64"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.22.1"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:HzFfmkOzH5Q8L8G+kSJKUx5dtG87sewO+FoDDqP5Tbk="
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "github.com/prometheus/client_model",
+      "version": "v0.5.0",
+      "cpe": "cpe:2.3:a:prometheus:client-model:v0.5.0:*:*:*:*:*:*:*",
+      "purl": "pkg:golang/github.com/prometheus/client_model@v0.5.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "GolangBinMetadata"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:prometheus:client_model:v0.5.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:b98b42999bb47b0a8d7c6dba4236b00fbf2fc529b66b7ff501e7222bc89c3918"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/manager"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "amd64"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.22.1"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:VQw1hfvPvk3Uv6Qf29VrPF32JB6rtbgI6cYPYQjL0Qw="
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "github.com/prometheus/common",
+      "version": "v0.45.0",
+      "cpe": "cpe:2.3:a:prometheus:common:v0.45.0:*:*:*:*:*:*:*",
+      "purl": "pkg:golang/github.com/prometheus/common@v0.45.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "GolangBinMetadata"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:b98b42999bb47b0a8d7c6dba4236b00fbf2fc529b66b7ff501e7222bc89c3918"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/manager"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "amd64"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.22.1"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:2BGz0eBc2hdMDLnO/8n0jeB3oPrt2D08CekT0lneoxM="
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "github.com/prometheus/procfs",
+      "version": "v0.12.0",
+      "cpe": "cpe:2.3:a:prometheus:procfs:v0.12.0:*:*:*:*:*:*:*",
+      "purl": "pkg:golang/github.com/prometheus/procfs@v0.12.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "GolangBinMetadata"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:b98b42999bb47b0a8d7c6dba4236b00fbf2fc529b66b7ff501e7222bc89c3918"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/manager"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "amd64"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.22.1"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:jluTpSng7V9hY0O2R9DzzJHYb2xULk9VTR1V1R/k6Bo="
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "github.com/spf13/pflag",
+      "version": "v1.0.5",
+      "cpe": "cpe:2.3:a:spf13:pflag:v1.0.5:*:*:*:*:*:*:*",
+      "purl": "pkg:golang/github.com/spf13/pflag@v1.0.5",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "GolangBinMetadata"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:b98b42999bb47b0a8d7c6dba4236b00fbf2fc529b66b7ff501e7222bc89c3918"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/manager"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "amd64"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.22.1"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA="
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "go.mongodb.org/atlas",
+      "version": "v0.36.0",
+      "purl": "pkg:golang/go.mongodb.org/atlas@v0.36.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "GolangBinMetadata"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:b98b42999bb47b0a8d7c6dba4236b00fbf2fc529b66b7ff501e7222bc89c3918"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/manager"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "amd64"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.22.1"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:m05S3AO7zkl+bcG1qaNsEKBnAqnKx2FDwLooHpIG3j4="
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "go.mongodb.org/atlas-sdk/v20231115008",
+      "version": "v20231115008.5.0",
+      "cpe": "cpe:2.3:a:atlas-sdk:v20231115008:v20231115008.5.0:*:*:*:*:*:*:*",
+      "purl": "pkg:golang/go.mongodb.org/atlas-sdk/v20231115008@v20231115008.5.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "GolangBinMetadata"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:atlas_sdk:v20231115008:v20231115008.5.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:atlas:v20231115008:v20231115008.5.0:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:b98b42999bb47b0a8d7c6dba4236b00fbf2fc529b66b7ff501e7222bc89c3918"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/manager"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "amd64"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.22.1"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:OuV1HfIpZUZa4+BKvtrvDlNqnilkCkdHspuZok6KAbM="
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "go.uber.org/multierr",
+      "version": "v1.11.0",
+      "purl": "pkg:golang/go.uber.org/multierr@v1.11.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "GolangBinMetadata"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:b98b42999bb47b0a8d7c6dba4236b00fbf2fc529b66b7ff501e7222bc89c3918"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/manager"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "amd64"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.22.1"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0="
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "go.uber.org/zap",
+      "version": "v1.27.0",
+      "purl": "pkg:golang/go.uber.org/zap@v1.27.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "GolangBinMetadata"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:b98b42999bb47b0a8d7c6dba4236b00fbf2fc529b66b7ff501e7222bc89c3918"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/manager"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "amd64"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.22.1"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:aJMhYGrd5QSmlpLMr2MftRKl7t8J8PTZPA732ud/XR8="
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "golang.org/x/exp",
+      "version": "v0.0.0-20230522175609-2e198f4a06a1",
+      "cpe": "cpe:2.3:a:golang:x\\/exp:v0.0.0-20230522175609-2e198f4a06a1:*:*:*:*:*:*:*",
+      "purl": "pkg:golang/golang.org/x/exp@v0.0.0-20230522175609-2e198f4a06a1",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "GolangBinMetadata"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:b98b42999bb47b0a8d7c6dba4236b00fbf2fc529b66b7ff501e7222bc89c3918"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/manager"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "amd64"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.22.1"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:k/i9J1pBpvlfR+9QsetwPyERsqu1GIbi967PQMq3Ivc="
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "golang.org/x/net",
+      "version": "v0.24.0",
+      "cpe": "cpe:2.3:a:golang:x\\/net:v0.24.0:*:*:*:*:*:*:*",
+      "purl": "pkg:golang/golang.org/x/net@v0.24.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "GolangBinMetadata"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:b98b42999bb47b0a8d7c6dba4236b00fbf2fc529b66b7ff501e7222bc89c3918"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/manager"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "amd64"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.22.1"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:1PcaxkF854Fu3+lvBIx5SYn9wRlBzzcnHZSiaFFAb0w="
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "golang.org/x/oauth2",
+      "version": "v0.19.0",
+      "cpe": "cpe:2.3:a:golang:x\\/oauth2:v0.19.0:*:*:*:*:*:*:*",
+      "purl": "pkg:golang/golang.org/x/oauth2@v0.19.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "GolangBinMetadata"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:b98b42999bb47b0a8d7c6dba4236b00fbf2fc529b66b7ff501e7222bc89c3918"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/manager"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "amd64"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.22.1"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:9+E/EZBCbTLNrbN35fHv/a/d/mOBatymz1zbtQrXpIg="
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "golang.org/x/sync",
+      "version": "v0.7.0",
+      "cpe": "cpe:2.3:a:golang:x\\/sync:v0.7.0:*:*:*:*:*:*:*",
+      "purl": "pkg:golang/golang.org/x/sync@v0.7.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "GolangBinMetadata"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:b98b42999bb47b0a8d7c6dba4236b00fbf2fc529b66b7ff501e7222bc89c3918"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/manager"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "amd64"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.22.1"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:YsImfSBoP9QPYL0xyKJPq0gcaJdG3rInoqxTWbfQu9M="
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "golang.org/x/sys",
+      "version": "v0.19.0",
+      "cpe": "cpe:2.3:a:golang:x\\/sys:v0.19.0:*:*:*:*:*:*:*",
+      "purl": "pkg:golang/golang.org/x/sys@v0.19.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "GolangBinMetadata"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:b98b42999bb47b0a8d7c6dba4236b00fbf2fc529b66b7ff501e7222bc89c3918"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/manager"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "amd64"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.22.1"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:q5f1RH2jigJ1MoAWp2KTp3gm5zAGFUTarQZ5U386+4o="
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "golang.org/x/term",
+      "version": "v0.19.0",
+      "cpe": "cpe:2.3:a:golang:x\\/term:v0.19.0:*:*:*:*:*:*:*",
+      "purl": "pkg:golang/golang.org/x/term@v0.19.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "GolangBinMetadata"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:b98b42999bb47b0a8d7c6dba4236b00fbf2fc529b66b7ff501e7222bc89c3918"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/manager"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "amd64"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.22.1"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:+ThwsDv+tYfnJFhF4L8jITxu1tdTWRTZpdsWgEgjL6Q="
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "golang.org/x/text",
+      "version": "v0.14.0",
+      "cpe": "cpe:2.3:a:golang:x\\/text:v0.14.0:*:*:*:*:*:*:*",
+      "purl": "pkg:golang/golang.org/x/text@v0.14.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "GolangBinMetadata"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:b98b42999bb47b0a8d7c6dba4236b00fbf2fc529b66b7ff501e7222bc89c3918"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/manager"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "amd64"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.22.1"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ="
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "golang.org/x/time",
+      "version": "v0.5.0",
+      "cpe": "cpe:2.3:a:golang:x\\/time:v0.5.0:*:*:*:*:*:*:*",
+      "purl": "pkg:golang/golang.org/x/time@v0.5.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "GolangBinMetadata"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:b98b42999bb47b0a8d7c6dba4236b00fbf2fc529b66b7ff501e7222bc89c3918"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/manager"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "amd64"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.22.1"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:o7cqy6amK/52YcAKIPlM3a+Fpj35zvRj2TP+e1xFSfk="
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "gomodules.xyz/jsonpatch/v2",
+      "version": "v2.4.0",
+      "cpe": "cpe:2.3:a:jsonpatch:v2:v2.4.0:*:*:*:*:*:*:*",
+      "purl": "pkg:golang/gomodules.xyz/jsonpatch/v2@v2.4.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "GolangBinMetadata"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:b98b42999bb47b0a8d7c6dba4236b00fbf2fc529b66b7ff501e7222bc89c3918"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/manager"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "amd64"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.22.1"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:Ci3iUJyx9UeRx7CeFN8ARgGbkESwJK+KB9lLcWxY/Zw="
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "google.golang.org/protobuf",
+      "version": "v1.33.0",
+      "cpe": "cpe:2.3:a:google:protobuf:v1.33.0:*:*:*:*:*:*:*",
+      "purl": "pkg:golang/google.golang.org/protobuf@v1.33.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "GolangBinMetadata"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:b98b42999bb47b0a8d7c6dba4236b00fbf2fc529b66b7ff501e7222bc89c3918"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/manager"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "amd64"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.22.1"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI="
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "gopkg.in/inf.v0",
+      "version": "v0.9.1",
+      "purl": "pkg:golang/gopkg.in/inf.v0@v0.9.1",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "GolangBinMetadata"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:b98b42999bb47b0a8d7c6dba4236b00fbf2fc529b66b7ff501e7222bc89c3918"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/manager"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "amd64"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.22.1"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc="
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "gopkg.in/yaml.v2",
+      "version": "v2.4.0",
+      "purl": "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "GolangBinMetadata"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:b98b42999bb47b0a8d7c6dba4236b00fbf2fc529b66b7ff501e7222bc89c3918"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/manager"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "amd64"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.22.1"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY="
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "gopkg.in/yaml.v3",
+      "version": "v3.0.1",
+      "purl": "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "GolangBinMetadata"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:b98b42999bb47b0a8d7c6dba4236b00fbf2fc529b66b7ff501e7222bc89c3918"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/manager"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "amd64"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.22.1"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA="
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "k8s.io/api",
+      "version": "v0.30.0",
+      "purl": "pkg:golang/k8s.io/api@v0.30.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "GolangBinMetadata"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:b98b42999bb47b0a8d7c6dba4236b00fbf2fc529b66b7ff501e7222bc89c3918"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/manager"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "amd64"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.22.1"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:siWhRq7cNjy2iHssOB9SCGNCl2spiF1dO3dABqZ8niA="
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "k8s.io/apiextensions-apiserver",
+      "version": "v0.29.2",
+      "purl": "pkg:golang/k8s.io/apiextensions-apiserver@v0.29.2",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "GolangBinMetadata"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:b98b42999bb47b0a8d7c6dba4236b00fbf2fc529b66b7ff501e7222bc89c3918"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/manager"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "amd64"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.22.1"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:UK3xB5lOWSnhaCk0RFZ0LUacPZz9RY4wi/yt2Iu+btg="
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "k8s.io/apimachinery",
+      "version": "v0.30.0",
+      "purl": "pkg:golang/k8s.io/apimachinery@v0.30.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "GolangBinMetadata"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:b98b42999bb47b0a8d7c6dba4236b00fbf2fc529b66b7ff501e7222bc89c3918"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/manager"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "amd64"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.22.1"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:qxVPsyDM5XS96NIh9Oj6LavoVFYff/Pon9cZeDIkHHA="
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "k8s.io/client-go",
+      "version": "v0.29.2",
+      "purl": "pkg:golang/k8s.io/client-go@v0.29.2",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "GolangBinMetadata"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:b98b42999bb47b0a8d7c6dba4236b00fbf2fc529b66b7ff501e7222bc89c3918"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/manager"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "amd64"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.22.1"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:FEg85el1TeZp+/vYJM7hkDlSTFZ+c5nnK44DJ4FyoRg="
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "k8s.io/component-base",
+      "version": "v0.29.2",
+      "purl": "pkg:golang/k8s.io/component-base@v0.29.2",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "GolangBinMetadata"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:b98b42999bb47b0a8d7c6dba4236b00fbf2fc529b66b7ff501e7222bc89c3918"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/manager"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "amd64"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.22.1"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:lpiLyuvPA9yV1aQwGLENYyK7n/8t6l3nn3zAtFTJYe8="
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "k8s.io/klog/v2",
+      "version": "v2.120.1",
+      "cpe": "cpe:2.3:a:klog:v2:v2.120.1:*:*:*:*:*:*:*",
+      "purl": "pkg:golang/k8s.io/klog/v2@v2.120.1",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "GolangBinMetadata"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:b98b42999bb47b0a8d7c6dba4236b00fbf2fc529b66b7ff501e7222bc89c3918"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/manager"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "amd64"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.22.1"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:QXU6cPEOIslTGvZaXvFWiP9VKyeet3sawzTOvdXb4Vw="
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "k8s.io/kube-openapi",
+      "version": "v0.0.0-20240228011516-70dd3763d340",
+      "purl": "pkg:golang/k8s.io/kube-openapi@v0.0.0-20240228011516-70dd3763d340",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "GolangBinMetadata"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:b98b42999bb47b0a8d7c6dba4236b00fbf2fc529b66b7ff501e7222bc89c3918"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/manager"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "amd64"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.22.1"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:BZqlfIlq5YbRMFko6/PM7FjZpUb45WallggurYhKGag="
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "k8s.io/utils",
+      "version": "v0.0.0-20230726121419-3b25d923346b",
+      "purl": "pkg:golang/k8s.io/utils@v0.0.0-20230726121419-3b25d923346b",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "GolangBinMetadata"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:b98b42999bb47b0a8d7c6dba4236b00fbf2fc529b66b7ff501e7222bc89c3918"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/manager"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "amd64"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.22.1"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:sgn3ZU783SCgtaSJjpcVVlRqd6GSnlTLKgpAAttJvpI="
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "sigs.k8s.io/controller-runtime",
+      "version": "v0.17.3",
+      "purl": "pkg:golang/sigs.k8s.io/controller-runtime@v0.17.3",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "GolangBinMetadata"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:b98b42999bb47b0a8d7c6dba4236b00fbf2fc529b66b7ff501e7222bc89c3918"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/manager"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "amd64"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.22.1"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:65QmN7r3FWgTxDMz9fvGnO1kbf2nu+acg9p2R9oYYYk="
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "sigs.k8s.io/json",
+      "version": "v0.0.0-20221116044647-bc3834ca7abd",
+      "purl": "pkg:golang/sigs.k8s.io/json@v0.0.0-20221116044647-bc3834ca7abd",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "GolangBinMetadata"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:b98b42999bb47b0a8d7c6dba4236b00fbf2fc529b66b7ff501e7222bc89c3918"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/manager"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "amd64"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.22.1"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:EDPBXCAspyGV4jQlpZSudPeMmr1bNJefnuqLsRAsHZo="
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "sigs.k8s.io/structured-merge-diff/v4",
+      "version": "v4.4.1",
+      "cpe": "cpe:2.3:a:structured-merge-diff:v4:v4.4.1:*:*:*:*:*:*:*",
+      "purl": "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.4.1",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "GolangBinMetadata"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:structured_merge_diff:v4:v4.4.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:structured-merge:v4:v4.4.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:structured_merge:v4:v4.4.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:cpe23",
+          "value": "cpe:2.3:a:structured:v4:v4.4.1:*:*:*:*:*:*:*"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:b98b42999bb47b0a8d7c6dba4236b00fbf2fc529b66b7ff501e7222bc89c3918"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/manager"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "amd64"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.22.1"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:150L+0vs/8DA78h1u02ooW1/fFq/Lwr+sGiqlzvrtq4="
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "sigs.k8s.io/yaml",
+      "version": "v1.4.0",
+      "purl": "pkg:golang/sigs.k8s.io/yaml@v1.4.0",
+      "properties": [
+        {
+          "name": "syft:package:foundBy",
+          "value": "go-module-binary-cataloger"
+        },
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:metadataType",
+          "value": "GolangBinMetadata"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        },
+        {
+          "name": "syft:location:0:layerID",
+          "value": "sha256:b98b42999bb47b0a8d7c6dba4236b00fbf2fc529b66b7ff501e7222bc89c3918"
+        },
+        {
+          "name": "syft:location:0:path",
+          "value": "/manager"
+        },
+        {
+          "name": "syft:metadata:architecture",
+          "value": "amd64"
+        },
+        {
+          "name": "syft:metadata:goCompiledVersion",
+          "value": "go1.22.1"
+        },
+        {
+          "name": "syft:metadata:h1Digest",
+          "value": "h1:Mk1wCc2gy/F0THH0TAp1QYyJNzRm2KCLy3o5ASXVI5E="
+        }
+      ]
+    },
+    {
+      "type": "operating-system",
+      "name": "rhel",
+      "version": "9.2",
+      "description": "Red Hat Enterprise Linux 9.2 (Plow)",
+      "cpe": "cpe:/o:redhat:enterprise_linux:9::baseos",
+      "swid": {
+        "tagId": "rhel",
+        "name": "rhel",
+        "version": "9.2"
+      },
+      "externalReferences": [
+        {
+          "url": "https://bugzilla.redhat.com/",
+          "type": "issue-tracker"
+        },
+        {
+          "url": "https://www.redhat.com/",
+          "type": "website"
+        }
+      ],
+      "properties": [
+        {
+          "name": "syft:distro:id",
+          "value": "rhel"
+        },
+        {
+          "name": "syft:distro:idLike:0",
+          "value": "fedora"
+        },
+        {
+          "name": "syft:distro:prettyName",
+          "value": "Red Hat Enterprise Linux 9.2 (Plow)"
+        },
+        {
+          "name": "syft:distro:versionID",
+          "value": "9.2"
+        }
+      ]
+    }
+  ]
+}

--- a/docs/releases/v2.3.0/linux_arm64.sbom.json
+++ b/docs/releases/v2.3.0/linux_arm64.sbom.json
@@ -1,10 +1,10 @@
 {
   "bomFormat": "CycloneDX",
   "specVersion": "1.4",
-  "serialNumber": "urn:uuid:6381326d-8bed-4060-b655-df82cccd3e70",
+  "serialNumber": "urn:uuid:dee5714f-fbcc-4601-b976-aa95db091ec6",
   "version": 1,
   "metadata": {
-    "timestamp": "2024-06-06T09:15:52+02:00",
+    "timestamp": "2024-06-07T12:14:36+02:00",
     "tools": [
       {
         "vendor": "anchore",
@@ -13,10 +13,10 @@
       }
     ],
     "component": {
-      "bom-ref": "1be44a63dfedb15d",
+      "bom-ref": "e72759fd06e1b023",
       "type": "container",
-      "name": "mongodb/mongodb-atlas-kubernetes-operator:2.3.0",
-      "version": "sha256:6cc6abb7916dc0c4f0f4ef743ad0a65484bf5cf093b1098235479cbc4c253f6a"
+      "name": "mongodb/mongodb-atlas-kubernetes-operator:2.3.0@sha256:040064b4c0c3822213635135c38c162ab099a40594104f5131f03907005a842b",
+      "version": "sha256:28e3400f0c31bc844c1c267d30978fc95405a897a84decd0ec28393e80a4470f"
     }
   },
   "components": [
@@ -45,7 +45,7 @@
         },
         {
           "name": "syft:location:0:layerID",
-          "value": "sha256:4714905109f08e13428fd32e6811b61bcd5fd3cb23ba3f7e2fd73b7f45079ca6"
+          "value": "sha256:ca22e46e6b3bf5be8466b0068d8a9f0db9ff84eab39822b3b5d69e7dbc5cd3c3"
         },
         {
           "name": "syft:location:0:path",
@@ -90,7 +90,7 @@
         },
         {
           "name": "syft:location:0:layerID",
-          "value": "sha256:4714905109f08e13428fd32e6811b61bcd5fd3cb23ba3f7e2fd73b7f45079ca6"
+          "value": "sha256:ca22e46e6b3bf5be8466b0068d8a9f0db9ff84eab39822b3b5d69e7dbc5cd3c3"
         },
         {
           "name": "syft:location:0:path",
@@ -135,7 +135,7 @@
         },
         {
           "name": "syft:location:0:layerID",
-          "value": "sha256:4714905109f08e13428fd32e6811b61bcd5fd3cb23ba3f7e2fd73b7f45079ca6"
+          "value": "sha256:ca22e46e6b3bf5be8466b0068d8a9f0db9ff84eab39822b3b5d69e7dbc5cd3c3"
         },
         {
           "name": "syft:location:0:path",
@@ -184,7 +184,7 @@
         },
         {
           "name": "syft:location:0:layerID",
-          "value": "sha256:4714905109f08e13428fd32e6811b61bcd5fd3cb23ba3f7e2fd73b7f45079ca6"
+          "value": "sha256:ca22e46e6b3bf5be8466b0068d8a9f0db9ff84eab39822b3b5d69e7dbc5cd3c3"
         },
         {
           "name": "syft:location:0:path",
@@ -233,7 +233,7 @@
         },
         {
           "name": "syft:location:0:layerID",
-          "value": "sha256:4714905109f08e13428fd32e6811b61bcd5fd3cb23ba3f7e2fd73b7f45079ca6"
+          "value": "sha256:ca22e46e6b3bf5be8466b0068d8a9f0db9ff84eab39822b3b5d69e7dbc5cd3c3"
         },
         {
           "name": "syft:location:0:path",
@@ -282,7 +282,7 @@
         },
         {
           "name": "syft:location:0:layerID",
-          "value": "sha256:4714905109f08e13428fd32e6811b61bcd5fd3cb23ba3f7e2fd73b7f45079ca6"
+          "value": "sha256:ca22e46e6b3bf5be8466b0068d8a9f0db9ff84eab39822b3b5d69e7dbc5cd3c3"
         },
         {
           "name": "syft:location:0:path",
@@ -327,7 +327,7 @@
         },
         {
           "name": "syft:location:0:layerID",
-          "value": "sha256:4714905109f08e13428fd32e6811b61bcd5fd3cb23ba3f7e2fd73b7f45079ca6"
+          "value": "sha256:ca22e46e6b3bf5be8466b0068d8a9f0db9ff84eab39822b3b5d69e7dbc5cd3c3"
         },
         {
           "name": "syft:location:0:path",
@@ -380,7 +380,7 @@
         },
         {
           "name": "syft:location:0:layerID",
-          "value": "sha256:4714905109f08e13428fd32e6811b61bcd5fd3cb23ba3f7e2fd73b7f45079ca6"
+          "value": "sha256:ca22e46e6b3bf5be8466b0068d8a9f0db9ff84eab39822b3b5d69e7dbc5cd3c3"
         },
         {
           "name": "syft:location:0:path",
@@ -433,7 +433,7 @@
         },
         {
           "name": "syft:location:0:layerID",
-          "value": "sha256:4714905109f08e13428fd32e6811b61bcd5fd3cb23ba3f7e2fd73b7f45079ca6"
+          "value": "sha256:ca22e46e6b3bf5be8466b0068d8a9f0db9ff84eab39822b3b5d69e7dbc5cd3c3"
         },
         {
           "name": "syft:location:0:path",
@@ -486,7 +486,7 @@
         },
         {
           "name": "syft:location:0:layerID",
-          "value": "sha256:4714905109f08e13428fd32e6811b61bcd5fd3cb23ba3f7e2fd73b7f45079ca6"
+          "value": "sha256:ca22e46e6b3bf5be8466b0068d8a9f0db9ff84eab39822b3b5d69e7dbc5cd3c3"
         },
         {
           "name": "syft:location:0:path",
@@ -539,7 +539,7 @@
         },
         {
           "name": "syft:location:0:layerID",
-          "value": "sha256:4714905109f08e13428fd32e6811b61bcd5fd3cb23ba3f7e2fd73b7f45079ca6"
+          "value": "sha256:ca22e46e6b3bf5be8466b0068d8a9f0db9ff84eab39822b3b5d69e7dbc5cd3c3"
         },
         {
           "name": "syft:location:0:path",
@@ -592,7 +592,7 @@
         },
         {
           "name": "syft:location:0:layerID",
-          "value": "sha256:4714905109f08e13428fd32e6811b61bcd5fd3cb23ba3f7e2fd73b7f45079ca6"
+          "value": "sha256:ca22e46e6b3bf5be8466b0068d8a9f0db9ff84eab39822b3b5d69e7dbc5cd3c3"
         },
         {
           "name": "syft:location:0:path",
@@ -637,7 +637,7 @@
         },
         {
           "name": "syft:location:0:layerID",
-          "value": "sha256:4714905109f08e13428fd32e6811b61bcd5fd3cb23ba3f7e2fd73b7f45079ca6"
+          "value": "sha256:ca22e46e6b3bf5be8466b0068d8a9f0db9ff84eab39822b3b5d69e7dbc5cd3c3"
         },
         {
           "name": "syft:location:0:path",
@@ -682,7 +682,7 @@
         },
         {
           "name": "syft:location:0:layerID",
-          "value": "sha256:4714905109f08e13428fd32e6811b61bcd5fd3cb23ba3f7e2fd73b7f45079ca6"
+          "value": "sha256:ca22e46e6b3bf5be8466b0068d8a9f0db9ff84eab39822b3b5d69e7dbc5cd3c3"
         },
         {
           "name": "syft:location:0:path",
@@ -727,7 +727,7 @@
         },
         {
           "name": "syft:location:0:layerID",
-          "value": "sha256:4714905109f08e13428fd32e6811b61bcd5fd3cb23ba3f7e2fd73b7f45079ca6"
+          "value": "sha256:ca22e46e6b3bf5be8466b0068d8a9f0db9ff84eab39822b3b5d69e7dbc5cd3c3"
         },
         {
           "name": "syft:location:0:path",
@@ -776,7 +776,7 @@
         },
         {
           "name": "syft:location:0:layerID",
-          "value": "sha256:4714905109f08e13428fd32e6811b61bcd5fd3cb23ba3f7e2fd73b7f45079ca6"
+          "value": "sha256:ca22e46e6b3bf5be8466b0068d8a9f0db9ff84eab39822b3b5d69e7dbc5cd3c3"
         },
         {
           "name": "syft:location:0:path",
@@ -825,7 +825,7 @@
         },
         {
           "name": "syft:location:0:layerID",
-          "value": "sha256:4714905109f08e13428fd32e6811b61bcd5fd3cb23ba3f7e2fd73b7f45079ca6"
+          "value": "sha256:ca22e46e6b3bf5be8466b0068d8a9f0db9ff84eab39822b3b5d69e7dbc5cd3c3"
         },
         {
           "name": "syft:location:0:path",
@@ -874,7 +874,7 @@
         },
         {
           "name": "syft:location:0:layerID",
-          "value": "sha256:4714905109f08e13428fd32e6811b61bcd5fd3cb23ba3f7e2fd73b7f45079ca6"
+          "value": "sha256:ca22e46e6b3bf5be8466b0068d8a9f0db9ff84eab39822b3b5d69e7dbc5cd3c3"
         },
         {
           "name": "syft:location:0:path",
@@ -919,7 +919,7 @@
         },
         {
           "name": "syft:location:0:layerID",
-          "value": "sha256:4714905109f08e13428fd32e6811b61bcd5fd3cb23ba3f7e2fd73b7f45079ca6"
+          "value": "sha256:ca22e46e6b3bf5be8466b0068d8a9f0db9ff84eab39822b3b5d69e7dbc5cd3c3"
         },
         {
           "name": "syft:location:0:path",
@@ -964,7 +964,7 @@
         },
         {
           "name": "syft:location:0:layerID",
-          "value": "sha256:4714905109f08e13428fd32e6811b61bcd5fd3cb23ba3f7e2fd73b7f45079ca6"
+          "value": "sha256:ca22e46e6b3bf5be8466b0068d8a9f0db9ff84eab39822b3b5d69e7dbc5cd3c3"
         },
         {
           "name": "syft:location:0:path",
@@ -1009,7 +1009,7 @@
         },
         {
           "name": "syft:location:0:layerID",
-          "value": "sha256:4714905109f08e13428fd32e6811b61bcd5fd3cb23ba3f7e2fd73b7f45079ca6"
+          "value": "sha256:ca22e46e6b3bf5be8466b0068d8a9f0db9ff84eab39822b3b5d69e7dbc5cd3c3"
         },
         {
           "name": "syft:location:0:path",
@@ -1054,7 +1054,7 @@
         },
         {
           "name": "syft:location:0:layerID",
-          "value": "sha256:4714905109f08e13428fd32e6811b61bcd5fd3cb23ba3f7e2fd73b7f45079ca6"
+          "value": "sha256:ca22e46e6b3bf5be8466b0068d8a9f0db9ff84eab39822b3b5d69e7dbc5cd3c3"
         },
         {
           "name": "syft:location:0:path",
@@ -1107,7 +1107,7 @@
         },
         {
           "name": "syft:location:0:layerID",
-          "value": "sha256:4714905109f08e13428fd32e6811b61bcd5fd3cb23ba3f7e2fd73b7f45079ca6"
+          "value": "sha256:ca22e46e6b3bf5be8466b0068d8a9f0db9ff84eab39822b3b5d69e7dbc5cd3c3"
         },
         {
           "name": "syft:location:0:path",
@@ -1152,7 +1152,7 @@
         },
         {
           "name": "syft:location:0:layerID",
-          "value": "sha256:4714905109f08e13428fd32e6811b61bcd5fd3cb23ba3f7e2fd73b7f45079ca6"
+          "value": "sha256:ca22e46e6b3bf5be8466b0068d8a9f0db9ff84eab39822b3b5d69e7dbc5cd3c3"
         },
         {
           "name": "syft:location:0:path",
@@ -1201,7 +1201,7 @@
         },
         {
           "name": "syft:location:0:layerID",
-          "value": "sha256:4714905109f08e13428fd32e6811b61bcd5fd3cb23ba3f7e2fd73b7f45079ca6"
+          "value": "sha256:ca22e46e6b3bf5be8466b0068d8a9f0db9ff84eab39822b3b5d69e7dbc5cd3c3"
         },
         {
           "name": "syft:location:0:path",
@@ -1254,7 +1254,7 @@
         },
         {
           "name": "syft:location:0:layerID",
-          "value": "sha256:4714905109f08e13428fd32e6811b61bcd5fd3cb23ba3f7e2fd73b7f45079ca6"
+          "value": "sha256:ca22e46e6b3bf5be8466b0068d8a9f0db9ff84eab39822b3b5d69e7dbc5cd3c3"
         },
         {
           "name": "syft:location:0:path",
@@ -1307,7 +1307,7 @@
         },
         {
           "name": "syft:location:0:layerID",
-          "value": "sha256:4714905109f08e13428fd32e6811b61bcd5fd3cb23ba3f7e2fd73b7f45079ca6"
+          "value": "sha256:ca22e46e6b3bf5be8466b0068d8a9f0db9ff84eab39822b3b5d69e7dbc5cd3c3"
         },
         {
           "name": "syft:location:0:path",
@@ -1360,7 +1360,7 @@
         },
         {
           "name": "syft:location:0:layerID",
-          "value": "sha256:4714905109f08e13428fd32e6811b61bcd5fd3cb23ba3f7e2fd73b7f45079ca6"
+          "value": "sha256:ca22e46e6b3bf5be8466b0068d8a9f0db9ff84eab39822b3b5d69e7dbc5cd3c3"
         },
         {
           "name": "syft:location:0:path",
@@ -1409,7 +1409,7 @@
         },
         {
           "name": "syft:location:0:layerID",
-          "value": "sha256:4714905109f08e13428fd32e6811b61bcd5fd3cb23ba3f7e2fd73b7f45079ca6"
+          "value": "sha256:ca22e46e6b3bf5be8466b0068d8a9f0db9ff84eab39822b3b5d69e7dbc5cd3c3"
         },
         {
           "name": "syft:location:0:path",
@@ -1450,7 +1450,7 @@
         },
         {
           "name": "syft:location:0:layerID",
-          "value": "sha256:4714905109f08e13428fd32e6811b61bcd5fd3cb23ba3f7e2fd73b7f45079ca6"
+          "value": "sha256:ca22e46e6b3bf5be8466b0068d8a9f0db9ff84eab39822b3b5d69e7dbc5cd3c3"
         },
         {
           "name": "syft:location:0:path",
@@ -1495,7 +1495,7 @@
         },
         {
           "name": "syft:location:0:layerID",
-          "value": "sha256:4714905109f08e13428fd32e6811b61bcd5fd3cb23ba3f7e2fd73b7f45079ca6"
+          "value": "sha256:ca22e46e6b3bf5be8466b0068d8a9f0db9ff84eab39822b3b5d69e7dbc5cd3c3"
         },
         {
           "name": "syft:location:0:path",
@@ -1544,7 +1544,7 @@
         },
         {
           "name": "syft:location:0:layerID",
-          "value": "sha256:4714905109f08e13428fd32e6811b61bcd5fd3cb23ba3f7e2fd73b7f45079ca6"
+          "value": "sha256:ca22e46e6b3bf5be8466b0068d8a9f0db9ff84eab39822b3b5d69e7dbc5cd3c3"
         },
         {
           "name": "syft:location:0:path",
@@ -1593,7 +1593,7 @@
         },
         {
           "name": "syft:location:0:layerID",
-          "value": "sha256:4714905109f08e13428fd32e6811b61bcd5fd3cb23ba3f7e2fd73b7f45079ca6"
+          "value": "sha256:ca22e46e6b3bf5be8466b0068d8a9f0db9ff84eab39822b3b5d69e7dbc5cd3c3"
         },
         {
           "name": "syft:location:0:path",
@@ -1638,7 +1638,7 @@
         },
         {
           "name": "syft:location:0:layerID",
-          "value": "sha256:4714905109f08e13428fd32e6811b61bcd5fd3cb23ba3f7e2fd73b7f45079ca6"
+          "value": "sha256:ca22e46e6b3bf5be8466b0068d8a9f0db9ff84eab39822b3b5d69e7dbc5cd3c3"
         },
         {
           "name": "syft:location:0:path",
@@ -1683,7 +1683,7 @@
         },
         {
           "name": "syft:location:0:layerID",
-          "value": "sha256:4714905109f08e13428fd32e6811b61bcd5fd3cb23ba3f7e2fd73b7f45079ca6"
+          "value": "sha256:ca22e46e6b3bf5be8466b0068d8a9f0db9ff84eab39822b3b5d69e7dbc5cd3c3"
         },
         {
           "name": "syft:location:0:path",
@@ -1728,7 +1728,7 @@
         },
         {
           "name": "syft:location:0:layerID",
-          "value": "sha256:4714905109f08e13428fd32e6811b61bcd5fd3cb23ba3f7e2fd73b7f45079ca6"
+          "value": "sha256:ca22e46e6b3bf5be8466b0068d8a9f0db9ff84eab39822b3b5d69e7dbc5cd3c3"
         },
         {
           "name": "syft:location:0:path",
@@ -1772,7 +1772,7 @@
         },
         {
           "name": "syft:location:0:layerID",
-          "value": "sha256:4714905109f08e13428fd32e6811b61bcd5fd3cb23ba3f7e2fd73b7f45079ca6"
+          "value": "sha256:ca22e46e6b3bf5be8466b0068d8a9f0db9ff84eab39822b3b5d69e7dbc5cd3c3"
         },
         {
           "name": "syft:location:0:path",
@@ -1825,7 +1825,7 @@
         },
         {
           "name": "syft:location:0:layerID",
-          "value": "sha256:4714905109f08e13428fd32e6811b61bcd5fd3cb23ba3f7e2fd73b7f45079ca6"
+          "value": "sha256:ca22e46e6b3bf5be8466b0068d8a9f0db9ff84eab39822b3b5d69e7dbc5cd3c3"
         },
         {
           "name": "syft:location:0:path",
@@ -1869,7 +1869,7 @@
         },
         {
           "name": "syft:location:0:layerID",
-          "value": "sha256:4714905109f08e13428fd32e6811b61bcd5fd3cb23ba3f7e2fd73b7f45079ca6"
+          "value": "sha256:ca22e46e6b3bf5be8466b0068d8a9f0db9ff84eab39822b3b5d69e7dbc5cd3c3"
         },
         {
           "name": "syft:location:0:path",
@@ -1913,7 +1913,7 @@
         },
         {
           "name": "syft:location:0:layerID",
-          "value": "sha256:4714905109f08e13428fd32e6811b61bcd5fd3cb23ba3f7e2fd73b7f45079ca6"
+          "value": "sha256:ca22e46e6b3bf5be8466b0068d8a9f0db9ff84eab39822b3b5d69e7dbc5cd3c3"
         },
         {
           "name": "syft:location:0:path",
@@ -1958,7 +1958,7 @@
         },
         {
           "name": "syft:location:0:layerID",
-          "value": "sha256:4714905109f08e13428fd32e6811b61bcd5fd3cb23ba3f7e2fd73b7f45079ca6"
+          "value": "sha256:ca22e46e6b3bf5be8466b0068d8a9f0db9ff84eab39822b3b5d69e7dbc5cd3c3"
         },
         {
           "name": "syft:location:0:path",
@@ -2003,7 +2003,7 @@
         },
         {
           "name": "syft:location:0:layerID",
-          "value": "sha256:4714905109f08e13428fd32e6811b61bcd5fd3cb23ba3f7e2fd73b7f45079ca6"
+          "value": "sha256:ca22e46e6b3bf5be8466b0068d8a9f0db9ff84eab39822b3b5d69e7dbc5cd3c3"
         },
         {
           "name": "syft:location:0:path",
@@ -2048,7 +2048,7 @@
         },
         {
           "name": "syft:location:0:layerID",
-          "value": "sha256:4714905109f08e13428fd32e6811b61bcd5fd3cb23ba3f7e2fd73b7f45079ca6"
+          "value": "sha256:ca22e46e6b3bf5be8466b0068d8a9f0db9ff84eab39822b3b5d69e7dbc5cd3c3"
         },
         {
           "name": "syft:location:0:path",
@@ -2093,7 +2093,7 @@
         },
         {
           "name": "syft:location:0:layerID",
-          "value": "sha256:4714905109f08e13428fd32e6811b61bcd5fd3cb23ba3f7e2fd73b7f45079ca6"
+          "value": "sha256:ca22e46e6b3bf5be8466b0068d8a9f0db9ff84eab39822b3b5d69e7dbc5cd3c3"
         },
         {
           "name": "syft:location:0:path",
@@ -2138,7 +2138,7 @@
         },
         {
           "name": "syft:location:0:layerID",
-          "value": "sha256:4714905109f08e13428fd32e6811b61bcd5fd3cb23ba3f7e2fd73b7f45079ca6"
+          "value": "sha256:ca22e46e6b3bf5be8466b0068d8a9f0db9ff84eab39822b3b5d69e7dbc5cd3c3"
         },
         {
           "name": "syft:location:0:path",
@@ -2183,7 +2183,7 @@
         },
         {
           "name": "syft:location:0:layerID",
-          "value": "sha256:4714905109f08e13428fd32e6811b61bcd5fd3cb23ba3f7e2fd73b7f45079ca6"
+          "value": "sha256:ca22e46e6b3bf5be8466b0068d8a9f0db9ff84eab39822b3b5d69e7dbc5cd3c3"
         },
         {
           "name": "syft:location:0:path",
@@ -2228,7 +2228,7 @@
         },
         {
           "name": "syft:location:0:layerID",
-          "value": "sha256:4714905109f08e13428fd32e6811b61bcd5fd3cb23ba3f7e2fd73b7f45079ca6"
+          "value": "sha256:ca22e46e6b3bf5be8466b0068d8a9f0db9ff84eab39822b3b5d69e7dbc5cd3c3"
         },
         {
           "name": "syft:location:0:path",
@@ -2273,7 +2273,7 @@
         },
         {
           "name": "syft:location:0:layerID",
-          "value": "sha256:4714905109f08e13428fd32e6811b61bcd5fd3cb23ba3f7e2fd73b7f45079ca6"
+          "value": "sha256:ca22e46e6b3bf5be8466b0068d8a9f0db9ff84eab39822b3b5d69e7dbc5cd3c3"
         },
         {
           "name": "syft:location:0:path",
@@ -2318,7 +2318,7 @@
         },
         {
           "name": "syft:location:0:layerID",
-          "value": "sha256:4714905109f08e13428fd32e6811b61bcd5fd3cb23ba3f7e2fd73b7f45079ca6"
+          "value": "sha256:ca22e46e6b3bf5be8466b0068d8a9f0db9ff84eab39822b3b5d69e7dbc5cd3c3"
         },
         {
           "name": "syft:location:0:path",
@@ -2363,7 +2363,7 @@
         },
         {
           "name": "syft:location:0:layerID",
-          "value": "sha256:4714905109f08e13428fd32e6811b61bcd5fd3cb23ba3f7e2fd73b7f45079ca6"
+          "value": "sha256:ca22e46e6b3bf5be8466b0068d8a9f0db9ff84eab39822b3b5d69e7dbc5cd3c3"
         },
         {
           "name": "syft:location:0:path",
@@ -2407,7 +2407,7 @@
         },
         {
           "name": "syft:location:0:layerID",
-          "value": "sha256:4714905109f08e13428fd32e6811b61bcd5fd3cb23ba3f7e2fd73b7f45079ca6"
+          "value": "sha256:ca22e46e6b3bf5be8466b0068d8a9f0db9ff84eab39822b3b5d69e7dbc5cd3c3"
         },
         {
           "name": "syft:location:0:path",
@@ -2451,7 +2451,7 @@
         },
         {
           "name": "syft:location:0:layerID",
-          "value": "sha256:4714905109f08e13428fd32e6811b61bcd5fd3cb23ba3f7e2fd73b7f45079ca6"
+          "value": "sha256:ca22e46e6b3bf5be8466b0068d8a9f0db9ff84eab39822b3b5d69e7dbc5cd3c3"
         },
         {
           "name": "syft:location:0:path",
@@ -2495,7 +2495,7 @@
         },
         {
           "name": "syft:location:0:layerID",
-          "value": "sha256:4714905109f08e13428fd32e6811b61bcd5fd3cb23ba3f7e2fd73b7f45079ca6"
+          "value": "sha256:ca22e46e6b3bf5be8466b0068d8a9f0db9ff84eab39822b3b5d69e7dbc5cd3c3"
         },
         {
           "name": "syft:location:0:path",
@@ -2539,7 +2539,7 @@
         },
         {
           "name": "syft:location:0:layerID",
-          "value": "sha256:4714905109f08e13428fd32e6811b61bcd5fd3cb23ba3f7e2fd73b7f45079ca6"
+          "value": "sha256:ca22e46e6b3bf5be8466b0068d8a9f0db9ff84eab39822b3b5d69e7dbc5cd3c3"
         },
         {
           "name": "syft:location:0:path",
@@ -2583,7 +2583,7 @@
         },
         {
           "name": "syft:location:0:layerID",
-          "value": "sha256:4714905109f08e13428fd32e6811b61bcd5fd3cb23ba3f7e2fd73b7f45079ca6"
+          "value": "sha256:ca22e46e6b3bf5be8466b0068d8a9f0db9ff84eab39822b3b5d69e7dbc5cd3c3"
         },
         {
           "name": "syft:location:0:path",
@@ -2627,7 +2627,7 @@
         },
         {
           "name": "syft:location:0:layerID",
-          "value": "sha256:4714905109f08e13428fd32e6811b61bcd5fd3cb23ba3f7e2fd73b7f45079ca6"
+          "value": "sha256:ca22e46e6b3bf5be8466b0068d8a9f0db9ff84eab39822b3b5d69e7dbc5cd3c3"
         },
         {
           "name": "syft:location:0:path",
@@ -2671,7 +2671,7 @@
         },
         {
           "name": "syft:location:0:layerID",
-          "value": "sha256:4714905109f08e13428fd32e6811b61bcd5fd3cb23ba3f7e2fd73b7f45079ca6"
+          "value": "sha256:ca22e46e6b3bf5be8466b0068d8a9f0db9ff84eab39822b3b5d69e7dbc5cd3c3"
         },
         {
           "name": "syft:location:0:path",
@@ -2715,7 +2715,7 @@
         },
         {
           "name": "syft:location:0:layerID",
-          "value": "sha256:4714905109f08e13428fd32e6811b61bcd5fd3cb23ba3f7e2fd73b7f45079ca6"
+          "value": "sha256:ca22e46e6b3bf5be8466b0068d8a9f0db9ff84eab39822b3b5d69e7dbc5cd3c3"
         },
         {
           "name": "syft:location:0:path",
@@ -2760,7 +2760,7 @@
         },
         {
           "name": "syft:location:0:layerID",
-          "value": "sha256:4714905109f08e13428fd32e6811b61bcd5fd3cb23ba3f7e2fd73b7f45079ca6"
+          "value": "sha256:ca22e46e6b3bf5be8466b0068d8a9f0db9ff84eab39822b3b5d69e7dbc5cd3c3"
         },
         {
           "name": "syft:location:0:path",
@@ -2804,7 +2804,7 @@
         },
         {
           "name": "syft:location:0:layerID",
-          "value": "sha256:4714905109f08e13428fd32e6811b61bcd5fd3cb23ba3f7e2fd73b7f45079ca6"
+          "value": "sha256:ca22e46e6b3bf5be8466b0068d8a9f0db9ff84eab39822b3b5d69e7dbc5cd3c3"
         },
         {
           "name": "syft:location:0:path",
@@ -2848,7 +2848,7 @@
         },
         {
           "name": "syft:location:0:layerID",
-          "value": "sha256:4714905109f08e13428fd32e6811b61bcd5fd3cb23ba3f7e2fd73b7f45079ca6"
+          "value": "sha256:ca22e46e6b3bf5be8466b0068d8a9f0db9ff84eab39822b3b5d69e7dbc5cd3c3"
         },
         {
           "name": "syft:location:0:path",
@@ -2892,7 +2892,7 @@
         },
         {
           "name": "syft:location:0:layerID",
-          "value": "sha256:4714905109f08e13428fd32e6811b61bcd5fd3cb23ba3f7e2fd73b7f45079ca6"
+          "value": "sha256:ca22e46e6b3bf5be8466b0068d8a9f0db9ff84eab39822b3b5d69e7dbc5cd3c3"
         },
         {
           "name": "syft:location:0:path",
@@ -2936,7 +2936,7 @@
         },
         {
           "name": "syft:location:0:layerID",
-          "value": "sha256:4714905109f08e13428fd32e6811b61bcd5fd3cb23ba3f7e2fd73b7f45079ca6"
+          "value": "sha256:ca22e46e6b3bf5be8466b0068d8a9f0db9ff84eab39822b3b5d69e7dbc5cd3c3"
         },
         {
           "name": "syft:location:0:path",
@@ -2997,7 +2997,7 @@
         },
         {
           "name": "syft:location:0:layerID",
-          "value": "sha256:4714905109f08e13428fd32e6811b61bcd5fd3cb23ba3f7e2fd73b7f45079ca6"
+          "value": "sha256:ca22e46e6b3bf5be8466b0068d8a9f0db9ff84eab39822b3b5d69e7dbc5cd3c3"
         },
         {
           "name": "syft:location:0:path",
@@ -3041,7 +3041,7 @@
         },
         {
           "name": "syft:location:0:layerID",
-          "value": "sha256:4714905109f08e13428fd32e6811b61bcd5fd3cb23ba3f7e2fd73b7f45079ca6"
+          "value": "sha256:ca22e46e6b3bf5be8466b0068d8a9f0db9ff84eab39822b3b5d69e7dbc5cd3c3"
         },
         {
           "name": "syft:location:0:path",

--- a/docs/releases/v2.3.0/sdlc-compliance.md
+++ b/docs/releases/v2.3.0/sdlc-compliance.md
@@ -2,13 +2,13 @@ SSDLC Compliance Report: Atlas Kubernetes Operator Manager v2.3.0
 =================================================================
 
 - Release Creators: igor.karpukhin@mongodb.com
-- Created On:       2024-06-06
+- Created On:       2024-06-07
 
 Overview:
 
 - **Product and Release Name**
 
-    - Atlas Kubernetes Operator v2.3.0, 2024-06-06.
+    - Atlas Kubernetes Operator v2.3.0, 2024-06-07.
     - Release Type: Minor
 
 - **Process Document**

--- a/scripts/generate_upload_sbom.sh
+++ b/scripts/generate_upload_sbom.sh
@@ -44,9 +44,10 @@ function validate() {
 function generate_sbom() {
   local image_pull_spec=$1
   local platform=$2
-  local file_name=$3
+  local digest=$3
+  local file_name=$4
   set +Ee
-  docker sbom --platform "$platform" -o "$file_name" --format "cyclonedx-json" "$image_pull_spec"
+  docker sbom --platform "$platform" -o "$file_name" --format "cyclonedx-json" "$image_pull_spec@$digest"
   docker_sbom_return_code=$?
   set -Ee
   if ((docker_sbom_return_code != 0)); then
@@ -109,7 +110,7 @@ for platform in "${platforms[@]}"; do
 
   echo "Generating SBOM for $image_pull_spec ($platform) and uploading to $s3_path_platform_dependent"
 
-  if generate_sbom "$image_pull_spec" "$platform" "$output_folder/$file_name"; then
+  if generate_sbom "$image_pull_spec" "$platform" "$digest" "$output_folder/$file_name"; then
     echo "Done generating SBOM for $image_pull_spec ($platform)"
     if [ -z "$bucket_name" ]; then
       echo "Skipping S3 Upload (no bucket specified)"


### PR DESCRIPTION
This fixes a bug in the SBOM generation when the host machine does not match the arch from the `docker sbom` requested. Eg:

`image has unexpected architecture "arm64", which differs from the user specified architecture "amd64"`

The only workaround I found was to be explicit about the platform image SHA, so it will not complain and just compute the SBOM properly.

This PR also fixed version 2.3.0 SBOMs affected by this issue earlier.

### All Submissions:

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?

