### PR TITLE
Revert attempted test fixes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,6 @@ on:
       - 'docs/**'
   merge_group:
   workflow_dispatch:
-  workflow_call:
 
 concurrency:
   group: test-${{ github.head_ref || github.ref_name }}

--- a/.github/workflows/update-licenses.yml
+++ b/.github/workflows/update-licenses.yml
@@ -17,7 +17,7 @@ permissions:
   pull-requests: write
 
 jobs:
-  update-licenses:
+  run:
     name: Recompute licenses & update PR
     runs-on: ubuntu-latest
     env:
@@ -49,8 +49,3 @@ jobs:
           else
             echo 'Clean nothing to do'
           fi
-
-  re-run-tests:
-    needs:
-      - update-licenses
-    uses: ./.github/workflows/test.yml


### PR DESCRIPTION
The directly kicked off tests:
- Are not executed within the actual open PR, but on a separate action, disconnected.
- Are run on the original commit, not the one the update licenses fixed, so they fail anyways.

We might need to kick them indirectly, maybe labelling would work? Not sure.

### All Submissions:

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
