### PR TITLE
CLOUDP-251873: Decouple SBOMs from checklist

### DIFF
--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -70,5 +70,6 @@ jobs:
       uses: ./.github/actions/create-pr
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        REVIEWERS: ${{ env.REVIEWERS }}
       with:
-        REVIEWERS: igor-karpukhin,helderjs,josvazg,roothorp
+        REVIEWERS: ${{ env.REVIEWERS }}

--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -9,6 +9,9 @@ on:
       version:
         description: "Release version:"
         required: true
+      authors:
+        description: "Comma separated list of the release authors' emails"
+        required: true
 
 jobs:
   create-release-branch:
@@ -17,6 +20,7 @@ jobs:
     env:
       VERSION: ${{ github.event.inputs.version }}
       TAG: v${{ github.event.inputs.version }}
+      AUTHORS: ${{ github.event.inputs.authors }}
       GITHUB_REPO: mongodb/mongodb-atlas-kubernetes
       DOCKER_RELEASE_REPO: mongodb/mongodb-atlas-kubernetes-operator
     steps:
@@ -40,8 +44,11 @@ jobs:
         cache: false
 
     - name: Download dependencies
+      run: go mod download
+
+    - name: Generate SDLC checklist files for released version
       run: |
-        go mod download
+         make gen-sdlc-checklist VERSION=${{ env.VERSION }} AUTHORS=${{ env.AUTHORS }}
 
     - name: Configure Git
       run: |

--- a/.github/workflows/release-post-merge.yml
+++ b/.github/workflows/release-post-merge.yml
@@ -241,5 +241,6 @@ jobs:
         uses: ./.github/actions/create-pr
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REVIEWERS: ${{ env.REVIEWERS }}
         with:
-          REVIEWERS: igor-karpukhin,helderjs,josvazg,roothorp
+          REVIEWERS: ${{ env.REVIEWERS }}

--- a/.github/workflows/release-post-merge.yml
+++ b/.github/workflows/release-post-merge.yml
@@ -225,3 +225,21 @@ jobs:
           asset_path: ./atlas-operator-all-in-one-${{ steps.tag.outputs.version }}.tar.gz
           asset_name: atlas-operator-all-in-one-${{ steps.tag.outputs.version }}.tar.gz
           asset_content_type: application/tgz
+
+      - name: Create SBOMs branch
+        env:
+          BRANCH: version-${{ steps.tag.outputs.version }}-sboms
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          make generate-sboms VERSION=${{ steps.tag.outputs.version }}
+          git checkout -b $BRANCH
+          git add .
+          git commit -m "Add SBOMs for version ${{ steps.tag.outputs.version }}"
+          git push --set-upstream origin $BRANCH
+
+      - name: Create SBOMs PR
+        uses: ./.github/actions/create-pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          REVIEWERS: igor-karpukhin,helderjs,josvazg,roothorp

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,7 @@ REGISTRY ?= quay.io/mongodb
 BUNDLE_IMG ?= $(REGISTRY)/mongodb-atlas-kubernetes-operator-prerelease-bundle:$(VERSION)
 
 #BUNDLE_REGISTRY ?= $(REGISTRY)/mongodb-atlas-operator-bundle
+RELEASED_OPERATOR_IMAGE ?= mongodb/mongodb-atlas-kubernetes-operator
 OPERATOR_REGISTRY ?= $(REGISTRY)/mongodb-atlas-kubernetes-operator-prerelease
 CATALOG_REGISTRY ?= $(REGISTRY)/mongodb-atlas-kubernetes-operator-prerelease-catalog
 OPERATOR_IMAGE ?= ${OPERATOR_REGISTRY}:${VERSION}
@@ -491,10 +492,15 @@ docker-sbom:
 	@docker sbom --help > /dev/null || \
 	echo "You might need to install the SBOM plugin for docker, check out docs/dev/release.md#tools"
 
+.PHONY: generate-sboms
+generate-sboms: docker-sbom ## Generate a released version SBOMs
+	@mkdir -p docs/releases/v$(VERSION) && \
+	./scripts/generate_upload_sbom.sh -i $(RELEASED_OPERATOR_IMAGE):$(VERSION) -o docs/releases/v$(VERSION) && \
+	ls -l docs/releases/v$(VERSION)
+
 .PHONY: gen-sdlc-checklist
-gen-sdlc-checklist: envsubst docker-sbom ## Generate the SDLC checklist
-	@VERSION="$(VERSION)" AUTHORS="$(AUTHORS)" RELEASE_TYPE="$(RELEASE_TYPE)" \
-	./scripts/gen-sdlc-checklist.sh
+gen-sdlc-checklist: envsubst ## Generate the SDLC checklist
+	@VERSION="$(VERSION)" AUTHORS="$(AUTHORS)" ./scripts/gen-sdlc-checklist.sh
 
 # TODO: avoid leaving leftovers in the first place
 .PHONY: clear-e2e-leftovers

--- a/docs/dev/image-sboms.md
+++ b/docs/dev/image-sboms.md
@@ -1,0 +1,57 @@
+# Image SBOMs
+
+Starting from version 2.2.0 and onward, all Atlas Kubernetes Operator images are attached SBOMs files per image platform released. SBOM stands for Software Bill Of Materials, a recursive list of all dependencies within of a software binary or image image that is useful to evaluate potential security vulnerabilities that might be affected that particular version.
+
+These SBOMs attached after release, as they need the images to be published for the SBOMs to be computed.
+
+This document describes how the project computes those SBOMs as well as how end users can compute them on their own.
+
+## Scripts computing the SBOMs for the CI
+
+The main script to check is [scripts/generate_upload_sbom.sh](../../scripts/generate_upload_sbom.sh):
+
+```shell
+$ ./scripts/generate_upload_sbom.sh -h
+Generates and uploads an SBOM to an S3 bucket.
+
+Usage:
+  generate_upload_sbom.sh [-h]
+  generate_upload_sbom.sh -i <image_name>
+
+Options:
+  -h                   (optional) Shows this screen.
+  -i <image_name>      (required) Image to be processed.
+  -b                   (optional) S3 bucket name.
+  -p                   (optional) An array of platforms, for example 'linux/arm64,linux/amd64'. The script **doesn't** fail if a particular architecture is not found.
+  -o <output_folder>   (optional) Folder to output SBOM to.
+```
+
+As you can see one what you use it will be:
+
+```shell
+$ ./scripts/generate_upload_sbom.sh -i mongodb/mongodb-atlas-kubernetes-operator:2.3.0
+```
+
+When given no platforms it will default to `linux/amd64` & `linux/arm64` and try to download them and produce the SBOMS files.
+
+## DIY SBOMs
+
+To compute the SBOMs manually the only complication, other than having `docker` with the `sbom` plug-in installed, is that to get SBOMs from multi-architecture images require the full SHA nomenclature to successfully produce the SBOM regardless of the host architecture the `docker sbom` where command is run. The gist of it getting the SHA of the desired platform and then getting the SBOM for that particular image SHA:
+
+```shell
+export digest=$(docker manifest inspect "${img}" |jq -r '.manifests[] | select(.platform.os == "'"${os}"'" and .platform.architecture=="'"${arch}"'") | .digest')
+docker sbom --platform "${os}/${arch}" --format "cyclonedx-json" "${img}@${digest}"
+```
+
+For example:
+```shell
+$ export os=linux
+$ export arch=amd64
+$ export img=mongodb/mongodb-atlas-kubernetes-operator:2.3.0
+$ export digest=$(docker manifest inspect "${img}" |jq -r '.manifests[] | select(.platform.os == "'"${os}"'" and .platform.architecture=="'"${arch}"'") | .digest')
+$ docker sbom --platform "${os}/${arch}" --format "cyclonedx-json" "${img}@${digest}"
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.4",
+...
+```

--- a/docs/dev/release.md
+++ b/docs/dev/release.md
@@ -19,13 +19,15 @@ Most tools are automatically installed for you. Most of them are Go binaries and
 
 ## Create the release branch
 
-Use the GitHub UI to create the new "Create Release Branch" workflow. Specify the version to be released in the text box.
+Use the GitHub UI to create the new "Create Release Branch" workflow. Specify the `version` to be released in the text box and the author or `authors` involved in the release.
 The deployment scripts (K8s configs, OLM bundle) will be generated and PR will be created with new changes on behalf
 of the `github-actions` bot.
 
 Pass the version with the `X.Y.Z` eg. `1.2.3`, **without** the `v...` prefix.
 
 See [Troubleshooting](#troubleshooting) in case of issues, such as [errors with the major version](#major-version-issues-when-create-release-branch).
+
+Expect this branch to include the Software Security Development Lifecycle Policy Checklist (SSDLC) document at path `docs/releases/v${VERSION}/sdlc-compliance.md`. Note the SBOM files cannot be generated yet, as they require the image to have been published already.
 
 ## Approve the Pull Request named "Release x.y.z"
 
@@ -35,6 +37,12 @@ The new job "Create Release" will be triggered and the following will be done:
 * Draft Release will be created with all commits since the previous release
 
 The "Create Release Branch" workflow is going to create a Pull Request pointing to a `release/X.Y.Z` branch. Once approved and merged, automation is going to create a `vX.Y.Z` tag.
+
+### SSDLC SBOMs PR
+
+A new PR should have been created titled `Add SBOMs for version ...`. Please review all is as expected and merge. It should contain just a couple of new files at directory `docs/releases/v${VERSION}/`:
+- `linux-amd64.sbom.json`
+- `linux-arm64.sbom.json`
 
 ## Edit the Release Notes and publish the release
 
@@ -160,29 +168,11 @@ You can see an [example fixed PR here for certified version 1.9.1](https://githu
 
 After the PR is approved it will soon appear in the [Atlas Operator openshift cluster](https://console-openshift-console.apps.atlas.operator.mongokubernetes.com)
 
-# SSDLC checklist publishing
-
-You can create the draft for the SSDLC checklist just by running:
-
-```shell
-$ DATE= VERSION="${version}" AUTHORS="${release_authors}" RELEASE_TYPE= make gen-sdlc-checklist
-```
-
-- You can leave `DATE` unset so the script may use today's date.
-- `RELEASE_TYPE` is also optional defaulting to `Minor` releases, set to `Major`when appropriate.
-
-The script generates the directory `docs/releases/v${VERSION}/` with files:
-- `linux-amd64.sbom.json`
-- `linux-arm64.sbom.json`
-- `sdlc-compliance.md`
-
-Add those files to `git`, and create a PR to review the changes to close the release.
-
 # Post install hook release
 
 If changes have been made to the post install hook (mongodb-atlas-kubernetes/cmd/post-install/main.go).
 You must also release this image. Run the "Release Post Install Hook" workflow manually specifying the desired 
-release version. 
+release version.
 
 # Post Release actions
 

--- a/docs/releases/sdlc-compliance.template.md
+++ b/docs/releases/sdlc-compliance.template.md
@@ -9,16 +9,17 @@ Overview:
 - **Product and Release Name**
 
     - Atlas Kubernetes Operator v${VERSION}, ${DATE}.
-    - Release Type: ${RELEASE_TYPE}
 
 - **Process Document**
   - http://go/how-we-develop-software-doc
 
 - **Tool used to track third party vulnerabilities**
-  - Silk
+  - [Silk](https://www.silk.security/)
 
 - **Dependency Information**
-  - See SBOMS Lite manifests (CycloneDX in JSON format) for [Intel](./linux-amd64.sbom.json) or [ARM](./linux-arm64.sbom.json)
+  - See SBOMS Lite manifests (CycloneDX in JSON format) for `Intel` and `ARM` are to be found [here](.)
+  - See [instructions on how the SBOMs are generated or how to generate them manually](../../dev/image-sboms.md)
+  - [Internal compliance folder](https://drive.google.com/drive/folders/1k0TsPgJcMwgj2muSPHU0FHHBjPT0dkS0?usp=drive_link)
 
 - **Static Analysis Report**
   - No SAST findings. Our CI system blocks merges on any SAST findings.${IGNORED_VULNERABILITIES}

--- a/scripts/gen-sdlc-checklist.sh
+++ b/scripts/gen-sdlc-checklist.sh
@@ -4,7 +4,6 @@ set -eu
 
 release_date=${DATE:-$(date -u '+%Y-%m-%d')}
 release_type=${RELEASE_TYPE:-Minor}
-SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 export DATE="${release_date}"
 export VERSION="${VERSION}"
@@ -20,9 +19,7 @@ else
 fi
 export IGNORED_VULNERABILITIES="${ignored_list}"
 
-img="mongodb/mongodb-atlas-kubernetes-operator:${VERSION}"
-"${SCRIPT_DIR}"/generate_upload_sbom.sh -i "$img" -o "docs/releases/v${VERSION}"
-
+mkdir -p "docs/releases/v${VERSION}/"
 envsubst < docs/releases/sdlc-compliance.template.md \
   > "docs/releases/v${VERSION}/sdlc-compliance.md"
 

--- a/scripts/generate_upload_sbom.sh
+++ b/scripts/generate_upload_sbom.sh
@@ -16,12 +16,12 @@ function usage() {
 
 Usage:
   generate_upload_sbom.sh [-h]
-  generate_upload_sbom.sh -i <image_name> -b <bucket_name>
+  generate_upload_sbom.sh -i <image_name>
 
 Options:
   -h                   (optional) Shows this screen.
   -i <image_name>      (required) Image to be processed.
-  -b                   (required) S3 bucket name.
+  -b                   (optional) S3 bucket name.
   -p                   (optional) An array of platforms, for example 'linux/arm64,linux/amd64'. The script **doesn't** fail if a particular architecture is not found.
   -o <output_folder>   (optional) Folder to output SBOM to.
 "


### PR DESCRIPTION
This PR solves several things:
- Decouples the creation of the SSDLC checklist document from the SBOMs that will be attached later, once the released image is actually available.
- The SSDLC checklist document creation is automated by the `release-branch.yml`workflow.
- The images SBOM creation is automated by a new branch and PR creation at the end of the `release-post-merge.yml`, right after the release images have been created.
- Both actions are also separated in the `Makefile` invocation.
- The script `scripts/gen-sdlc-checklist.sh` no longers invokes the SBOM creation.
- An specific development documentation is added to explain how the CI generates the SBOMs and how to create them manually.
- The SSDLC tamplet no longer links to the SBOMs directly, but just to the folder.
- It also links to the internal Google Drive for internal compliance assets.
- And we drop the need to specify if the release is a Major one, as it has no implications in our case.
- The release documentation is also updated to reflect the new semi-automated SSDLC process.

### All Submissions:

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
