### PR TITLE
Abort attempt to automate checks after AKObot

### DIFF
--- a/.github/workflows/update-licenses.yml
+++ b/.github/workflows/update-licenses.yml
@@ -17,12 +17,13 @@ permissions:
   pull-requests: write
 
 jobs:
-  run:
+  update-licenses:
     name: Recompute licenses & update PR
     runs-on: ubuntu-latest
     env:
       BRANCH: ${{ inputs.branch || github.ref_name  }}
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      JWT_APP_ID: ${{ secrets.AKO_RELEASER_APP_ID }}
+      JWT_RSA_PEM_KEY_BASE64: ${{ secrets.AKO_RELEASER_RSA_KEY_BASE64 }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -39,6 +40,8 @@ jobs:
 
       - name: Commit as needed
         run: |
+          make tools/makejwt/makejwt
+          export GITHUB_TOKEN=$(make github-token)
           if [[ $(git diff --stat) != '' ]]; then
             echo 'Committing changes'
             git config user.email "akobot@ako-team-fake.mongodb.com"
@@ -47,15 +50,12 @@ jobs:
             git commit -m "Fix licenses after dependabot changes" -m "[dependabot skip]"
             git push
           else
-            echo 'Clean nothing to do'
+            # echo 'Clean nothing to do'
+            echo 'Committing dummy changes to kick off tests'
+            git config user.email "akobot@ako-team-fake.mongodb.com"
+            git config user.name "AKOBot"
+            date -u --iso-8601=seconds > force-compile.timestamp
+            git add .
+            git commit -m "Force re-testing after dependabot changes" -m "[dependabot skip]"
+            git push
           fi
-
-      - name: Remove retest Label
-        uses: actions-ecosystem/action-remove-labels@v1
-        with:
-          labels: retest
-
-      - name: Add retest label
-        uses: actions-ecosystem/action-add-labels@v1
-        with:
-          labels: retest

--- a/.github/workflows/update-licenses.yml
+++ b/.github/workflows/update-licenses.yml
@@ -22,9 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       BRANCH: ${{ inputs.branch || github.ref_name  }}
-      JWT_APP_ID: ${{ secrets.AKO_RELEASER_APP_ID }}
-      JWT_RSA_PEM_KEY_BASE64: ${{ secrets.AKO_RELEASER_RSA_KEY_BASE64 }}
-      GITHUB_TOKEN: ${{ secrets.COMMIT_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -41,8 +39,6 @@ jobs:
 
       - name: Commit as needed
         run: |
-          #make tools/makejwt/makejwt
-          #export GITHUB_TOKEN=$(make github-token)
           if [[ $(git diff --stat) != '' ]]; then
             echo 'Committing changes'
             git config user.email "akobot@ako-team-fake.mongodb.com"
@@ -51,12 +47,5 @@ jobs:
             git commit -m "Fix licenses after dependabot changes" -m "[dependabot skip]"
             git push
           else
-            # echo 'Clean nothing to do'
-            echo 'Committing dummy changes to kick off tests'
-            git config user.email "akobot@ako-team-fake.mongodb.com"
-            git config user.name "AKOBot"
-            date -u --iso-8601=seconds > force-compile.timestamp
-            git add .
-            git commit -m "Force re-testing after dependabot changes" -m "[dependabot skip]"
-            git push
+            echo 'Clean nothing to do'
           fi

--- a/.github/workflows/update-licenses.yml
+++ b/.github/workflows/update-licenses.yml
@@ -24,6 +24,7 @@ jobs:
       BRANCH: ${{ inputs.branch || github.ref_name  }}
       JWT_APP_ID: ${{ secrets.AKO_RELEASER_APP_ID }}
       JWT_RSA_PEM_KEY_BASE64: ${{ secrets.AKO_RELEASER_RSA_KEY_BASE64 }}
+      GITHUB_TOKEN: ${{ secrets.COMMIT_TOKEN }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -40,8 +41,8 @@ jobs:
 
       - name: Commit as needed
         run: |
-          make tools/makejwt/makejwt
-          export GITHUB_TOKEN=$(make github-token)
+          #make tools/makejwt/makejwt
+          #export GITHUB_TOKEN=$(make github-token)
           if [[ $(git diff --stat) != '' ]]; then
             echo 'Committing changes'
             git config user.email "akobot@ako-team-fake.mongodb.com"


### PR DESCRIPTION
`AKObot` updates licenses at `dependabot` PRs. But after pushing its fix commit, the checks are not run, they need to be kicked manually.

Have tried several ways so try to automate them and none have worked:
- Changing labels manually works, but if done from a workflow, they do nothing.
- Closing and opening the PR manually re-run checks, but if done in a workflow it does nothing.
- Using a PAT to commit the changes with actions permissions also does not work.

This PR restores the update licenses workflow to its original state. We need to keep on adding `retest` label manually to run the `dependabot` PR tests to completion, one by one.

### All Submissions:

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
