### PR TITLE
Make update licenses re-test the updated PR

### DIFF
--- a/.github/workflows/update-licenses.yml
+++ b/.github/workflows/update-licenses.yml
@@ -17,7 +17,7 @@ permissions:
   pull-requests: write
 
 jobs:
-  run:
+  update-licenses:
     name: Recompute licenses & update PR
     runs-on: ubuntu-latest
     env:
@@ -49,3 +49,8 @@ jobs:
           else
             echo 'Clean nothing to do'
           fi
+
+  re-run-tests:
+    needs:
+      - update-licenses
+    uses: ./.github/workflows/test.yml


### PR DESCRIPTION
Rater than placing a label to force the re-test of the PR, as done in #1730, just directly dispatch the test workflow after the licenses got updated.

This replaced #1730 

### All Submissions:

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
