### PR TITLE
CLOUDP-260750: Display OpenShift cluster version

### DIFF
--- a/.github/workflows/openshift-upgrade-test.yaml
+++ b/.github/workflows/openshift-upgrade-test.yaml
@@ -76,6 +76,9 @@ jobs:
           opm version
           oc version
           operator-sdk version
+
+          kubectl version
+          oc get clusterversion/version
       - name: Install Go dependencies
         run: go install golang.org/x/tools/cmd/goimports@latest
       - name: Login to registry

--- a/.github/workflows/openshift-upgrade-test.yaml
+++ b/.github/workflows/openshift-upgrade-test.yaml
@@ -76,9 +76,6 @@ jobs:
           opm version
           oc version
           operator-sdk version
-
-          kubectl version
-          oc get clusterversion/version
       - name: Install Go dependencies
         run: go install golang.org/x/tools/cmd/goimports@latest
       - name: Login to registry

--- a/scripts/openshift-upgrade-test.sh
+++ b/scripts/openshift-upgrade-test.sh
@@ -131,6 +131,8 @@ oc_login() {
   echo "Logging in to the cluster..."
   expect_success_silent "oc login --token=${OC_TOKEN} --server=${CLUSTER_API_URL}"
   echo "Logged in to the cluster"
+  kubectl version
+  oc get clusterversion/version
 }
 
 prepare_test_namespace() {


### PR DESCRIPTION
https://github.com/mongodb/mongodb-atlas-kubernetes/actions/runs/9970869505/job/27550963780

```
Kustomize Version: v5.0.4-0.20230601165947-6ce0bf390ce3
Server Version: v1.28.10+a2c84a5
NAME      VERSION   AVAILABLE   PROGRESSING   SINCE   STATUS
version   4.15.19   True        False         12d     Cluster version is 4.15.19
```

### All Submissions:

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
