### PR TITLE
Tweak linting to be faster

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -27,6 +27,3 @@ jobs:
 
       - name: lint
         run: make lint
-
-      - name: goimports
-        run: make fmt

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -19,11 +19,14 @@ jobs:
           go-version-file: "${{ github.workspace }}/go.mod"
           cache: false
 
-      - name: lint
-        run: make lint
-
       - name: Run ShellCheck
         uses: bewuethr/shellcheck-action@v2
 
       - name: Run govulncheck
         run: make vulncheck
+
+      - name: lint
+        run: make lint
+
+      - name: goimports
+        run: make fmt

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,33 +2,33 @@ linters:
   disable-all: true
   enable:
     #- bodyclose
-    - depguard
-    - dogsled
-    - dupl
-    - errcheck
-    - errorlint
-    - exportloopref
+    - depguard # 49s
+    - dogsled # 42s
+    - dupl # 43s
+    - errcheck # 42s
+    - errorlint # 42s
+    - exportloopref # 41s
     #- gocritic
-    - gocyclo
-    - goimports
-    - goprintffuncname
-    - gosec
-    - gosimple
-    - govet
-    - gofmt
-    - ineffassign
-    - misspell
-    - noctx
-    - prealloc
-    - rowserrcheck
-    - staticcheck
-    - stylecheck
-    - typecheck
-    - unconvert
-    - unparam
-    - unused
-    - whitespace
-    - importas
+    - gocyclo # 42s
+    #- goimports # 5m23s
+    - goprintffuncname # 46s
+    - gosec # 44s
+    - gosimple # 43s
+    - govet # 42s
+    - gofmt # 44s
+    - ineffassign # 42s
+    - misspell # 42s
+    - noctx # 43s
+    - prealloc # 43s
+    - rowserrcheck # 41s
+    - staticcheck # 43s
+    - stylecheck # 44s
+    - typecheck # 42s
+    - unconvert # 41s
+    - unparam # 43s
+    - unused # 42s
+    - whitespace # 42s
+    - importas # 44s
 
 linters-settings:
   misspell:

--- a/Makefile
+++ b/Makefile
@@ -218,7 +218,7 @@ golangci-lint:
 
 .PHONY: lint
 lint: golangci-lint
-	golangci-lint run --timeout 10m
+	golangci-lint run --timeout 10m --verbose
 
 $(TIMESTAMPS_DIR)/fmt: $(GO_SOURCES)
 	@echo "goimports -local github.com/mongodb/mongodb-atlas-kubernetes/v2 -l -w \$$(GO_SOURCES)"


### PR DESCRIPTION
Turns out golingci is made slow by `goimports` alone. Most other linters, including `gofmt` take below 50 seconds to run, typically even less than 45 seconds. We can also run `goimports` separately anyway.

### All Submissions:

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
