### PR TITLE
Auto add retest label after updating licenses

### DIFF
--- a/.github/workflows/update-licenses.yml
+++ b/.github/workflows/update-licenses.yml
@@ -49,3 +49,13 @@ jobs:
           else
             echo 'Clean nothing to do'
           fi
+
+      - name: Remove retest Label
+        uses: actions-ecosystem/action-remove-labels@v1
+        with:
+          labels: retest
+
+      - name: Add retest label
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          labels: retest


### PR DESCRIPTION
This is a quick experiment checking is this will fix our `dependabot` automated workflow after the licenses get fixed.

### All Submissions:

* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if there is one).
* [ ] Update docs/release-notes/release-notes-template.md if your changes should be included in the release notes for the next release.
