### PR TITLE
Fix license update re-adding retest label

### DIFF
--- a/.github/workflows/update-licenses.yml
+++ b/.github/workflows/update-licenses.yml
@@ -52,6 +52,7 @@ jobs:
             git push
 
             echo 'Adding label retest'
+            gh pr edit ${{ env.BRANCH }} --remove-label retest
             gh pr edit ${{ env.BRANCH }} --add-label retest
           else
             echo 'Clean nothing to do'


### PR DESCRIPTION
Small change to https://github.com/mongodb/mongodb-atlas-kubernetes/pull/1780, which would attempt to add the retest label (to run tests again) even if it was already there, which would not run the tests. We now remove it beforehand, to ensure that the tests are run.

I have tested locally and attempting to remove a label that does not exist is fine (exit code 0), so this should not affect fresh PRs.

### All Submissions:

* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if there is one).
* [ ] Update docs/release-notes/release-notes-template.md if your changes should be included in the release notes for the next release.
