### PR TITLE
Add label retest after licenses update

### DIFF
--- a/.github/workflows/update-licenses.yml
+++ b/.github/workflows/update-licenses.yml
@@ -20,9 +20,11 @@ jobs:
   update-licenses:
     name: Recompute licenses & update PR
     runs-on: ubuntu-latest
+    environment: release
     env:
       BRANCH: ${{ inputs.branch || github.ref_name  }}
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      JWT_APP_ID: ${{ secrets.AKO_RELEASER_APP_ID }}
+      JWT_RSA_PEM_KEY_BASE64: ${{ secrets.AKO_RELEASER_RSA_KEY_BASE64 }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -39,6 +41,8 @@ jobs:
 
       - name: Commit as needed
         run: |
+          make tools/makejwt/makejwt
+          export GITHUB_TOKEN=$(make github-token)
           if [[ $(git diff --stat) != '' ]]; then
             echo 'Committing changes'
             git config user.email "akobot@ako-team-fake.mongodb.com"
@@ -46,6 +50,9 @@ jobs:
             git add .
             git commit -m "Fix licenses after dependabot changes" -m "[dependabot skip]"
             git push
+
+            echo 'Adding label retest'
+            gh pr edit ${{ env.BRANCH }} --add-label retest
           else
             echo 'Clean nothing to do'
           fi


### PR DESCRIPTION
After requesting extra permissions for our [GitHub App ako releaser](https://github.com/apps/ako-releaser/installations/44334998) with this [Zendesk ticket](https://help-it.mongodb.com/hc/en-us/requests/437709) this change should make the AKO bot updating licenses to auto label the PR with retest, so it will complete the unit tests without our manual intervention.

✅ [Manual workflow is able to set the `retest` tag on its own](https://github.com/mongodb/mongodb-atlas-kubernetes/actions/runs/10507336462)

### All Submissions:

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
