### PR TITLE
CLOUDP-270164: Fix local tests scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,9 +161,6 @@ unit-test:
 .PHONY: int-test
 int-test: ENVTEST_ASSETS_DIR = $(shell pwd)/testbin
 int-test: ENVTEST_K8S_VERSION = 1.26.1
-int-test: export ATLAS_ORG_ID=$(shell grep "ATLAS_ORG_ID" .actrc | cut -d "=" -f 2)
-int-test: export ATLAS_PUBLIC_KEY=$(shell grep "ATLAS_PUBLIC_KEY" .actrc | cut -d "=" -f 2)
-int-test: export ATLAS_PRIVATE_KEY=$(shell grep "ATLAS_PRIVATE_KEY" .actrc | cut -d "=" -f 2)
 # magical env that if specified makes the test output 0 on successful runs
 # https://github.com/onsi/ginkgo/blob/master/ginkgo/run_command.go#L130
 int-test: export GINKGO_EDITOR_INTEGRATION="true"

--- a/scripts/e2e_local.sh
+++ b/scripts/e2e_local.sh
@@ -23,8 +23,9 @@ export INPUT_ENV=dev
 
 if [[ "${build}" == "true" ]]; then
     ./.github/actions/gen-install-scripts/entrypoint.sh
-    awk '{gsub(/cloud.mongodb.com/, "cloud-qa.mongodb.com", $0); print}' bundle/manifests/mongodb-atlas-kubernetes.clusterserviceversion.yaml > tmp && mv tmp bundle/manifests/mongodb-atlas-kubernetes.clusterserviceversion.yaml
+    awk '{gsub(/cloud.mongodb.com/, "cloud-qa.mongodb.com", $0); print}' bundle/manifests/mongodb-atlas-kubernetes.clusterserviceversion.yaml > yaml.tmp && mv yaml.tmp bundle/manifests/mongodb-atlas-kubernetes.clusterserviceversion.yaml
 
+    make all-platforms
     docker build -f fast.Dockerfile -t "${image}" .
     docker push "${image}"
 

--- a/scripts/int_local.sh
+++ b/scripts/int_local.sh
@@ -11,9 +11,9 @@ public_key=$(grep "ATLAS_PUBLIC_KEY" .actrc | cut -d "=" -f 2)
 private_key=$(grep "ATLAS_PRIVATE_KEY" .actrc | cut -d "=" -f 2)
 org_id=$(grep "ATLAS_ORG_ID" .actrc | cut -d "=" -f 2)
 
-export MCLI_OPS_MANAGER_URL="https://cloud-qa.mongodb.com/"
-export MCLI_PUBLIC_API_KEY="${public_key}"
-export MCLI_PRIVATE_API_KEY="${private_key}"
-export MCLI_ORG_ID="${org_id}"
+export MCLI_OPS_MANAGER_URL="${MCLI_OPS_MANAGER_URL:-https://cloud-qa.mongodb.com/}"
+export MCLI_PUBLIC_API_KEY="${MCLI_PUBLIC_API_KEY:-$public_key}"
+export MCLI_PRIVATE_API_KEY="${MCLI_PRIVATE_API_KEY:-$private_key}"
+export MCLI_ORG_ID="${MCLI_ORG_ID:-$org_id}"
 
 AKO_INT_TEST=1 ginkgo run --race --label-filter="${label}" --timeout 80m -v ./test/int ./test/int/clusterwide -coverprofile cover.out


### PR DESCRIPTION
- Fix `e2e` local script errors.
- Fix `int` local script for consistency to also prefer MCLI en vars of arcrc configs. Also remove redundant code in Makefile about this.

### All Submissions:

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if there is one).
* [ ] Update docs/release-notes/release-notes-template.md if your changes should be included in the release notes for the next release.
