### PR TITLE
CLOUDP-265413: Operator failed to reconcile and already deleted user

### DIFF
--- a/internal/translation/dbuser/dbuser.go
+++ b/internal/translation/dbuser/dbuser.go
@@ -44,7 +44,7 @@ func NewAtlasUsers(api admin.DatabaseUsersApi) *AtlasUsers {
 func (dus *AtlasUsers) Get(ctx context.Context, db, projectID, username string) (*User, error) {
 	atlasDBUser, _, err := dus.usersAPI.GetDatabaseUser(ctx, projectID, db, username).Execute()
 	if err != nil {
-		if admin.IsErrorCode(err, atlas.UsernameNotFound) || admin.IsErrorCode(err, atlas.UserNotfound) {
+		if admin.IsErrorCode(err, atlas.UsernameNotFound) {
 			return nil, errors.Join(ErrorNotFound, err)
 		}
 		return nil, fmt.Errorf("failed to get database user %q: %w", username, err)
@@ -55,7 +55,7 @@ func (dus *AtlasUsers) Get(ctx context.Context, db, projectID, username string) 
 func (dus *AtlasUsers) Delete(ctx context.Context, db, projectID, username string) error {
 	_, _, err := dus.usersAPI.DeleteDatabaseUser(ctx, projectID, db, username).Execute()
 	if err != nil {
-		if admin.IsErrorCode(err, atlas.UsernameNotFound) || admin.IsErrorCode(err, atlas.UserNotfound) {
+		if admin.IsErrorCode(err, atlas.UserNotfound) {
 			return errors.Join(ErrorNotFound, err)
 		}
 		return err

--- a/internal/translation/dbuser/dbuser.go
+++ b/internal/translation/dbuser/dbuser.go
@@ -44,7 +44,7 @@ func NewAtlasUsers(api admin.DatabaseUsersApi) *AtlasUsers {
 func (dus *AtlasUsers) Get(ctx context.Context, db, projectID, username string) (*User, error) {
 	atlasDBUser, _, err := dus.usersAPI.GetDatabaseUser(ctx, projectID, db, username).Execute()
 	if err != nil {
-		if admin.IsErrorCode(err, atlas.UsernameNotFound) {
+		if admin.IsErrorCode(err, atlas.UsernameNotFound) || admin.IsErrorCode(err, atlas.UserNotfound) {
 			return nil, errors.Join(ErrorNotFound, err)
 		}
 		return nil, fmt.Errorf("failed to get database user %q: %w", username, err)
@@ -55,7 +55,7 @@ func (dus *AtlasUsers) Get(ctx context.Context, db, projectID, username string) 
 func (dus *AtlasUsers) Delete(ctx context.Context, db, projectID, username string) error {
 	_, _, err := dus.usersAPI.DeleteDatabaseUser(ctx, projectID, db, username).Execute()
 	if err != nil {
-		if admin.IsErrorCode(err, atlas.UsernameNotFound) {
+		if admin.IsErrorCode(err, atlas.UsernameNotFound) || admin.IsErrorCode(err, atlas.UserNotfound) {
 			return errors.Join(ErrorNotFound, err)
 		}
 		return err

--- a/internal/translation/dbuser/dbuser_test.go
+++ b/internal/translation/dbuser/dbuser_test.go
@@ -1,19 +1,22 @@
-package dbuser_test
+package dbuser
 
 import (
 	"context"
 	"errors"
+	"fmt"
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/atlas-sdk/v20231115008/admin"
+	"go.mongodb.org/atlas-sdk/v20231115008/mockadmin"
 	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/mocks/atlas"
-	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/translation/dbuser"
+	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/pointer"
 )
 
 func TestNewAtlasDatabaseUsersService(t *testing.T) {
@@ -25,9 +28,9 @@ func TestNewAtlasDatabaseUsersService(t *testing.T) {
 	}
 	secretRef := &types.NamespacedName{}
 	log := zap.S()
-	users, err := dbuser.NewAtlasDatabaseUsersService(ctx, provider, secretRef, log)
+	users, err := NewAtlasDatabaseUsersService(ctx, provider, secretRef, log)
 	require.NoError(t, err)
-	assert.Equal(t, &dbuser.AtlasUsers{}, users)
+	assert.Equal(t, &AtlasUsers{}, users)
 }
 
 func TestFailedNewAtlasDatabaseUsersService(t *testing.T) {
@@ -40,7 +43,149 @@ func TestFailedNewAtlasDatabaseUsersService(t *testing.T) {
 	}
 	secretRef := &types.NamespacedName{}
 	log := zap.S()
-	users, err := dbuser.NewAtlasDatabaseUsersService(ctx, provider, secretRef, log)
+	users, err := NewAtlasDatabaseUsersService(ctx, provider, secretRef, log)
 	require.Nil(t, users)
 	require.ErrorIs(t, err, expectedErr)
+}
+func TestAtlasUsersGet(t *testing.T) {
+	ctx := context.Background()
+	projectID := "project-id"
+	db := "database"
+	username := "test-user"
+
+	tests := []struct {
+		name         string
+		setupMock    func(mockUsersAPI *mockadmin.DatabaseUsersApi)
+		expectedUser *admin.CloudDatabaseUser // Replace with actual user type
+		expectedErr  string
+	}{
+		{
+			name: "User found",
+			setupMock: func(mockUsersAPI *mockadmin.DatabaseUsersApi) {
+				expectedUser := &admin.CloudDatabaseUser{DatabaseName: db, GroupId: projectID, Username: username}
+				mockUsersAPI.EXPECT().GetDatabaseUser(ctx, projectID, db, username).Return(
+					admin.GetDatabaseUserApiRequest{ApiService: mockUsersAPI})
+
+				mockUsersAPI.EXPECT().GetDatabaseUserExecute(admin.GetDatabaseUserApiRequest{ApiService: mockUsersAPI}).Return(
+					expectedUser, &http.Response{StatusCode: http.StatusOK}, nil)
+			},
+			expectedUser: &admin.CloudDatabaseUser{DatabaseName: db, GroupId: projectID, Username: username},
+			expectedErr:  "",
+		},
+		{
+			name: "User not found",
+			setupMock: func(mockUsersAPI *mockadmin.DatabaseUsersApi) {
+				mockUsersAPI.EXPECT().GetDatabaseUser(ctx, projectID, db, username).Return(
+					admin.GetDatabaseUserApiRequest{ApiService: mockUsersAPI})
+
+				notFoundErr := &admin.GenericOpenAPIError{}
+				notFoundErr.SetModel(admin.ApiError{ErrorCode: pointer.MakePtr("USERNAME_NOT_FOUND")})
+				mockUsersAPI.EXPECT().GetDatabaseUserExecute(admin.GetDatabaseUserApiRequest{ApiService: mockUsersAPI}).Return(
+					nil, &http.Response{StatusCode: http.StatusNotFound}, notFoundErr)
+			},
+			expectedUser: nil,
+			expectedErr:  "database user not found\n",
+		},
+		{
+			name: "API error",
+			setupMock: func(mockUsersAPI *mockadmin.DatabaseUsersApi) {
+				mockUsersAPI.EXPECT().GetDatabaseUser(ctx, projectID, db, username).Return(
+					admin.GetDatabaseUserApiRequest{ApiService: mockUsersAPI})
+
+				internalServerError := &admin.GenericOpenAPIError{}
+				internalServerError.SetModel(admin.ApiError{ErrorCode: pointer.MakePtr("500")})
+				mockUsersAPI.EXPECT().GetDatabaseUserExecute(admin.GetDatabaseUserApiRequest{ApiService: mockUsersAPI}).Return(
+					nil, &http.Response{StatusCode: http.StatusInternalServerError}, fmt.Errorf("some problem"))
+			},
+			expectedUser: nil,
+			expectedErr:  fmt.Sprintf("failed to get database user %q: %s", username, "some problem"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockUsersAPI := mockadmin.NewDatabaseUsersApi(t)
+			tt.setupMock(mockUsersAPI)
+
+			dus := &AtlasUsers{
+				usersAPI: mockUsersAPI,
+			}
+			user, err := dus.Get(ctx, db, projectID, username)
+
+			if tt.expectedErr != "" {
+				require.Equal(t, tt.expectedErr, err.Error())
+			} else {
+				require.NoError(t, err)
+			}
+			kubUser, _ := fromAtlas(tt.expectedUser)
+			assert.Equal(t, kubUser, user)
+		})
+	}
+}
+func TestAtlasUsersDelete(t *testing.T) {
+	ctx := context.Background()
+	projectID := "project-id"
+	db := "database"
+	username := "test-user"
+
+	tests := []struct {
+		name        string
+		setupMock   func(mockUsersAPI *mockadmin.DatabaseUsersApi)
+		expectedErr string
+	}{
+		{
+			name: "User successfully deleted",
+			setupMock: func(mockUsersAPI *mockadmin.DatabaseUsersApi) {
+				mockUsersAPI.EXPECT().DeleteDatabaseUser(ctx, projectID, db, username).Return(
+					admin.DeleteDatabaseUserApiRequest{ApiService: mockUsersAPI})
+				mockUsersAPI.EXPECT().DeleteDatabaseUserExecute(admin.DeleteDatabaseUserApiRequest{ApiService: mockUsersAPI}).
+					Return(nil, &http.Response{StatusCode: http.StatusOK}, nil)
+			},
+			expectedErr: "",
+		},
+		{
+			name: "User not found",
+			setupMock: func(mockUsersAPI *mockadmin.DatabaseUsersApi) {
+				mockUsersAPI.EXPECT().DeleteDatabaseUser(ctx, projectID, db, username).Return(
+					admin.DeleteDatabaseUserApiRequest{ApiService: mockUsersAPI})
+
+				notFoundErr := &admin.GenericOpenAPIError{}
+				notFoundErr.SetModel(admin.ApiError{ErrorCode: pointer.MakePtr("USER_NOT_FOUND")})
+				mockUsersAPI.EXPECT().DeleteDatabaseUserExecute(admin.DeleteDatabaseUserApiRequest{ApiService: mockUsersAPI}).
+					Return(nil, &http.Response{StatusCode: http.StatusNotFound}, notFoundErr)
+			},
+			expectedErr: "database user not found\n",
+		},
+		{
+			name: "API error",
+			setupMock: func(mockUsersAPI *mockadmin.DatabaseUsersApi) {
+				mockUsersAPI.EXPECT().DeleteDatabaseUser(ctx, projectID, db, username).Return(
+					admin.DeleteDatabaseUserApiRequest{ApiService: mockUsersAPI})
+
+				internalServerError := &admin.GenericOpenAPIError{}
+				internalServerError.SetModel(admin.ApiError{ErrorCode: pointer.MakePtr("500")})
+				mockUsersAPI.EXPECT().DeleteDatabaseUserExecute(admin.DeleteDatabaseUserApiRequest{ApiService: mockUsersAPI}).
+					Return(nil, &http.Response{StatusCode: http.StatusInternalServerError}, fmt.Errorf("some problem"))
+			},
+			expectedErr: "some problem",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockUsersAPI := mockadmin.NewDatabaseUsersApi(t)
+			tt.setupMock(mockUsersAPI)
+
+			dus := &AtlasUsers{
+				usersAPI: mockUsersAPI,
+			}
+			err := dus.Delete(ctx, db, projectID, username)
+
+			if tt.expectedErr != "" {
+				require.Equal(t, tt.expectedErr, err.Error())
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
 }

--- a/pkg/controller/atlas/api_error.go
+++ b/pkg/controller/atlas/api_error.go
@@ -14,6 +14,9 @@ const (
 	// Error indicates that the database user doesn't exist
 	UsernameNotFound = "USERNAME_NOT_FOUND"
 
+	// Error indicates that the database user doesn't exist
+	UserNotfound = "USER_NOT_FOUND"
+
 	// Error indicates that the cluster doesn't exist
 	ClusterNotFound = "CLUSTER_NOT_FOUND"
 


### PR DESCRIPTION
### All Submissions:
**What and why?**
There's an inconsistency in error codes: "USERNAME_NOT_FOUND" when fetching a user versus "USER_NOT_FOUND" when deleting. This discrepancy causes the operator to error, preventing the removal of the finalizer and blocking resource deletion.
* [x] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [x] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if there is one).
* [x] Update docs/release-notes/release-notes-template.md if your changes should be included in the release notes for the next release.
