### PR TITLE
CLOUDP-251770: Added zap-logging to the controller-runtime leader election.

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -31,6 +31,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -67,6 +68,7 @@ func main() {
 	}
 
 	ctrl.SetLogger(zapr.NewLogger(logger))
+	klog.SetLogger(zapr.NewLogger(logger))
 	setupLog := logger.Named("setup").Sugar()
 	setupLog.Info("starting with configuration", zap.Any("config", config), zap.Any("version", version.Version))
 


### PR DESCRIPTION
Before and After

<img width="733" alt="Screenshot 2024-07-03 at 15 55 10" src="https://github.com/mongodb/mongodb-atlas-kubernetes/assets/173696323/d042d639-13e7-495c-8ec4-22e415a1465a">
<img width="754" alt="Screenshot 2024-07-03 at 15 55 35" src="https://github.com/mongodb/mongodb-atlas-kubernetes/assets/173696323/b9af6c37-6f89-4829-bc73-4ed8057d91d2">

### All Submissions:

* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if there is one).
* [ ] Update docs/release-notes/release-notes-template.md if your changes should be included in the release notes for the next release.
