### PR TITLE
Allow workflow call from update licenses

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,7 @@ on:
       - 'docs/**'
   merge_group:
   workflow_dispatch:
+  workflow_call:
 
 concurrency:
   group: test-${{ github.head_ref || github.ref_name }}


### PR DESCRIPTION
Should fix this error:
https://github.com/mongodb/mongodb-atlas-kubernetes/actions/runs/10199327240

```
[Invalid workflow file: .github/workflows/update-licenses.yml#L56](https://github.com/mongodb/mongodb-atlas-kubernetes/actions/runs/10199327240/workflow)
error parsing called workflow
".github/workflows/update-licenses.yml"
-> "./.github/workflows/test.yml" (source branch with sha:de17e17780e38a27ffa4a527cccf15e8cb283e25)
: workflow is not reusable as it is missing a `on.workflow_call` trigger
```

### All Submissions:

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
