### PR TITLE
CLOUDP-264908: Wait for release image

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -46,7 +46,7 @@ jobs:
 
   sboms-pr:
     needs:
-    - tag
+    - release-post-merge
     uses: ./.github/workflows/sboms-pr.yaml
     secrets: inherit
     with:


### PR DESCRIPTION
Before creating the SBOMs PR.

Otherwise the job fails as the release image is not ready to compute the per platform SBOMs.

### All Submissions:

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
