### PR TITLE
CLOUDP-266544: Refactor Database User state machine

### DIFF
--- a/pkg/controller/atlasdatabaseuser/databaseuser_test.go
+++ b/pkg/controller/atlasdatabaseuser/databaseuser_test.go
@@ -2,49 +2,2045 @@ package atlasdatabaseuser
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"github.com/stretchr/testify/require"
 	"go.mongodb.org/atlas-sdk/v20231115008/admin"
 	"go.mongodb.org/atlas-sdk/v20231115008/mockadmin"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
 	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/kube"
-	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/mocks/atlas"
-	mocked "github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/mocks/translation"
+	atlasmock "github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/mocks/atlas"
+	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/mocks/translation"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/translation/dbuser"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/translation/deployment"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/api"
 	akov2 "github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/api/v1"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/api/v1/common"
-	"github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/controller/connectionsecret"
+	"github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/api/v1/status"
+	"github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/controller/atlas"
+	"github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/controller/customresource"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/controller/workflow"
+	"github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/version"
 )
 
-const (
-	testUserPasswordName = "password-name"
+func TestHandleDatabaseUser(t *testing.T) {
+	tests := map[string]struct {
+		dbUserInAKO        *akov2.AtlasDatabaseUser
+		dbUserSecret       *corev1.Secret
+		atlasProject       *akov2.AtlasProject
+		atlasProvider      func() atlas.Provider
+		expectedResult     ctrl.Result
+		expectedConditions []api.Condition
+	}{
+		"user spec is invalid": {
+			dbUserInAKO: &akov2.AtlasDatabaseUser{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "user1",
+					Namespace: "default",
+					Labels: map[string]string{
+						"mongodb.com/atlas-resource-version": "invalid-version",
+					},
+				},
+				Spec: akov2.AtlasDatabaseUserSpec{
+					Username: "user1",
+					PasswordSecret: &common.ResourceRef{
+						Name: "user-pass",
+					},
+					DatabaseName: "admin",
+				},
+			},
+			atlasProvider: func() atlas.Provider {
+				return &atlasmock.TestProvider{}
+			},
+			expectedResult: ctrl.Result{RequeueAfter: workflow.DefaultRetry},
+			expectedConditions: []api.Condition{
+				api.FalseCondition(api.ResourceVersionStatus).
+					WithReason(string(workflow.AtlasResourceVersionIsInvalid)).
+					WithMessageRegexp("invalid-version is not a valid semver version for label mongodb.com/atlas-resource-version"),
+			},
+		},
+		"user spec is mismatch": {
+			dbUserInAKO: &akov2.AtlasDatabaseUser{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "user1",
+					Namespace: "default",
+					Labels: map[string]string{
+						"mongodb.com/atlas-resource-version": "1000.0.1",
+					},
+				},
+				Spec: akov2.AtlasDatabaseUserSpec{
+					Username: "user1",
+					PasswordSecret: &common.ResourceRef{
+						Name: "user-pass",
+					},
+					DatabaseName: "admin",
+				},
+			},
+			atlasProvider: func() atlas.Provider {
+				return &atlasmock.TestProvider{}
+			},
+			expectedResult: ctrl.Result{RequeueAfter: workflow.DefaultRetry},
+			expectedConditions: []api.Condition{
+				api.FalseCondition(api.ResourceVersionStatus).
+					WithReason(string(workflow.AtlasResourceVersionMismatch)).
+					WithMessageRegexp("version of the resource 'user1' is higher than the operator version '2.4.1'"),
+			},
+		},
+		"resource is not supported": {
+			dbUserInAKO: &akov2.AtlasDatabaseUser{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "user1",
+					Namespace: "default",
+					Labels: map[string]string{
+						"mongodb.com/atlas-resource-version": "2.4.1",
+					},
+				},
+				Spec: akov2.AtlasDatabaseUserSpec{
+					Username: "user1",
+					PasswordSecret: &common.ResourceRef{
+						Name: "user-pass",
+					},
+					DatabaseName: "admin",
+				},
+			},
+			atlasProvider: func() atlas.Provider {
+				return &atlasmock.TestProvider{
+					IsSupportedFunc: func() bool {
+						return false
+					},
+				}
+			},
+			expectedResult: ctrl.Result{},
+			expectedConditions: []api.Condition{
+				api.TrueCondition(api.ResourceVersionStatus),
+				api.TrueCondition(api.ValidationSucceeded),
+				api.FalseCondition(api.DatabaseUserReadyType).
+					WithReason(string(workflow.AtlasGovUnsupported)).
+					WithMessageRegexp("the *v1.AtlasDatabaseUser is not supported by Atlas for government"),
+			},
+		},
+		"failed to get project": {
+			dbUserInAKO: &akov2.AtlasDatabaseUser{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "user1",
+					Namespace: "default",
+					Labels: map[string]string{
+						"mongodb.com/atlas-resource-version": "2.4.1",
+					},
+				},
+				Spec: akov2.AtlasDatabaseUserSpec{
+					Project: common.ResourceRefNamespaced{
+						Name:      "my-project",
+						Namespace: "default",
+					},
+					Username: "user1",
+					PasswordSecret: &common.ResourceRef{
+						Name: "user-pass",
+					},
+					DatabaseName: "admin",
+				},
+			},
+			atlasProvider: func() atlas.Provider {
+				return &atlasmock.TestProvider{
+					IsSupportedFunc: func() bool {
+						return true
+					},
+				}
+			},
+			expectedResult: ctrl.Result{RequeueAfter: workflow.DefaultRetry},
+			expectedConditions: []api.Condition{
+				api.TrueCondition(api.ResourceVersionStatus),
+				api.TrueCondition(api.ValidationSucceeded),
+				api.FalseCondition(api.DatabaseUserReadyType).
+					WithReason(string(workflow.Internal)).
+					WithMessageRegexp("atlasprojects.atlas.mongodb.com \"my-project\" not found"),
+			},
+		},
+		"failed to create atlas sdk": {
+			dbUserInAKO: &akov2.AtlasDatabaseUser{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "user1",
+					Namespace: "default",
+					Labels: map[string]string{
+						"mongodb.com/atlas-resource-version": "2.4.1",
+					},
+				},
+				Spec: akov2.AtlasDatabaseUserSpec{
+					Project: common.ResourceRefNamespaced{
+						Name:      "my-project",
+						Namespace: "default",
+					},
+					Username: "user1",
+					PasswordSecret: &common.ResourceRef{
+						Name: "user-pass",
+					},
+					DatabaseName: "admin",
+				},
+			},
+			atlasProject: &akov2.AtlasProject{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-project",
+					Namespace: "default",
+				},
+				Spec: akov2.AtlasProjectSpec{
+					Name: "my-project",
+				},
+			},
+			atlasProvider: func() atlas.Provider {
+				return &atlasmock.TestProvider{
+					IsSupportedFunc: func() bool {
+						return true
+					},
+					SdkClientFunc: func(secretRef *client.ObjectKey, log *zap.SugaredLogger) (*admin.APIClient, string, error) {
+						return nil, "", errors.New("failed to create client")
+					},
+				}
+			},
+			expectedResult: ctrl.Result{RequeueAfter: workflow.DefaultRetry},
+			expectedConditions: []api.Condition{
+				api.TrueCondition(api.ResourceVersionStatus),
+				api.TrueCondition(api.ValidationSucceeded),
+				api.FalseCondition(api.DatabaseUserReadyType).
+					WithReason(string(workflow.AtlasAPIAccessNotConfigured)).
+					WithMessageRegexp("failed to create client"),
+			},
+		},
+		"manage user": {
+			dbUserInAKO: &akov2.AtlasDatabaseUser{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "user1",
+					Namespace: "default",
+					Labels: map[string]string{
+						"mongodb.com/atlas-resource-version": "2.4.1",
+					},
+				},
+				Spec: akov2.AtlasDatabaseUserSpec{
+					Project: common.ResourceRefNamespaced{
+						Name:      "my-project",
+						Namespace: "default",
+					},
+					Username: "user1",
+					PasswordSecret: &common.ResourceRef{
+						Name: "user-pass",
+					},
+					DatabaseName: "admin",
+				},
+			},
+			dbUserSecret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "user-pass",
+					Namespace: "default",
+					Labels: map[string]string{
+						"atlas.mongodb.com/type": "credentials",
+					},
+				},
+				Data: map[string][]byte{
+					"password": []byte("Passw0rd!"),
+				},
+			},
+			atlasProject: &akov2.AtlasProject{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-project",
+					Namespace: "default",
+				},
+				Spec: akov2.AtlasProjectSpec{
+					Name: "my-project",
+				},
+			},
+			atlasProvider: func() atlas.Provider {
+				return &atlasmock.TestProvider{
+					IsSupportedFunc: func() bool {
+						return true
+					},
+					IsCloudGovFunc: func() bool {
+						return false
+					},
+					SdkClientFunc: func(secretRef *client.ObjectKey, log *zap.SugaredLogger) (*admin.APIClient, string, error) {
+						userAPI := mockadmin.NewDatabaseUsersApi(t)
+						userAPI.EXPECT().GetDatabaseUser(context.Background(), "", "admin", "user1").
+							Return(admin.GetDatabaseUserApiRequest{ApiService: userAPI})
+						userAPI.EXPECT().GetDatabaseUserExecute(mock.AnythingOfType("admin.GetDatabaseUserApiRequest")).
+							Return(nil, nil, nil)
+						userAPI.EXPECT().CreateDatabaseUser(context.Background(), "", mock.AnythingOfType("*admin.CloudDatabaseUser")).
+							Return(admin.CreateDatabaseUserApiRequest{ApiService: userAPI})
+						userAPI.EXPECT().CreateDatabaseUserExecute(mock.AnythingOfType("admin.CreateDatabaseUserApiRequest")).
+							Return(&admin.CloudDatabaseUser{}, nil, nil)
 
-	nonExistingCluster = "non-existing-cluster"
+						clusterAPI := mockadmin.NewClustersApi(t)
 
-	testDeployment = "deployment"
-)
+						return &admin.APIClient{
+							ClustersApi:      clusterAPI,
+							DatabaseUsersApi: userAPI,
+						}, "", nil
+					},
+				}
+			},
+			expectedResult: ctrl.Result{RequeueAfter: workflow.DefaultRetry},
+			expectedConditions: []api.Condition{
+				api.TrueCondition(api.ResourceVersionStatus),
+				api.TrueCondition(api.ValidationSucceeded),
+				api.FalseCondition(api.DatabaseUserReadyType).
+					WithReason(string(workflow.DatabaseUserDeploymentAppliedChanges)).
+					WithMessageRegexp("Clusters are scheduled to handle database users updates"),
+			},
+		},
+	}
 
-func init() {
-	logger, _ := zap.NewDevelopment()
-	zap.ReplaceGlobals(logger)
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			testScheme := runtime.NewScheme()
+			assert.NoError(t, akov2.AddToScheme(testScheme))
+			assert.NoError(t, corev1.AddToScheme(testScheme))
+			k8sClient := fake.NewClientBuilder().
+				WithScheme(testScheme).
+				WithObjects(tt.dbUserInAKO).
+				WithStatusSubresource(tt.dbUserInAKO)
+
+			if tt.atlasProject != nil {
+				k8sClient.WithObjects(tt.atlasProject)
+			}
+
+			if tt.dbUserSecret != nil {
+				k8sClient.WithObjects(tt.dbUserSecret)
+			}
+
+			logger := zaptest.NewLogger(t).Sugar()
+			r := AtlasDatabaseUserReconciler{
+				Client:        k8sClient.Build(),
+				AtlasProvider: tt.atlasProvider(),
+				Log:           logger,
+			}
+			ctx := &workflow.Context{
+				Context: context.Background(),
+				Log:     logger,
+			}
+			version.Version = "2.4.1"
+
+			result := r.handleDatabaseUser(ctx, tt.dbUserInAKO)
+			assert.Equal(t, tt.expectedResult, result)
+			logger.Infof("conditions", ctx.Conditions())
+			assert.True(
+				t,
+				cmp.Equal(
+					tt.expectedConditions,
+					ctx.Conditions(),
+					cmpopts.IgnoreFields(api.Condition{}, "LastTransitionTime"),
+				),
+			)
+		})
+	}
 }
 
-func TestFilterScopeClusters(t *testing.T) {
+func TestDbuLifeCycle(t *testing.T) {
+	deletionTime := metav1.Now()
+
+	tests := map[string]struct {
+		dbUserInAKO        *akov2.AtlasDatabaseUser
+		dbUserSecret       *corev1.Secret
+		dbUserService      func() dbuser.AtlasUsersService
+		dService           func() deployment.AtlasDeploymentsService
+		expectedResult     ctrl.Result
+		expectedConditions []api.Condition
+	}{
+		"failed to get user in atlas": {
+			dbUserInAKO: &akov2.AtlasDatabaseUser{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "user1",
+					Namespace: "default",
+				},
+				Spec: akov2.AtlasDatabaseUserSpec{
+					Username: "user1",
+					PasswordSecret: &common.ResourceRef{
+						Name: "user-pass",
+					},
+					DatabaseName: "admin",
+				},
+				Status: status.AtlasDatabaseUserStatus{
+					PasswordVersion: "888",
+				},
+			},
+			dbUserSecret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "user-pass",
+					Namespace: "default",
+					Labels: map[string]string{
+						"atlas.mongodb.com/type": "credentials",
+					},
+				},
+				Data: map[string][]byte{
+					"password": []byte("Passw0rd!"),
+				},
+			},
+			dbUserService: func() dbuser.AtlasUsersService {
+				service := translation.NewAtlasUsersServiceMock(t)
+				service.EXPECT().Get(context.Background(), "admin", "", "user1").
+					Return(nil, errors.New("failed to get user"))
+
+				return service
+			},
+			dService: func() deployment.AtlasDeploymentsService {
+				return translation.NewAtlasDeploymentsServiceMock(t)
+			},
+			expectedResult: ctrl.Result{RequeueAfter: workflow.DefaultRetry},
+			expectedConditions: []api.Condition{
+				api.FalseCondition(api.DatabaseUserReadyType).
+					WithReason(string(workflow.Internal)).
+					WithMessageRegexp("failed to get user"),
+			},
+		},
+		"failed to check user is expired": {
+			dbUserInAKO: &akov2.AtlasDatabaseUser{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "user1",
+					Namespace: "default",
+				},
+				Spec: akov2.AtlasDatabaseUserSpec{
+					Username: "user1",
+					PasswordSecret: &common.ResourceRef{
+						Name: "user-pass",
+					},
+					DatabaseName:    "admin",
+					DeleteAfterDate: "wrong-date",
+				},
+				Status: status.AtlasDatabaseUserStatus{
+					PasswordVersion: "888",
+				},
+			},
+			dbUserSecret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "user-pass",
+					Namespace: "default",
+					Labels: map[string]string{
+						"atlas.mongodb.com/type": "credentials",
+					},
+				},
+				Data: map[string][]byte{
+					"password": []byte("Passw0rd!"),
+				},
+			},
+			dbUserService: func() dbuser.AtlasUsersService {
+				service := translation.NewAtlasUsersServiceMock(t)
+				service.EXPECT().Get(context.Background(), "admin", "", "user1").Return(nil, nil)
+
+				return service
+			},
+			dService: func() deployment.AtlasDeploymentsService {
+				return translation.NewAtlasDeploymentsServiceMock(t)
+			},
+			expectedResult: ctrl.Result{},
+			expectedConditions: []api.Condition{
+				api.FalseCondition(api.DatabaseUserReadyType).
+					WithReason(string(workflow.DatabaseUserInvalidSpec)).
+					WithMessageRegexp("parsing time \"wrong-date\" as \"2006-01-02T15:04:05.999Z\": cannot parse \"wrong-date\" as \"2006\""),
+			},
+		},
+		"user is expired": {
+			dbUserInAKO: &akov2.AtlasDatabaseUser{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "user1",
+					Namespace: "default",
+				},
+				Spec: akov2.AtlasDatabaseUserSpec{
+					Username: "user1",
+					PasswordSecret: &common.ResourceRef{
+						Name: "user-pass",
+					},
+					DatabaseName:    "admin",
+					DeleteAfterDate: "2021-05-30T13:45:30Z",
+				},
+				Status: status.AtlasDatabaseUserStatus{
+					PasswordVersion: "888",
+				},
+			},
+			dbUserSecret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "user-pass",
+					Namespace: "default",
+					Labels: map[string]string{
+						"atlas.mongodb.com/type": "credentials",
+					},
+				},
+				Data: map[string][]byte{
+					"password": []byte("Passw0rd!"),
+				},
+			},
+			dbUserService: func() dbuser.AtlasUsersService {
+				service := translation.NewAtlasUsersServiceMock(t)
+				service.EXPECT().Get(context.Background(), "admin", "", "user1").Return(nil, nil)
+
+				return service
+			},
+			dService: func() deployment.AtlasDeploymentsService {
+				return translation.NewAtlasDeploymentsServiceMock(t)
+			},
+			expectedResult: ctrl.Result{},
+			expectedConditions: []api.Condition{
+				api.FalseCondition(api.DatabaseUserReadyType).
+					WithReason(string(workflow.DatabaseUserExpired)).
+					WithMessageRegexp("an expired user cannot be managed"),
+			},
+		},
+		"failed to validate scope": {
+			dbUserInAKO: &akov2.AtlasDatabaseUser{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "user1",
+					Namespace: "default",
+				},
+				Spec: akov2.AtlasDatabaseUserSpec{
+					Username: "user1",
+					PasswordSecret: &common.ResourceRef{
+						Name: "user-pass",
+					},
+					DatabaseName: "admin",
+					Scopes: []akov2.ScopeSpec{
+						{
+							Name: "cluster1",
+							Type: akov2.DeploymentScopeType,
+						},
+					},
+				},
+				Status: status.AtlasDatabaseUserStatus{
+					PasswordVersion: "888",
+				},
+			},
+			dbUserSecret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "user-pass",
+					Namespace: "default",
+					Labels: map[string]string{
+						"atlas.mongodb.com/type": "credentials",
+					},
+				},
+				Data: map[string][]byte{
+					"password": []byte("Passw0rd!"),
+				},
+			},
+			dbUserService: func() dbuser.AtlasUsersService {
+				service := translation.NewAtlasUsersServiceMock(t)
+				service.EXPECT().Get(context.Background(), "admin", "", "user1").Return(nil, nil)
+
+				return service
+			},
+			dService: func() deployment.AtlasDeploymentsService {
+				service := translation.NewAtlasDeploymentsServiceMock(t)
+				service.EXPECT().ClusterExists(context.Background(), "", "cluster1").
+					Return(false, errors.New("failed to check cluster exists"))
+
+				return service
+			},
+			expectedResult: ctrl.Result{},
+			expectedConditions: []api.Condition{
+				api.FalseCondition(api.DatabaseUserReadyType).
+					WithReason(string(workflow.DatabaseUserInvalidSpec)).
+					WithMessageRegexp("failed to check cluster exists"),
+			},
+		},
+		"deployment scope is invalid": {
+			dbUserInAKO: &akov2.AtlasDatabaseUser{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "user1",
+					Namespace: "default",
+				},
+				Spec: akov2.AtlasDatabaseUserSpec{
+					Username: "user1",
+					PasswordSecret: &common.ResourceRef{
+						Name: "user-pass",
+					},
+					DatabaseName: "admin",
+					Scopes: []akov2.ScopeSpec{
+						{
+							Name: "cluster1",
+							Type: akov2.DeploymentScopeType,
+						},
+					},
+				},
+				Status: status.AtlasDatabaseUserStatus{
+					PasswordVersion: "888",
+				},
+			},
+			dbUserSecret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "user-pass",
+					Namespace: "default",
+					Labels: map[string]string{
+						"atlas.mongodb.com/type": "credentials",
+					},
+				},
+				Data: map[string][]byte{
+					"password": []byte("Passw0rd!"),
+				},
+			},
+			dbUserService: func() dbuser.AtlasUsersService {
+				service := translation.NewAtlasUsersServiceMock(t)
+				service.EXPECT().Get(context.Background(), "admin", "", "user1").Return(nil, nil)
+
+				return service
+			},
+			dService: func() deployment.AtlasDeploymentsService {
+				service := translation.NewAtlasDeploymentsServiceMock(t)
+				service.EXPECT().ClusterExists(context.Background(), "", "cluster1").
+					Return(false, nil)
+
+				return service
+			},
+			expectedResult: ctrl.Result{},
+			expectedConditions: []api.Condition{
+				api.FalseCondition(api.DatabaseUserReadyType).
+					WithReason(string(workflow.DatabaseUserInvalidSpec)).
+					WithMessageRegexp("\"scopes\" field refer to one or more deployments that don't exist"),
+			},
+		},
+		"create an user": {
+			dbUserInAKO: &akov2.AtlasDatabaseUser{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "user1",
+					Namespace: "default",
+				},
+				Spec: akov2.AtlasDatabaseUserSpec{
+					Username: "user1",
+					PasswordSecret: &common.ResourceRef{
+						Name: "user-pass",
+					},
+					DatabaseName: "admin",
+				},
+			},
+			dbUserSecret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "user-pass",
+					Namespace: "default",
+					Labels: map[string]string{
+						"atlas.mongodb.com/type": "credentials",
+					},
+				},
+				Data: map[string][]byte{
+					"password": []byte("Passw0rd!"),
+				},
+			},
+			dbUserService: func() dbuser.AtlasUsersService {
+				service := translation.NewAtlasUsersServiceMock(t)
+				service.EXPECT().Get(context.Background(), "admin", "", "user1").Return(nil, nil)
+				service.EXPECT().Create(context.Background(), mock.AnythingOfType("*dbuser.User")).Return(nil)
+
+				return service
+			},
+			dService: func() deployment.AtlasDeploymentsService {
+				return translation.NewAtlasDeploymentsServiceMock(t)
+			},
+			expectedResult: ctrl.Result{RequeueAfter: workflow.DefaultRetry},
+			expectedConditions: []api.Condition{
+				api.FalseCondition(api.DatabaseUserReadyType).
+					WithReason(string(workflow.DatabaseUserDeploymentAppliedChanges)).
+					WithMessageRegexp("Clusters are scheduled to handle database users updates"),
+			},
+		},
+		"update an user": {
+			dbUserInAKO: &akov2.AtlasDatabaseUser{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "user1",
+					Namespace: "default",
+				},
+				Spec: akov2.AtlasDatabaseUserSpec{
+					Username: "user1",
+					PasswordSecret: &common.ResourceRef{
+						Name: "user-pass",
+					},
+					DatabaseName: "admin",
+				},
+				Status: status.AtlasDatabaseUserStatus{
+					PasswordVersion: "999",
+				},
+			},
+			dbUserSecret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "user-pass",
+					Namespace: "default",
+					Labels: map[string]string{
+						"atlas.mongodb.com/type": "credentials",
+					},
+				},
+				Data: map[string][]byte{
+					"password": []byte("Passw0rd!"),
+				},
+			},
+			dbUserService: func() dbuser.AtlasUsersService {
+				service := translation.NewAtlasUsersServiceMock(t)
+				service.EXPECT().Get(context.Background(), "admin", "", "user1").
+					Return(
+						&dbuser.User{
+							AtlasDatabaseUserSpec: &akov2.AtlasDatabaseUserSpec{
+								Username: "user1",
+								PasswordSecret: &common.ResourceRef{
+									Name: "user-pass",
+								},
+								DatabaseName: "admin",
+							},
+						},
+						nil,
+					)
+
+				return service
+			},
+			dService: func() deployment.AtlasDeploymentsService {
+				service := translation.NewAtlasDeploymentsServiceMock(t)
+				service.EXPECT().ListClusterNames(context.Background(), "").Return([]string{}, nil)
+				service.EXPECT().ListDeploymentConnections(context.Background(), "").Return([]deployment.Connection{}, nil)
+
+				return service
+			},
+			expectedResult: ctrl.Result{},
+			expectedConditions: []api.Condition{
+				api.TrueCondition(api.ReadyType),
+				api.TrueCondition(api.DatabaseUserReadyType),
+			},
+		},
+		"delete an user": {
+			dbUserInAKO: &akov2.AtlasDatabaseUser{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "user1",
+					Namespace:         "default",
+					Finalizers:        []string{"mongodbatlas/finalizer"},
+					DeletionTimestamp: &deletionTime,
+				},
+				Spec: akov2.AtlasDatabaseUserSpec{
+					Username: "user1",
+					PasswordSecret: &common.ResourceRef{
+						Name: "user-pass",
+					},
+					DatabaseName: "admin",
+				},
+				Status: status.AtlasDatabaseUserStatus{
+					PasswordVersion: "999",
+				},
+			},
+			dbUserSecret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "user-pass",
+					Namespace: "default",
+					Labels: map[string]string{
+						"atlas.mongodb.com/type": "credentials",
+					},
+				},
+				Data: map[string][]byte{
+					"password": []byte("Passw0rd!"),
+				},
+			},
+			dbUserService: func() dbuser.AtlasUsersService {
+				service := translation.NewAtlasUsersServiceMock(t)
+				service.EXPECT().Get(context.Background(), "admin", "", "user1").
+					Return(
+						&dbuser.User{
+							AtlasDatabaseUserSpec: &akov2.AtlasDatabaseUserSpec{
+								Username: "user1",
+								PasswordSecret: &common.ResourceRef{
+									Name: "user-pass",
+								},
+								DatabaseName: "admin",
+							},
+						},
+						nil,
+					)
+				service.EXPECT().Delete(context.Background(), "admin", "", "user1").Return(nil)
+
+				return service
+			},
+			dService: func() deployment.AtlasDeploymentsService {
+				return translation.NewAtlasDeploymentsServiceMock(t)
+			},
+			expectedResult: ctrl.Result{},
+		},
+		"unamage an user": {
+			dbUserInAKO: &akov2.AtlasDatabaseUser{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "user1",
+					Namespace:         "default",
+					Finalizers:        []string{"mongodbatlas/finalizer"},
+					DeletionTimestamp: &deletionTime,
+				},
+				Spec: akov2.AtlasDatabaseUserSpec{
+					Username: "user1",
+					PasswordSecret: &common.ResourceRef{
+						Name: "user-pass",
+					},
+					DatabaseName: "admin",
+				},
+				Status: status.AtlasDatabaseUserStatus{
+					PasswordVersion: "999",
+				},
+			},
+			dbUserSecret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "user-pass",
+					Namespace: "default",
+					Labels: map[string]string{
+						"atlas.mongodb.com/type": "credentials",
+					},
+				},
+				Data: map[string][]byte{
+					"password": []byte("Passw0rd!"),
+				},
+			},
+			dbUserService: func() dbuser.AtlasUsersService {
+				service := translation.NewAtlasUsersServiceMock(t)
+				service.EXPECT().Get(context.Background(), "admin", "", "user1").
+					Return(nil, nil)
+
+				return service
+			},
+			dService: func() deployment.AtlasDeploymentsService {
+				return translation.NewAtlasDeploymentsServiceMock(t)
+			},
+			expectedResult: ctrl.Result{},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			testScheme := runtime.NewScheme()
+			assert.NoError(t, akov2.AddToScheme(testScheme))
+			assert.NoError(t, corev1.AddToScheme(testScheme))
+			k8sClient := fake.NewClientBuilder().
+				WithScheme(testScheme).
+				WithObjects(tt.dbUserInAKO).
+				WithStatusSubresource(tt.dbUserInAKO)
+
+			if tt.dbUserSecret != nil {
+				k8sClient.WithObjects(tt.dbUserSecret)
+			}
+
+			logger := zaptest.NewLogger(t).Sugar()
+			r := AtlasDatabaseUserReconciler{
+				Client:            k8sClient.Build(),
+				Log:               logger,
+				dbUserService:     tt.dbUserService(),
+				deploymentService: tt.dService(),
+			}
+			ctx := &workflow.Context{
+				Context: context.Background(),
+				Log:     logger,
+			}
+
+			result := r.dbuLifeCycle(ctx, tt.dbUserInAKO, &akov2.AtlasProject{})
+			assert.Equal(t, tt.expectedResult, result)
+			assert.True(
+				t,
+				cmp.Equal(
+					tt.expectedConditions,
+					ctx.Conditions(),
+					cmpopts.IgnoreFields(api.Condition{}, "LastTransitionTime"),
+				),
+			)
+		})
+	}
+}
+
+func TestCreate(t *testing.T) {
+	tests := map[string]struct {
+		dbUserInAKO        *akov2.AtlasDatabaseUser
+		dbUserSecret       *corev1.Secret
+		dbUserService      func() dbuser.AtlasUsersService
+		oidcFlag           bool
+		expectedResult     ctrl.Result
+		expectedConditions []api.Condition
+	}{
+		"failed to set OIDC config when feature is not enabled": {
+			dbUserInAKO: &akov2.AtlasDatabaseUser{
+				Spec: akov2.AtlasDatabaseUserSpec{
+					OIDCAuthType: "USER",
+				},
+			},
+			oidcFlag: false,
+			dbUserService: func() dbuser.AtlasUsersService {
+				return translation.NewAtlasUsersServiceMock(t)
+			},
+			expectedResult: ctrl.Result{},
+			expectedConditions: []api.Condition{
+				api.FalseCondition(api.DatabaseUserReadyType).
+					WithReason(string(workflow.Internal)).
+					WithMessageRegexp(ErrOIDCNotEnabled.Error()),
+			},
+		},
+		"failed to read user password": {
+			dbUserInAKO: &akov2.AtlasDatabaseUser{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "user1",
+					Namespace: "default",
+				},
+				Spec: akov2.AtlasDatabaseUserSpec{
+					Username: "user1",
+					PasswordSecret: &common.ResourceRef{
+						Name: "user-pass",
+					},
+				},
+			},
+			oidcFlag: false,
+			dbUserService: func() dbuser.AtlasUsersService {
+				return translation.NewAtlasUsersServiceMock(t)
+			},
+			expectedResult: ctrl.Result{RequeueAfter: workflow.DefaultRetry},
+			expectedConditions: []api.Condition{
+				api.FalseCondition(api.DatabaseUserReadyType).
+					WithReason(string(workflow.Internal)).
+					WithMessageRegexp("secrets \"user-pass\" not found"),
+			},
+		},
+		"failed to convert to internal user": {
+			dbUserInAKO: &akov2.AtlasDatabaseUser{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "user1",
+					Namespace: "default",
+				},
+				Spec: akov2.AtlasDatabaseUserSpec{
+					Username: "user1",
+					PasswordSecret: &common.ResourceRef{
+						Name: "user-pass",
+					},
+					DeleteAfterDate: "wrong-date",
+				},
+			},
+			dbUserSecret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "user-pass",
+					Namespace: "default",
+					Labels: map[string]string{
+						"atlas.mongodb.com/type": "credentials",
+					},
+				},
+				Data: map[string][]byte{
+					"password": []byte("Passw0rd!"),
+				},
+			},
+			oidcFlag: false,
+			dbUserService: func() dbuser.AtlasUsersService {
+				return translation.NewAtlasUsersServiceMock(t)
+			},
+			expectedResult: ctrl.Result{RequeueAfter: workflow.DefaultRetry},
+			expectedConditions: []api.Condition{
+				api.FalseCondition(api.DatabaseUserReadyType).
+					WithReason(string(workflow.Internal)).
+					WithMessageRegexp("failed to create internal user type: failed to parse \"wrong-date\" to an ISO date: parsing time \"wrong-date\" as \"2006-01-02T15:04:05.999Z\": cannot parse \"wrong-date\" as \"2006\""),
+			},
+		},
+		"failed to create user": {
+			dbUserInAKO: &akov2.AtlasDatabaseUser{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "user1",
+					Namespace: "default",
+				},
+				Spec: akov2.AtlasDatabaseUserSpec{
+					Username: "user1",
+					PasswordSecret: &common.ResourceRef{
+						Name: "user-pass",
+					},
+					DatabaseName: "admin",
+				},
+				Status: status.AtlasDatabaseUserStatus{
+					PasswordVersion: "888",
+				},
+			},
+			dbUserSecret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "user-pass",
+					Namespace: "default",
+					Labels: map[string]string{
+						"atlas.mongodb.com/type": "credentials",
+					},
+				},
+				Data: map[string][]byte{
+					"password": []byte("Passw0rd!"),
+				},
+			},
+			oidcFlag: false,
+			dbUserService: func() dbuser.AtlasUsersService {
+				service := translation.NewAtlasUsersServiceMock(t)
+				service.EXPECT().Create(context.Background(), mock.AnythingOfType("*dbuser.User")).
+					Return(errors.New("failed to create user"))
+
+				return service
+			},
+			expectedResult: ctrl.Result{RequeueAfter: workflow.DefaultRetry},
+			expectedConditions: []api.Condition{
+				api.FalseCondition(api.DatabaseUserReadyType).
+					WithReason(string(workflow.DatabaseUserNotCreatedInAtlas)).
+					WithMessageRegexp("failed to create user"),
+			},
+		},
+		"renamed user": {
+			dbUserInAKO: &akov2.AtlasDatabaseUser{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "user1",
+					Namespace: "default",
+				},
+				Spec: akov2.AtlasDatabaseUserSpec{
+					Username: "user-renamed",
+					PasswordSecret: &common.ResourceRef{
+						Name: "user-pass",
+					},
+					DatabaseName: "admin",
+				},
+				Status: status.AtlasDatabaseUserStatus{
+					UserName:        "user1",
+					PasswordVersion: "999",
+				},
+			},
+			dbUserSecret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "user-pass",
+					Namespace: "default",
+					Labels: map[string]string{
+						"atlas.mongodb.com/type": "credentials",
+					},
+				},
+				Data: map[string][]byte{
+					"password": []byte("Passw0rd!"),
+				},
+			},
+			oidcFlag: false,
+			dbUserService: func() dbuser.AtlasUsersService {
+				service := translation.NewAtlasUsersServiceMock(t)
+				service.EXPECT().Create(context.Background(), mock.AnythingOfType("*dbuser.User")).Return(nil)
+				service.EXPECT().Delete(context.Background(), "admin", "", "user1").Return(nil)
+
+				return service
+			},
+			expectedResult: ctrl.Result{RequeueAfter: workflow.DefaultRetry},
+			expectedConditions: []api.Condition{
+				api.FalseCondition(api.DatabaseUserReadyType).
+					WithReason(string(workflow.DatabaseUserDeploymentAppliedChanges)).
+					WithMessageRegexp("Clusters are scheduled to handle database users updates"),
+			},
+		},
+		"create user": {
+			dbUserInAKO: &akov2.AtlasDatabaseUser{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "user1",
+					Namespace: "default",
+				},
+				Spec: akov2.AtlasDatabaseUserSpec{
+					Username: "user1",
+					PasswordSecret: &common.ResourceRef{
+						Name: "user-pass",
+					},
+					DatabaseName: "admin",
+				},
+				Status: status.AtlasDatabaseUserStatus{
+					PasswordVersion: "888",
+				},
+			},
+			dbUserSecret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "user-pass",
+					Namespace: "default",
+					Labels: map[string]string{
+						"atlas.mongodb.com/type": "credentials",
+					},
+				},
+				Data: map[string][]byte{
+					"password": []byte("Passw0rd!"),
+				},
+			},
+			oidcFlag: false,
+			dbUserService: func() dbuser.AtlasUsersService {
+				service := translation.NewAtlasUsersServiceMock(t)
+				service.EXPECT().Create(context.Background(), mock.AnythingOfType("*dbuser.User")).Return(nil)
+
+				return service
+			},
+			expectedResult: ctrl.Result{RequeueAfter: workflow.DefaultRetry},
+			expectedConditions: []api.Condition{
+				api.FalseCondition(api.DatabaseUserReadyType).
+					WithReason(string(workflow.DatabaseUserDeploymentAppliedChanges)).
+					WithMessageRegexp("Clusters are scheduled to handle database users updates"),
+			},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			testScheme := runtime.NewScheme()
+			assert.NoError(t, akov2.AddToScheme(testScheme))
+			assert.NoError(t, corev1.AddToScheme(testScheme))
+			k8sClient := fake.NewClientBuilder().
+				WithScheme(testScheme).
+				WithObjects(tt.dbUserInAKO).
+				WithStatusSubresource(tt.dbUserInAKO)
+
+			if tt.dbUserSecret != nil {
+				k8sClient.WithObjects(tt.dbUserSecret)
+			}
+
+			logger := zaptest.NewLogger(t).Sugar()
+			r := AtlasDatabaseUserReconciler{
+				Client:                        k8sClient.Build(),
+				Log:                           logger,
+				dbUserService:                 tt.dbUserService(),
+				FeaturePreviewOIDCAuthEnabled: tt.oidcFlag,
+			}
+			ctx := &workflow.Context{
+				Context: context.Background(),
+				Log:     logger,
+			}
+
+			result := r.create(ctx, tt.dbUserInAKO, &akov2.AtlasProject{})
+			assert.Equal(t, tt.expectedResult, result)
+			assert.True(
+				t,
+				cmp.Equal(
+					tt.expectedConditions,
+					ctx.Conditions(),
+					cmpopts.IgnoreFields(api.Condition{}, "LastTransitionTime"),
+				),
+			)
+		})
+	}
+}
+
+func TestUpdate(t *testing.T) {
+	tests := map[string]struct {
+		dbUserInAKO        *akov2.AtlasDatabaseUser
+		dbUserSecret       *corev1.Secret
+		dbUserInAtlas      *dbuser.User
+		dbUserService      func() dbuser.AtlasUsersService
+		dService           func() deployment.AtlasDeploymentsService
+		oidcFlag           bool
+		expectedResult     ctrl.Result
+		expectedConditions []api.Condition
+	}{
+		"failed to set OIDC config when feature is not enabled": {
+			dbUserInAKO: &akov2.AtlasDatabaseUser{
+				Spec: akov2.AtlasDatabaseUserSpec{
+					OIDCAuthType: "USER",
+				},
+			},
+			oidcFlag: false,
+			dbUserService: func() dbuser.AtlasUsersService {
+				return translation.NewAtlasUsersServiceMock(t)
+			},
+			dService: func() deployment.AtlasDeploymentsService {
+				return translation.NewAtlasDeploymentsServiceMock(t)
+			},
+			expectedResult: ctrl.Result{},
+			expectedConditions: []api.Condition{
+				api.FalseCondition(api.DatabaseUserReadyType).
+					WithReason(string(workflow.Internal)).
+					WithMessageRegexp(ErrOIDCNotEnabled.Error()),
+			},
+		},
+		"failed to read user password": {
+			dbUserInAKO: &akov2.AtlasDatabaseUser{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "user1",
+					Namespace: "default",
+				},
+				Spec: akov2.AtlasDatabaseUserSpec{
+					Username: "user1",
+					PasswordSecret: &common.ResourceRef{
+						Name: "user-pass",
+					},
+				},
+			},
+			oidcFlag: false,
+			dbUserService: func() dbuser.AtlasUsersService {
+				return translation.NewAtlasUsersServiceMock(t)
+			},
+			dService: func() deployment.AtlasDeploymentsService {
+				return translation.NewAtlasDeploymentsServiceMock(t)
+			},
+			expectedResult: ctrl.Result{RequeueAfter: workflow.DefaultRetry},
+			expectedConditions: []api.Condition{
+				api.FalseCondition(api.DatabaseUserReadyType).
+					WithReason(string(workflow.Internal)).
+					WithMessageRegexp("secrets \"user-pass\" not found"),
+			},
+		},
+		"failed to convert to internal user": {
+			dbUserInAKO: &akov2.AtlasDatabaseUser{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "user1",
+					Namespace: "default",
+				},
+				Spec: akov2.AtlasDatabaseUserSpec{
+					Username: "user1",
+					PasswordSecret: &common.ResourceRef{
+						Name: "user-pass",
+					},
+					DeleteAfterDate: "wrong-date",
+				},
+			},
+			dbUserSecret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "user-pass",
+					Namespace: "default",
+					Labels: map[string]string{
+						"atlas.mongodb.com/type": "credentials",
+					},
+				},
+				Data: map[string][]byte{
+					"password": []byte("Passw0rd!"),
+				},
+			},
+			oidcFlag: false,
+			dbUserService: func() dbuser.AtlasUsersService {
+				return translation.NewAtlasUsersServiceMock(t)
+			},
+			dService: func() deployment.AtlasDeploymentsService {
+				return translation.NewAtlasDeploymentsServiceMock(t)
+			},
+			expectedResult: ctrl.Result{RequeueAfter: workflow.DefaultRetry},
+			expectedConditions: []api.Condition{
+				api.FalseCondition(api.DatabaseUserReadyType).
+					WithReason(string(workflow.Internal)).
+					WithMessageRegexp("failed to create internal user type: failed to parse \"wrong-date\" to an ISO date: parsing time \"wrong-date\" as \"2006-01-02T15:04:05.999Z\": cannot parse \"wrong-date\" as \"2006\""),
+			},
+		},
+		"user hasn't change": {
+			dbUserInAKO: &akov2.AtlasDatabaseUser{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "user1",
+					Namespace: "default",
+				},
+				Spec: akov2.AtlasDatabaseUserSpec{
+					Username: "user1",
+					PasswordSecret: &common.ResourceRef{
+						Name: "user-pass",
+					},
+					DatabaseName: "admin",
+				},
+				Status: status.AtlasDatabaseUserStatus{
+					PasswordVersion: "999",
+				},
+			},
+			dbUserSecret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "user-pass",
+					Namespace: "default",
+					Labels: map[string]string{
+						"atlas.mongodb.com/type": "credentials",
+					},
+				},
+				Data: map[string][]byte{
+					"password": []byte("Passw0rd!"),
+				},
+			},
+			dbUserInAtlas: &dbuser.User{
+				AtlasDatabaseUserSpec: &akov2.AtlasDatabaseUserSpec{
+					Username: "user1",
+					PasswordSecret: &common.ResourceRef{
+						Name: "user-pass",
+					},
+					DatabaseName: "admin",
+				},
+			},
+			oidcFlag: false,
+			dbUserService: func() dbuser.AtlasUsersService {
+				return translation.NewAtlasUsersServiceMock(t)
+			},
+			dService: func() deployment.AtlasDeploymentsService {
+				service := translation.NewAtlasDeploymentsServiceMock(t)
+				service.EXPECT().ListClusterNames(context.Background(), "").Return([]string{}, nil)
+				service.EXPECT().ListDeploymentConnections(context.Background(), "").Return([]deployment.Connection{}, nil)
+
+				return service
+			},
+			expectedResult: ctrl.Result{},
+			expectedConditions: []api.Condition{
+				api.TrueCondition(api.ReadyType),
+				api.TrueCondition(api.DatabaseUserReadyType),
+			},
+		},
+		"failed to update user": {
+			dbUserInAKO: &akov2.AtlasDatabaseUser{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "user1",
+					Namespace: "default",
+				},
+				Spec: akov2.AtlasDatabaseUserSpec{
+					Username: "user1",
+					PasswordSecret: &common.ResourceRef{
+						Name: "user-pass",
+					},
+					DatabaseName: "admin",
+				},
+				Status: status.AtlasDatabaseUserStatus{
+					PasswordVersion: "888",
+				},
+			},
+			dbUserSecret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "user-pass",
+					Namespace: "default",
+					Labels: map[string]string{
+						"atlas.mongodb.com/type": "credentials",
+					},
+				},
+				Data: map[string][]byte{
+					"password": []byte("Passw0rd!"),
+				},
+			},
+			dbUserInAtlas: &dbuser.User{
+				AtlasDatabaseUserSpec: &akov2.AtlasDatabaseUserSpec{
+					Username: "user1",
+					PasswordSecret: &common.ResourceRef{
+						Name: "user-pass",
+					},
+					DatabaseName: "admin",
+				},
+			},
+			oidcFlag: false,
+			dbUserService: func() dbuser.AtlasUsersService {
+				service := translation.NewAtlasUsersServiceMock(t)
+				service.EXPECT().Update(context.Background(), mock.AnythingOfType("*dbuser.User")).
+					Return(errors.New("failed to update user"))
+
+				return service
+			},
+			dService: func() deployment.AtlasDeploymentsService {
+				return translation.NewAtlasDeploymentsServiceMock(t)
+			},
+			expectedResult: ctrl.Result{RequeueAfter: workflow.DefaultRetry},
+			expectedConditions: []api.Condition{
+				api.FalseCondition(api.DatabaseUserReadyType).
+					WithReason(string(workflow.DatabaseUserNotUpdatedInAtlas)).
+					WithMessageRegexp("failed to update user"),
+			},
+		},
+		"update user": {
+			dbUserInAKO: &akov2.AtlasDatabaseUser{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "user1",
+					Namespace: "default",
+				},
+				Spec: akov2.AtlasDatabaseUserSpec{
+					Username: "user1",
+					PasswordSecret: &common.ResourceRef{
+						Name: "user-pass",
+					},
+					DatabaseName: "admin",
+				},
+				Status: status.AtlasDatabaseUserStatus{
+					PasswordVersion: "888",
+				},
+			},
+			dbUserSecret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "user-pass",
+					Namespace: "default",
+					Labels: map[string]string{
+						"atlas.mongodb.com/type": "credentials",
+					},
+				},
+				Data: map[string][]byte{
+					"password": []byte("Passw0rd!"),
+				},
+			},
+			dbUserInAtlas: &dbuser.User{
+				AtlasDatabaseUserSpec: &akov2.AtlasDatabaseUserSpec{
+					Username: "user1",
+					PasswordSecret: &common.ResourceRef{
+						Name: "user-pass",
+					},
+					DatabaseName: "admin",
+				},
+			},
+			oidcFlag: false,
+			dbUserService: func() dbuser.AtlasUsersService {
+				service := translation.NewAtlasUsersServiceMock(t)
+				service.EXPECT().Update(context.Background(), mock.AnythingOfType("*dbuser.User")).Return(nil)
+
+				return service
+			},
+			dService: func() deployment.AtlasDeploymentsService {
+				return translation.NewAtlasDeploymentsServiceMock(t)
+			},
+			expectedResult: ctrl.Result{RequeueAfter: workflow.DefaultRetry},
+			expectedConditions: []api.Condition{
+				api.FalseCondition(api.DatabaseUserReadyType).
+					WithReason(string(workflow.DatabaseUserDeploymentAppliedChanges)).
+					WithMessageRegexp("Clusters are scheduled to handle database users updates"),
+			},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			testScheme := runtime.NewScheme()
+			assert.NoError(t, akov2.AddToScheme(testScheme))
+			assert.NoError(t, corev1.AddToScheme(testScheme))
+			k8sClient := fake.NewClientBuilder().
+				WithScheme(testScheme).
+				WithObjects(tt.dbUserInAKO).
+				WithStatusSubresource(tt.dbUserInAKO)
+
+			if tt.dbUserSecret != nil {
+				k8sClient.WithObjects(tt.dbUserSecret)
+			}
+
+			logger := zaptest.NewLogger(t).Sugar()
+			r := AtlasDatabaseUserReconciler{
+				Client:                        k8sClient.Build(),
+				Log:                           logger,
+				dbUserService:                 tt.dbUserService(),
+				deploymentService:             tt.dService(),
+				FeaturePreviewOIDCAuthEnabled: tt.oidcFlag,
+			}
+			ctx := &workflow.Context{
+				Context: context.Background(),
+				Log:     logger,
+			}
+
+			result := r.update(ctx, tt.dbUserInAKO, &akov2.AtlasProject{}, tt.dbUserInAtlas)
+			assert.Equal(t, tt.expectedResult, result)
+			assert.True(
+				t,
+				cmp.Equal(
+					tt.expectedConditions,
+					ctx.Conditions(),
+					cmpopts.IgnoreFields(api.Condition{}, "LastTransitionTime"),
+				),
+			)
+		})
+	}
+}
+
+func TestDelete(t *testing.T) {
+	tests := map[string]struct {
+		dbUser             *akov2.AtlasDatabaseUser
+		dbUserService      func() dbuser.AtlasUsersService
+		deletionProtection bool
+		expectedResult     ctrl.Result
+		expectedConditions []api.Condition
+	}{
+		"don't delete resource on atlas when deletion protection is enabled": {
+			dbUser: &akov2.AtlasDatabaseUser{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "user1",
+					Namespace: "default",
+				},
+				Spec: akov2.AtlasDatabaseUserSpec{
+					Username: "user1",
+					PasswordSecret: &common.ResourceRef{
+						Name: "user-pass",
+					},
+				},
+			},
+			dbUserService: func() dbuser.AtlasUsersService {
+				return translation.NewAtlasUsersServiceMock(t)
+			},
+			deletionProtection: true,
+			expectedResult:     ctrl.Result{},
+			expectedConditions: nil,
+		},
+		"don't delete resource on atlas when is annotated to keep resource": {
+			dbUser: &akov2.AtlasDatabaseUser{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "user1",
+					Namespace: "default",
+					Annotations: map[string]string{
+						customresource.ResourcePolicyAnnotation: customresource.ResourcePolicyKeep,
+					},
+				},
+				Spec: akov2.AtlasDatabaseUserSpec{
+					Username: "user1",
+					PasswordSecret: &common.ResourceRef{
+						Name: "user-pass",
+					},
+				},
+			},
+			dbUserService: func() dbuser.AtlasUsersService {
+				return translation.NewAtlasUsersServiceMock(t)
+			},
+			deletionProtection: false,
+			expectedResult:     ctrl.Result{},
+			expectedConditions: nil,
+		},
+		"failed to delete resource": {
+			dbUser: &akov2.AtlasDatabaseUser{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "user1",
+					Namespace: "default",
+				},
+				Spec: akov2.AtlasDatabaseUserSpec{
+					Username:     "user1",
+					DatabaseName: "admin",
+					PasswordSecret: &common.ResourceRef{
+						Name: "user-pass",
+					},
+				},
+			},
+			dbUserService: func() dbuser.AtlasUsersService {
+				service := translation.NewAtlasUsersServiceMock(t)
+				service.EXPECT().Delete(context.Background(), "admin", "", "user1").
+					Return(errors.New("failed to delete user"))
+
+				return service
+			},
+			deletionProtection: false,
+			expectedResult:     ctrl.Result{RequeueAfter: workflow.DefaultRetry},
+			expectedConditions: []api.Condition{
+				api.FalseCondition(api.DatabaseUserReadyType).
+					WithReason(string(workflow.DatabaseUserNotDeletedInAtlas)).
+					WithMessageRegexp("failed to delete user"),
+			},
+		},
+		"user was already deleted": {
+			dbUser: &akov2.AtlasDatabaseUser{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "user1",
+					Namespace: "default",
+				},
+				Spec: akov2.AtlasDatabaseUserSpec{
+					Username:     "user1",
+					DatabaseName: "admin",
+					PasswordSecret: &common.ResourceRef{
+						Name: "user-pass",
+					},
+				},
+			},
+			dbUserService: func() dbuser.AtlasUsersService {
+				service := translation.NewAtlasUsersServiceMock(t)
+				service.EXPECT().Delete(context.Background(), "admin", "", "user1").
+					Return(dbuser.ErrorNotFound)
+
+				return service
+			},
+			deletionProtection: false,
+			expectedResult:     ctrl.Result{},
+			expectedConditions: nil,
+		},
+		"delete user": {
+			dbUser: &akov2.AtlasDatabaseUser{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "user1",
+					Namespace: "default",
+				},
+				Spec: akov2.AtlasDatabaseUserSpec{
+					Username:     "user1",
+					DatabaseName: "admin",
+					PasswordSecret: &common.ResourceRef{
+						Name: "user-pass",
+					},
+				},
+			},
+			dbUserService: func() dbuser.AtlasUsersService {
+				service := translation.NewAtlasUsersServiceMock(t)
+				service.EXPECT().Delete(context.Background(), "admin", "", "user1").
+					Return(nil)
+
+				return service
+			},
+			deletionProtection: false,
+			expectedResult:     ctrl.Result{},
+			expectedConditions: nil,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			testScheme := runtime.NewScheme()
+			assert.NoError(t, akov2.AddToScheme(testScheme))
+			assert.NoError(t, corev1.AddToScheme(testScheme))
+			k8sClient := fake.NewClientBuilder().
+				WithScheme(testScheme).
+				WithObjects(tt.dbUser).
+				WithStatusSubresource(tt.dbUser).
+				Build()
+			logger := zaptest.NewLogger(t).Sugar()
+			r := AtlasDatabaseUserReconciler{
+				Client:                   k8sClient,
+				Log:                      logger,
+				dbUserService:            tt.dbUserService(),
+				ObjectDeletionProtection: tt.deletionProtection,
+			}
+			ctx := &workflow.Context{
+				Context: context.Background(),
+				Log:     logger,
+			}
+
+			result := r.delete(ctx, tt.dbUser, &akov2.AtlasProject{})
+			assert.Equal(t, tt.expectedResult, result)
+			assert.True(
+				t,
+				cmp.Equal(
+					tt.expectedConditions,
+					ctx.Conditions(),
+					cmpopts.IgnoreFields(api.Condition{}, "LastTransitionTime"),
+				),
+			)
+		})
+	}
+}
+
+func TestReadiness(t *testing.T) {
+	tests := map[string]struct {
+		dbUser             *akov2.AtlasDatabaseUser
+		dService           func() deployment.AtlasDeploymentsService
+		expectedResult     ctrl.Result
+		expectedConditions []api.Condition
+	}{
+		"failed to list cluster names": {
+			dbUser: &akov2.AtlasDatabaseUser{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "user1",
+					Namespace: "default",
+				},
+				Spec: akov2.AtlasDatabaseUserSpec{
+					Username: "user1",
+					PasswordSecret: &common.ResourceRef{
+						Name: "user-pass",
+					},
+				},
+			},
+			dService: func() deployment.AtlasDeploymentsService {
+				service := translation.NewAtlasDeploymentsServiceMock(t)
+				service.EXPECT().ListClusterNames(context.Background(), "").
+					Return(nil, errors.New("failed to list cluster names"))
+
+				return service
+			},
+			expectedResult: ctrl.Result{RequeueAfter: workflow.DefaultRetry},
+			expectedConditions: []api.Condition{
+				api.FalseCondition(api.DatabaseUserReadyType).
+					WithReason(string(workflow.Internal)).
+					WithMessageRegexp("failed to list cluster names"),
+			},
+		},
+		"failed to check deployment status": {
+			dbUser: &akov2.AtlasDatabaseUser{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "user1",
+					Namespace: "default",
+				},
+				Spec: akov2.AtlasDatabaseUserSpec{
+					Username: "user1",
+					PasswordSecret: &common.ResourceRef{
+						Name: "user-pass",
+					},
+					Scopes: []akov2.ScopeSpec{
+						{
+							Name: "cluster2",
+							Type: akov2.DeploymentScopeType,
+						},
+					},
+				},
+			},
+			dService: func() deployment.AtlasDeploymentsService {
+				service := translation.NewAtlasDeploymentsServiceMock(t)
+				service.EXPECT().ListClusterNames(context.Background(), "").
+					Return([]string{"cluster1", "cluster2"}, nil)
+				service.EXPECT().DeploymentIsReady(context.Background(), "", "cluster2").
+					Return(false, errors.New("failed to check status"))
+
+				return service
+			},
+			expectedResult: ctrl.Result{RequeueAfter: workflow.DefaultRetry},
+			expectedConditions: []api.Condition{
+				api.FalseCondition(api.DatabaseUserReadyType).
+					WithReason(string(workflow.Internal)).
+					WithMessageRegexp("failed to check status"),
+			},
+		},
+		"deployments are in progress": {
+			dbUser: &akov2.AtlasDatabaseUser{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "user1",
+					Namespace: "default",
+				},
+				Spec: akov2.AtlasDatabaseUserSpec{
+					Username: "user1",
+					PasswordSecret: &common.ResourceRef{
+						Name: "user-pass",
+					},
+					Scopes: []akov2.ScopeSpec{
+						{
+							Name: "cluster2",
+							Type: akov2.DeploymentScopeType,
+						},
+					},
+				},
+			},
+			dService: func() deployment.AtlasDeploymentsService {
+				service := translation.NewAtlasDeploymentsServiceMock(t)
+				service.EXPECT().ListClusterNames(context.Background(), "").
+					Return([]string{"cluster1", "cluster2"}, nil)
+				service.EXPECT().DeploymentIsReady(context.Background(), "", "cluster2").
+					Return(false, nil)
+
+				return service
+			},
+			expectedResult: ctrl.Result{RequeueAfter: workflow.DefaultRetry},
+			expectedConditions: []api.Condition{
+				api.FalseCondition(api.DatabaseUserReadyType).
+					WithReason(string(workflow.DatabaseUserDeploymentAppliedChanges)).
+					WithMessageRegexp("0 out of 1 deployments have applied database user changes"),
+			},
+		},
+		"failed to create connection secrets": {
+			dbUser: &akov2.AtlasDatabaseUser{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "user1",
+					Namespace: "default",
+				},
+				Spec: akov2.AtlasDatabaseUserSpec{
+					Username: "user1",
+					PasswordSecret: &common.ResourceRef{
+						Name: "user-pass",
+					},
+					Scopes: []akov2.ScopeSpec{
+						{
+							Name: "cluster2",
+							Type: akov2.DeploymentScopeType,
+						},
+					},
+				},
+			},
+			dService: func() deployment.AtlasDeploymentsService {
+				service := translation.NewAtlasDeploymentsServiceMock(t)
+				service.EXPECT().ListClusterNames(context.Background(), "").
+					Return([]string{"cluster1", "cluster2"}, nil)
+				service.EXPECT().DeploymentIsReady(context.Background(), "", "cluster2").
+					Return(true, nil)
+				service.EXPECT().ListDeploymentConnections(context.Background(), "").
+					Return(nil, errors.New("failed to list cluster connections"))
+
+				return service
+			},
+			expectedResult: ctrl.Result{RequeueAfter: workflow.DefaultRetry},
+			expectedConditions: []api.Condition{
+				api.FalseCondition(api.DatabaseUserReadyType).
+					WithReason(string(workflow.DatabaseUserConnectionSecretsNotCreated)).
+					WithMessageRegexp("failed to list cluster connections"),
+			},
+		},
+		"resource is ready": {
+			dbUser: &akov2.AtlasDatabaseUser{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "user1",
+					Namespace: "default",
+				},
+				Spec: akov2.AtlasDatabaseUserSpec{
+					Username: "user1",
+					PasswordSecret: &common.ResourceRef{
+						Name: "user-pass",
+					},
+					Scopes: []akov2.ScopeSpec{
+						{
+							Name: "cluster2",
+							Type: akov2.DeploymentScopeType,
+						},
+					},
+				},
+			},
+			dService: func() deployment.AtlasDeploymentsService {
+				service := translation.NewAtlasDeploymentsServiceMock(t)
+				service.EXPECT().ListClusterNames(context.Background(), "").
+					Return([]string{"cluster1", "cluster2"}, nil)
+				service.EXPECT().DeploymentIsReady(context.Background(), "", "cluster2").
+					Return(true, nil)
+				service.EXPECT().ListDeploymentConnections(context.Background(), "").
+					Return([]deployment.Connection{}, nil)
+
+				return service
+			},
+			expectedResult: ctrl.Result{},
+			expectedConditions: []api.Condition{
+				api.TrueCondition(api.ReadyType),
+				api.TrueCondition(api.DatabaseUserReadyType),
+			},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			testScheme := runtime.NewScheme()
+			assert.NoError(t, akov2.AddToScheme(testScheme))
+			assert.NoError(t, corev1.AddToScheme(testScheme))
+			k8sClient := fake.NewClientBuilder().
+				WithScheme(testScheme).
+				WithObjects(tt.dbUser).
+				WithStatusSubresource(tt.dbUser).
+				Build()
+			logger := zaptest.NewLogger(t).Sugar()
+			r := AtlasDatabaseUserReconciler{
+				Client:            k8sClient,
+				Log:               logger,
+				deploymentService: tt.dService(),
+			}
+			ctx := &workflow.Context{
+				Context: context.Background(),
+				Log:     logger,
+			}
+
+			result := r.readiness(ctx, tt.dbUser, &akov2.AtlasProject{}, "999")
+			assert.Equal(t, tt.expectedResult, result)
+			assert.True(
+				t,
+				cmp.Equal(
+					tt.expectedConditions,
+					ctx.Conditions(),
+					cmpopts.IgnoreFields(api.Condition{}, "LastTransitionTime"),
+				),
+			)
+		})
+	}
+}
+
+func TestReadPassword(t *testing.T) {
+	tests := map[string]struct {
+		dbUser           *akov2.AtlasDatabaseUser
+		secret           *corev1.Secret
+		expectedPassword string
+		expectedVersion  string
+		expectedErr      error
+	}{
+		"return empty if password secret is unset": {
+			dbUser: &akov2.AtlasDatabaseUser{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "user1",
+					Namespace: "default",
+				},
+				Spec: akov2.AtlasDatabaseUserSpec{},
+			},
+		},
+		"read password from secret": {
+			dbUser: &akov2.AtlasDatabaseUser{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "user1",
+					Namespace: "default",
+				},
+				Spec: akov2.AtlasDatabaseUserSpec{
+					PasswordSecret: &common.ResourceRef{
+						Name: "user-pass",
+					},
+				},
+			},
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "user-pass",
+					Namespace: "default",
+					Labels: map[string]string{
+						"atlas.mongodb.com/type": "credentials",
+					},
+				},
+				Data: map[string][]byte{
+					"password": []byte("Passw0rd!"),
+				},
+			},
+			expectedPassword: "Passw0rd!",
+			expectedVersion:  "999",
+		},
+		"err when secret is not found": {
+			dbUser: &akov2.AtlasDatabaseUser{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "user1",
+					Namespace: "default",
+				},
+				Spec: akov2.AtlasDatabaseUserSpec{
+					PasswordSecret: &common.ResourceRef{
+						Name: "user-pass",
+					},
+				},
+			},
+			expectedErr: &k8serrors.StatusError{ErrStatus: metav1.Status{Status: "Failure", Message: "secrets \"user-pass\" not found", Code: 404, Details: &metav1.StatusDetails{Name: "user-pass", Kind: "secrets"}, Reason: "NotFound"}},
+		},
+		"error when password is not present in the secret": {
+			dbUser: &akov2.AtlasDatabaseUser{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "user1",
+					Namespace: "default",
+				},
+				Spec: akov2.AtlasDatabaseUserSpec{
+					PasswordSecret: &common.ResourceRef{
+						Name: "user-pass",
+					},
+				},
+			},
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "user-pass",
+					Namespace: "default",
+					Labels: map[string]string{
+						"atlas.mongodb.com/type": "credentials",
+					},
+				},
+				Data: map[string][]byte{
+					"no-password": []byte("Passw0rd!"),
+				},
+			},
+			expectedErr: errors.New("secret user-pass is invalid: it doesn't contain 'password' field"),
+		},
+		"error when password is empty in the secret": {
+			dbUser: &akov2.AtlasDatabaseUser{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "user1",
+					Namespace: "default",
+				},
+				Spec: akov2.AtlasDatabaseUserSpec{
+					PasswordSecret: &common.ResourceRef{
+						Name: "user-pass",
+					},
+				},
+			},
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "user-pass",
+					Namespace: "default",
+					Labels: map[string]string{
+						"atlas.mongodb.com/type": "credentials",
+					},
+				},
+				Data: map[string][]byte{
+					"password": {},
+				},
+			},
+			expectedErr: errors.New("secret user-pass is invalid: the 'password' field is empty"),
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			testScheme := runtime.NewScheme()
+			assert.NoError(t, corev1.AddToScheme(testScheme))
+			k8sClient := fake.NewClientBuilder().
+				WithScheme(testScheme)
+
+			if tt.secret != nil {
+				k8sClient.WithObjects(tt.secret)
+			}
+
+			r := AtlasDatabaseUserReconciler{
+				Client: k8sClient.Build(),
+			}
+
+			pass, version, err := r.readPassword(context.Background(), tt.dbUser)
+			assert.Equal(t, tt.expectedErr, err)
+			assert.Equal(t, tt.expectedPassword, pass)
+			assert.Equal(t, tt.expectedVersion, version)
+		})
+	}
+}
+
+func TestAreDeploymentScopesValid(t *testing.T) {
+	tests := map[string]struct {
+		dbUser   *akov2.AtlasDatabaseUser
+		call     func(ctx context.Context, s string, s2 string) (bool, error)
+		expected bool
+		err      error
+	}{
+		"scope is empty": {
+			dbUser:   &akov2.AtlasDatabaseUser{},
+			expected: true,
+		},
+		"scope doesn't contains deployments": {
+			dbUser: &akov2.AtlasDatabaseUser{
+				Spec: akov2.AtlasDatabaseUserSpec{
+					Scopes: []akov2.ScopeSpec{
+						{
+							Name: "dl1",
+							Type: akov2.DataLakeScopeType,
+						},
+						{
+							Name: "dl2",
+							Type: akov2.DataLakeScopeType,
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		"fail to evaluate scope": {
+			dbUser: &akov2.AtlasDatabaseUser{
+				Spec: akov2.AtlasDatabaseUserSpec{
+					Scopes: []akov2.ScopeSpec{
+						{
+							Name: "d1",
+							Type: akov2.DeploymentScopeType,
+						},
+						{
+							Name: "d2",
+							Type: akov2.DeploymentScopeType,
+						},
+					},
+				},
+			},
+			call: func(ctx context.Context, s string, s2 string) (bool, error) {
+				return false, errors.New("failed to request")
+			},
+			expected: false,
+			err:      errors.New("failed to request"),
+		},
+		"return false when deployment doesn't exist": {
+			dbUser: &akov2.AtlasDatabaseUser{
+				Spec: akov2.AtlasDatabaseUserSpec{
+					Scopes: []akov2.ScopeSpec{
+						{
+							Name: "d1",
+							Type: akov2.DeploymentScopeType,
+						},
+						{
+							Name: "d2",
+							Type: akov2.DeploymentScopeType,
+						},
+					},
+				},
+			},
+			call: func(ctx context.Context, s string, s2 string) (bool, error) {
+				return false, nil
+			},
+			expected: false,
+		},
+		"return true when all deployment exist": {
+			dbUser: &akov2.AtlasDatabaseUser{
+				Spec: akov2.AtlasDatabaseUserSpec{
+					Scopes: []akov2.ScopeSpec{
+						{
+							Name: "d1",
+							Type: akov2.DeploymentScopeType,
+						},
+						{
+							Name: "d2",
+							Type: akov2.DeploymentScopeType,
+						},
+					},
+				},
+			},
+			call: func(ctx context.Context, s string, s2 string) (bool, error) {
+				return true, nil
+			},
+			expected: true,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			deploymentService := translation.NewAtlasDeploymentsServiceMock(t)
+			if tt.call != nil {
+				deploymentService.EXPECT().ClusterExists(context.Background(), "", mock.AnythingOfType("string")).
+					RunAndReturn(tt.call)
+			}
+			r := AtlasDatabaseUserReconciler{
+				deploymentService: deploymentService,
+			}
+			ctx := &workflow.Context{
+				Context: context.Background(),
+			}
+			valid, err := r.areDeploymentScopesValid(ctx, tt.dbUser, &akov2.AtlasProject{})
+			assert.Equal(t, tt.err, err)
+			assert.Equal(t, tt.expected, valid)
+		})
+	}
+
 	scopeSpecs := []akov2.ScopeSpec{{
 		Name: "dbLake",
 		Type: akov2.DataLakeScopeType,
@@ -56,346 +2052,292 @@ func TestFilterScopeClusters(t *testing.T) {
 		Type: akov2.DeploymentScopeType,
 	}}
 	clusters := []string{"cluster1", "cluster4", "cluster5"}
-	scopeClusters := filterScopeDeployments(akov2.AtlasDatabaseUser{Spec: akov2.AtlasDatabaseUserSpec{Scopes: scopeSpecs}}, clusters)
+	scopeClusters := filterScopeDeployments(&akov2.AtlasDatabaseUser{Spec: akov2.AtlasDatabaseUserSpec{Scopes: scopeSpecs}}, clusters)
 	assert.Equal(t, []string{"cluster1"}, scopeClusters)
 }
 
-func TestCheckUserExpired(t *testing.T) {
-	// Fake client
-	scheme := runtime.NewScheme()
-	utilruntime.Must(corev1.AddToScheme(scheme))
-	utilruntime.Must(akov2.AddToScheme(scheme))
-	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
-
-	t.Run("Validate DeleteAfterDate", func(t *testing.T) {
-		result := checkUserExpired(context.Background(), zap.S(), fakeClient, "", *akov2.DefaultDBUser("ns", "theuser", "").WithDeleteAfterDate("foo"))
-		assert.False(t, result.IsOk())
-		assert.Equal(t, reconcile.Result{}, result.ReconcileResult())
-
-		result = checkUserExpired(context.Background(), zap.S(), fakeClient, "", *akov2.DefaultDBUser("ns", "theuser", "").WithDeleteAfterDate("2021/11/30T15:04:05"))
-		assert.False(t, result.IsOk())
-	})
-	t.Run("User Marked Expired", func(t *testing.T) {
-		data := dataForSecret()
-		// Create a connection secret
-		_, err := connectionsecret.Ensure(context.Background(), fakeClient, "tetNs", "project1", "603e7bf38a94956835659ae5", "cluster1", data)
-		assert.NoError(t, err)
-		// The secret for the other project
-		_, err = connectionsecret.Ensure(context.Background(), fakeClient, "testNs", "project2", "dsfsdf234234sdfdsf23423", "cluster1", data)
-		assert.NoError(t, err)
-
-		before := time.Now().UTC().Add(time.Minute * -1).Format("2006-01-02T15:04:05.999Z")
-		user := *akov2.DefaultDBUser("testNs", data.DBUserName, "").WithDeleteAfterDate(before)
-		result := checkUserExpired(context.Background(), zap.S(), fakeClient, "603e7bf38a94956835659ae5", user)
-		assert.False(t, result.IsOk())
-		assert.Equal(t, reconcile.Result{}, result.ReconcileResult())
-
-		// The secret has been removed
-		secret := corev1.Secret{}
-		secretName := fmt.Sprintf("%s-%s-%s", "project1", "cluster1", kube.NormalizeIdentifier(data.DBUserName))
-		err = fakeClient.Get(context.Background(), kube.ObjectKey("testNs", secretName), &secret)
-		assert.Error(t, err)
-
-		// The other secret still exists
-		secretName = fmt.Sprintf("%s-%s-%s", "project2", "cluster1", kube.NormalizeIdentifier(data.DBUserName))
-		err = fakeClient.Get(context.Background(), kube.ObjectKey("testNs", secretName), &secret)
-		assert.NoError(t, err)
-	})
-	t.Run("No expiration happened", func(t *testing.T) {
-		data := dataForSecret()
-		// Create a connection secret
-		_, err := connectionsecret.Ensure(context.Background(), fakeClient, "testNs", "project1", "603e7bf38a94956835659ae5", "cluster1", data)
-		assert.NoError(t, err)
-		after := time.Now().UTC().Add(time.Minute * 1).Format("2006-01-02T15:04:05")
-		result := checkUserExpired(context.Background(), zap.S(), fakeClient, "603e7bf38a94956835659ae5", *akov2.DefaultDBUser("testNs", data.DBUserName, "").WithDeleteAfterDate(after))
-		assert.True(t, result.IsOk())
-
-		// The secret is still there
-		secret := corev1.Secret{}
-		secretName := fmt.Sprintf("%s-%s-%s", "project1", "cluster1", kube.NormalizeIdentifier(data.DBUserName))
-		err = fakeClient.Get(context.Background(), kube.ObjectKey("testNs", secretName), &secret)
-		assert.NoError(t, err)
-	})
-}
-
-func TestHandleUserNameChange(t *testing.T) {
-	t.Run("Only one user after name change", func(t *testing.T) {
-		projectID := "project1"
-		username := "theuser"
-		user := *akov2.DefaultDBUser("ns", "theuser", projectID)
-		user.Spec.Username = "differentuser"
-		user.Status.UserName = username
-		ctx := workflow.NewContext(zap.S(), []api.Condition{}, nil)
-		ctx.Context = context.Background()
-		testUserAPI := mockadmin.NewDatabaseUsersApi(t)
-		dus := dbuser.NewAtlasUsers(testUserAPI)
-		testUserAPI.EXPECT().DeleteDatabaseUser(ctx.Context, projectID, "", username).Return(
-			admin.DeleteDatabaseUserApiRequest{ApiService: testUserAPI})
-		testUserAPI.EXPECT().DeleteDatabaseUserExecute(mock.Anything).Return(nil, nil, nil)
-		result := handleUserNameChange(ctx, dus, projectID, user)
-		assert.True(t, result.IsOk())
-	})
-}
-
-func dataForSecret() connectionsecret.ConnectionData {
-	return connectionsecret.ConnectionData{
-		DBUserName: "admin",
-		ConnURL:    "mongodb://mongodb0.example.com:27017,mongodb1.example.com:27017/?authSource=admin",
-		SrvConnURL: "mongodb+srv://mongodb.example.com:27017/?authSource=admin",
-		Password:   "m@gick%",
-	}
-}
-
-func TestEnsureDatabaseUser(t *testing.T) {
-	ctx := context.Background()
-	scheme := runtime.NewScheme()
-	utilruntime.Must(corev1.AddToScheme(scheme))
-	utilruntime.Must(akov2.AddToScheme(scheme))
-	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
-	project := defaultTestProject()
-	user := defaultTestUser()
-	user.Spec.PasswordSecret = &common.ResourceRef{Name: testUserPasswordName}
-	user.Status.PasswordVersion = "1"
-	require.NoError(t, fakeClient.Create(ctx, user))
-	defer fakeClient.Delete(ctx, user)
-	conditions := akov2.InitCondition(user, api.FalseCondition(api.ReadyType))
-	log := zap.S()
-	workflowCtx := workflow.NewContext(log, conditions, ctx)
-	differentUser := defaultTestUser()
-	differentUser.Spec.AWSIAMType = "USER"
-	r := &AtlasDatabaseUserReconciler{
-		Client: fakeClient,
-		Log:    log,
-		AtlasProvider: &atlas.TestProvider{
-			IsCloudGovFunc: func() bool { return false },
-		},
-	}
-	for _, tc := range []struct {
-		title           string
-		password        *corev1.Secret
-		dateOverride    string
-		scopeOverrides  []akov2.ScopeSpec
-		nameOverride    string
-		dus             dbuser.AtlasUsersService
-		ds              deployment.AtlasDeploymentsService
-		expectedMessage string
+func TestCanManageOIDC(t *testing.T) {
+	tests := map[string]struct {
+		featureFlag bool
+		oidc        string
+		expected    bool
 	}{
-		{
-			title:           "Missing password fails",
-			expectedMessage: `secrets "password-name" not found`,
+		"feature is disabled and config unset": {
+			featureFlag: false,
+			oidc:        "",
+			expected:    true,
 		},
+		"feature is disabled and config is none": {
+			featureFlag: false,
+			oidc:        "NONE",
+			expected:    true,
+		},
+		"feature is disabled and config is set": {
+			featureFlag: false,
+			oidc:        "USER",
+			expected:    false,
+		},
+		"feature is enabled and config unset": {
+			featureFlag: true,
+			oidc:        "",
+			expected:    true,
+		},
+		"feature is enabled and config is none": {
+			featureFlag: true,
+			oidc:        "NONE",
+			expected:    true,
+		},
+		"feature is enabled and config is set": {
+			featureFlag: true,
+			oidc:        "IDP_GROUP",
+			expected:    true,
+		},
+	}
 
-		{
-			title:           "Wrong date format fails",
-			password:        defaultTestPassword(),
-			dateOverride:    "this-is-not-a-proper-date",
-			expectedMessage: `failed to parse "this-is-not-a-proper-date" to an ISO date: parsing time "this-is-not-a-proper-date"`,
-		},
-
-		{
-			title:           "Expired user aborts",
-			password:        defaultTestPassword(),
-			dateOverride:    time.Now().Add(-time.Hour).Format("2006-01-02T15:04:05-07"),
-			expectedMessage: `The database user is expired and has been removed from Atlas`,
-		},
-
-		{
-			title:           "Invalid user scope aborts",
-			password:        defaultTestPassword(),
-			scopeOverrides:  []akov2.ScopeSpec{{Type: akov2.DeploymentScopeType, Name: nonExistingCluster}},
-			ds:              fakeClusterExists(ctx, testProjectID, nonExistingCluster, false, nil),
-			expectedMessage: `"scopes" field references deployment named "non-existing-cluster" but such deployment doesn't exist in Atlas'`,
-		},
-
-		{
-			title:           "User get fails",
-			password:        defaultTestPassword(),
-			dus:             fakeGetUser(ctx, nil, errRandom),
-			expectedMessage: errRandom.Error(),
-		},
-
-		{
-			title:    "User not found is created successfully",
-			password: defaultTestPassword(),
-			dus: func() dbuser.AtlasUsersService {
-				service := fakeGetUser(ctx, nil, dbuser.ErrorNotFound)
-				return withFakeCreateUser(service, ctx, internalUser(user), nil)
-			}(),
-			expectedMessage: `Clusters are scheduled to handle database users updates`,
-		},
-
-		{
-			title:    "User not found tries to create but fails",
-			password: defaultTestPassword(),
-			dus: func() dbuser.AtlasUsersService {
-				service := fakeGetUser(ctx, nil, dbuser.ErrorNotFound)
-				return withFakeCreateUser(service, ctx, internalUser(user), errRandom)
-			}(),
-			expectedMessage: errRandom.Error(),
-		},
-
-		{
-			title:    "User found unchanged does nothing",
-			password: defaultTestPassword(),
-			dus: func() dbuser.AtlasUsersService {
-				service := fakeGetUser(ctx, internalUser(user), nil)
-				return withFakeUpdateUser(service, ctx, internalUser(user), nil)
-			}(),
-			ds: func() deployment.AtlasDeploymentsService {
-				service := fakeListClusterNames(ctx, []string{testDeployment}, nil)
-				service = withFakeDeploymentIsReady(service, ctx)
-				return withFakeListDeploymentConnections(service, ctx, nil)
-			}(),
-			expectedMessage: "",
-		},
-
-		{
-			title:    "User different from Atlas is updated successfully",
-			password: defaultTestPassword(),
-			dus: func() dbuser.AtlasUsersService {
-				service := fakeGetUser(ctx, internalUser(differentUser), nil)
-				return withFakeUpdateUser(service, ctx, internalUser(user), nil)
-			}(),
-			expectedMessage: `Clusters are scheduled to handle database users updates`,
-		},
-
-		{
-			title:    "User different from Atlas tries to update but fails",
-			password: defaultTestPassword(),
-			dus: func() dbuser.AtlasUsersService {
-				service := fakeGetUser(ctx, internalUser(differentUser), nil)
-				return withFakeUpdateUser(service, ctx, internalUser(user), errRandom)
-			}(),
-			expectedMessage: errRandom.Error(),
-		},
-
-		{
-			title:    "User found unchanged but fails to check clusters",
-			password: defaultTestPassword(),
-			dus: func() dbuser.AtlasUsersService {
-				service := fakeGetUser(ctx, internalUser(user), nil)
-				return withFakeUpdateUser(service, ctx, internalUser(user), nil)
-			}(),
-			ds:              fakeListClusterNames(ctx, []string{testDeployment}, errRandom),
-			expectedMessage: errRandom.Error(),
-		},
-
-		{
-			title:    "User found unchanged but fails to check connections",
-			password: defaultTestPassword(),
-			dus: func() dbuser.AtlasUsersService {
-				service := fakeGetUser(ctx, internalUser(user), nil)
-				return withFakeUpdateUser(service, ctx, internalUser(user), nil)
-			}(),
-			ds: func() deployment.AtlasDeploymentsService {
-				service := fakeListClusterNames(ctx, []string{testDeployment}, nil)
-				service = withFakeDeploymentIsReady(service, ctx)
-				return withFakeListDeploymentConnections(service, ctx, errRandom)
-			}(),
-			expectedMessage: errRandom.Error(),
-		},
-
-		{
-			title:        "User found unchanged but changed name succeeds",
-			password:     defaultTestPassword(),
-			nameOverride: "some-other-name",
-			dus: func() dbuser.AtlasUsersService {
-				service := fakeGetUser(ctx, internalUser(user), nil)
-				service = withFakeUpdateUser(service, ctx, internalUser(user), nil)
-				return withFakeUserDeletion(service, ctx, testDatabase, testProjectID, "some-other-name", nil)
-			}(),
-			ds: func() deployment.AtlasDeploymentsService {
-				service := fakeListClusterNames(ctx, []string{testDeployment}, nil)
-				service = withFakeDeploymentIsReady(service, ctx)
-				return withFakeListDeploymentConnections(service, ctx, nil)
-			}(),
-		},
-
-		{
-			title:        "User found unchanged but changed name but fix fails",
-			password:     defaultTestPassword(),
-			nameOverride: "some-other-name",
-			dus: func() dbuser.AtlasUsersService {
-				service := fakeGetUser(ctx, internalUser(user), nil)
-				service = withFakeUpdateUser(service, ctx, internalUser(user), nil)
-				return withFakeUserDeletion(service, ctx, testDatabase, testProjectID, "some-other-name", errRandom)
-			}(),
-			ds: func() deployment.AtlasDeploymentsService {
-				service := fakeListClusterNames(ctx, []string{testDeployment}, nil)
-				service = withFakeDeploymentIsReady(service, ctx)
-				return withFakeListDeploymentConnections(service, ctx, nil)
-			}(),
-			expectedMessage: errRandom.Error(),
-		},
-	} {
-		t.Run(tc.title, func(t *testing.T) {
-			if tc.password != nil {
-				require.NoError(t, fakeClient.Create(ctx, tc.password))
-				defer fakeClient.Delete(ctx, tc.password)
-			}
-			user.Spec.DeleteAfterDate = tc.dateOverride
-			user.Spec.Scopes = tc.scopeOverrides
-			user.Status.UserName = tc.nameOverride
-			result := r.ensureDatabaseUser(workflowCtx, tc.dus, tc.ds, *project, *user)
-			if tc.expectedMessage == "" {
-				assert.Equal(t, true, result.IsOk())
-			} else {
-				assert.Equal(t, false, result.IsOk())
-				assert.Contains(t, result.GetMessage(), tc.expectedMessage)
-			}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, canManageOIDC(tt.featureFlag, tt.oidc))
 		})
 	}
 }
 
-func internalUser(user *akov2.AtlasDatabaseUser) *dbuser.User {
-	return &dbuser.User{
-		AtlasDatabaseUserSpec: &user.Spec,
-		Password:              "some-secret-here",
-		ProjectID:             testProjectID,
+func TestRemoveOldUser(t *testing.T) {
+	failedFirst := false
+
+	tests := map[string]struct {
+		call func(ctx context.Context, db string, project string, username string) error
+		err  error
+	}{
+		"delete old user": {
+			call: func(ctx context.Context, db string, project string, username string) error {
+				return nil
+			},
+		},
+		"user was already deleted": {
+			call: func(ctx context.Context, db string, project string, username string) error {
+				return dbuser.ErrorNotFound
+			},
+		},
+		"failed on first attempt and then succeed": {
+			call: func(ctx context.Context, db string, project string, username string) error {
+				if failedFirst {
+					return nil
+				}
+
+				failedFirst = true
+				return errors.New("failed first")
+			},
+		},
+		"failed to delete old user": {
+			call: func(ctx context.Context, db string, project string, username string) error {
+				return errors.New("fail always")
+			},
+			err: errors.New("fail always"),
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			dbUserService := translation.NewAtlasUsersServiceMock(t)
+			dbUserService.EXPECT().Delete(context.Background(), "", "", "").
+				RunAndReturn(tt.call)
+			r := &AtlasDatabaseUserReconciler{
+				Log:           zaptest.NewLogger(t).Sugar(),
+				dbUserService: dbUserService,
+			}
+
+			assert.Equal(t, tt.err, r.removeOldUser(context.Background(), &akov2.AtlasDatabaseUser{}, &akov2.AtlasProject{}))
+		})
 	}
 }
 
-func defaultTestPassword() *corev1.Secret {
-	return &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{Name: testUserPasswordName},
-		Data:       map[string][]byte{"password": []byte("some-secret-here")},
+func TestIsExpired(t *testing.T) {
+	after := time.Now().UTC().Add(time.Hour * 24).Format("2006-01-02T15:04:05")
+
+	tests := map[string]struct {
+		dbUser   *akov2.AtlasDatabaseUser
+		expected bool
+		err      error
+	}{
+		"user has no expiration date": {
+			dbUser:   akov2.DefaultDBUser("ns", "theuser", ""),
+			expected: false,
+			err:      nil,
+		},
+		"user has invalid expiration date": {
+			dbUser:   akov2.DefaultDBUser("ns", "theuser", "").WithDeleteAfterDate("foo"),
+			expected: false,
+			err:      &time.ParseError{Layout: "2006-01-02T15:04:05.999Z", Value: "foo", LayoutElem: "2006", ValueElem: "foo"},
+		},
+		"user has non expired date": {
+			dbUser:   akov2.DefaultDBUser("ns", "theuser", "").WithDeleteAfterDate(after),
+			expected: false,
+			err:      nil,
+		},
+		"user has an expired date": {
+			dbUser:   akov2.DefaultDBUser("ns", "theuser", "").WithDeleteAfterDate("2021-11-30T15:04:05"),
+			expected: true,
+			err:      nil,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			expired, err := isExpired(tt.dbUser)
+			assert.Equal(t, tt.err, err)
+			assert.Equal(t, tt.expected, expired)
+		})
 	}
 }
 
-func fakeGetUser(ctx context.Context, usr *dbuser.User, err error) *mocked.AtlasUsersServiceMock {
-	service := mocked.AtlasUsersServiceMock{}
-	service.EXPECT().Get(ctx, testDatabase, testProjectID, testUsername).Return(usr, err)
-	return &service
+func TestHasChanged(t *testing.T) {
+	tests := map[string]struct {
+		dbUserInAKO    *dbuser.User
+		dbUserInAtlas  *dbuser.User
+		currentVersion string
+		version        string
+		expected       bool
+	}{
+		"user and password haven't changed": {
+			dbUserInAKO: &dbuser.User{
+				AtlasDatabaseUserSpec: &akov2.AtlasDatabaseUserSpec{
+					Username:     "user1",
+					DatabaseName: "admin",
+					OIDCAuthType: "NONE",
+					AWSIAMType:   "NONE",
+					X509Type:     "NONE",
+				},
+				ProjectID: "project-id",
+			},
+			dbUserInAtlas: &dbuser.User{
+				AtlasDatabaseUserSpec: &akov2.AtlasDatabaseUserSpec{
+					Username:     "user1",
+					DatabaseName: "admin",
+					OIDCAuthType: "NONE",
+					AWSIAMType:   "NONE",
+					X509Type:     "NONE",
+				},
+				ProjectID: "project-id",
+			},
+			currentVersion: "123456",
+			version:        "123456",
+			expected:       false,
+		},
+		"user has changed and password doesn't": {
+			dbUserInAKO: &dbuser.User{
+				AtlasDatabaseUserSpec: &akov2.AtlasDatabaseUserSpec{
+					Username:     "user1",
+					DatabaseName: "admin",
+					OIDCAuthType: "NONE",
+					AWSIAMType:   "NONE",
+					X509Type:     "MANAGED",
+				},
+				ProjectID: "project-id",
+			},
+			dbUserInAtlas: &dbuser.User{
+				AtlasDatabaseUserSpec: &akov2.AtlasDatabaseUserSpec{
+					Username:     "user1",
+					DatabaseName: "admin",
+					OIDCAuthType: "NONE",
+					AWSIAMType:   "NONE",
+					X509Type:     "NONE",
+				},
+				ProjectID: "project-id",
+			},
+			currentVersion: "123456",
+			version:        "123456",
+			expected:       true,
+		},
+		"user hasn't changed and password does": {
+			dbUserInAKO: &dbuser.User{
+				AtlasDatabaseUserSpec: &akov2.AtlasDatabaseUserSpec{
+					Username:     "user1",
+					DatabaseName: "admin",
+					OIDCAuthType: "NONE",
+					AWSIAMType:   "NONE",
+					X509Type:     "NONE",
+				},
+				ProjectID: "project-id",
+			},
+			dbUserInAtlas: &dbuser.User{
+				AtlasDatabaseUserSpec: &akov2.AtlasDatabaseUserSpec{
+					Username:     "user1",
+					DatabaseName: "admin",
+					OIDCAuthType: "NONE",
+					AWSIAMType:   "NONE",
+					X509Type:     "NONE",
+				},
+				ProjectID: "project-id",
+			},
+			currentVersion: "123456",
+			version:        "654321",
+			expected:       true,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, hasChanged(tt.dbUserInAKO, tt.dbUserInAtlas, tt.currentVersion, tt.version))
+		})
+	}
 }
 
-func withFakeCreateUser(service *mocked.AtlasUsersServiceMock, ctx context.Context, usr *dbuser.User, err error) *mocked.AtlasUsersServiceMock {
-	service.EXPECT().Create(ctx, usr).Return(err)
-	return service
+func TestWasRenamed(t *testing.T) {
+	tests := map[string]struct {
+		dbUser   *akov2.AtlasDatabaseUser
+		expected bool
+	}{
+		"the user is new": {
+			dbUser: &akov2.AtlasDatabaseUser{
+				Spec: akov2.AtlasDatabaseUserSpec{
+					Username: "user1",
+				},
+			},
+			expected: false,
+		},
+		"the user hasn't been renamed": {
+			dbUser: &akov2.AtlasDatabaseUser{
+				Spec: akov2.AtlasDatabaseUserSpec{
+					Username: "user1",
+				},
+				Status: status.AtlasDatabaseUserStatus{
+					UserName: "user1",
+				},
+			},
+			expected: false,
+		},
+		"the user was renamed": {
+			dbUser: &akov2.AtlasDatabaseUser{
+				Spec: akov2.AtlasDatabaseUserSpec{
+					Username: "user1",
+				},
+				Status: status.AtlasDatabaseUserStatus{
+					UserName: "user2",
+				},
+			},
+			expected: true,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, wasRenamed(tt.dbUser))
+		})
+	}
 }
 
-func withFakeUpdateUser(service *mocked.AtlasUsersServiceMock, ctx context.Context, usr *dbuser.User, err error) *mocked.AtlasUsersServiceMock {
-	service.EXPECT().Update(ctx, usr).Return(err)
-	return service
-}
-
-func fakeClusterExists(ctx context.Context, projectID, clusterName string, exists bool, err error) *mocked.AtlasDeploymentsServiceMock {
-	service := mocked.AtlasDeploymentsServiceMock{}
-	service.EXPECT().ClusterExists(ctx, projectID, clusterName).Return(exists, err)
-	return &service
-}
-
-func fakeListClusterNames(ctx context.Context, names []string, err error) *mocked.AtlasDeploymentsServiceMock {
-	service := mocked.AtlasDeploymentsServiceMock{}
-	service.EXPECT().ListClusterNames(ctx, testProjectID).Return(names, err)
-	return &service
-}
-
-func withFakeDeploymentIsReady(service *mocked.AtlasDeploymentsServiceMock, ctx context.Context) *mocked.AtlasDeploymentsServiceMock {
-	service.EXPECT().DeploymentIsReady(ctx, testProjectID, testDeployment).Return(true, nil)
-	return service
-}
-
-func withFakeListDeploymentConnections(service *mocked.AtlasDeploymentsServiceMock, ctx context.Context, err error) *mocked.AtlasDeploymentsServiceMock {
-	service.EXPECT().ListDeploymentConnections(ctx, testProjectID).Return(nil, err)
-	return service
+func TestFilterScopeDeployments(t *testing.T) {
+	scopeSpecs := []akov2.ScopeSpec{{
+		Name: "dbLake",
+		Type: akov2.DataLakeScopeType,
+	}, {
+		Name: "cluster1",
+		Type: akov2.DeploymentScopeType,
+	}, {
+		Name: "cluster2",
+		Type: akov2.DeploymentScopeType,
+	}}
+	clusters := []string{"cluster1", "cluster4", "cluster5"}
+	scopeClusters := filterScopeDeployments(&akov2.AtlasDatabaseUser{Spec: akov2.AtlasDatabaseUserSpec{Scopes: scopeSpecs}}, clusters)
+	assert.Equal(t, []string{"cluster1"}, scopeClusters)
 }

--- a/test/e2e/db_users_oidc_test.go
+++ b/test/e2e/db_users_oidc_test.go
@@ -125,7 +125,7 @@ var _ = Describe("Operator to run db-user with the OIDC feature flags", Ordered,
 						Namespace: testData.Users[0].Namespace,
 					}, currentUser)).NotTo(HaveOccurred())
 				for _, condition := range currentUser.Status.Conditions {
-					if condition.Type == api.ReadyType {
+					if condition.Type == api.DatabaseUserReadyType {
 						g.Expect(condition.Status).Should(Equal(corev1.ConditionFalse))
 						g.Expect(condition.Message).To(ContainSubstring(dbuserController.ErrOIDCNotEnabled.Error()))
 					}

--- a/test/int/deployment_test.go
+++ b/test/int/deployment_test.go
@@ -903,7 +903,7 @@ var _ = Describe("AtlasDeployment", Label("int", "AtlasDeployment", "deployment-
 			})
 			checkNumberOfConnectionSecrets(k8sClient, *createdProject, namespace.Name, 0)
 
-			createdDeployment = akov2.DefaultAWSDeployment(namespace.Name, createdProject.Name)
+			createdDeployment = akov2.DefaultAWSDeployment(namespace.Name, createdProject.Name).Lightweight()
 			By(fmt.Sprintf("Creating the Deployment %s", kube.ObjectKeyFromObject(createdDeployment)), func() {
 				performCreate(createdDeployment, 30*time.Minute)
 
@@ -921,7 +921,7 @@ var _ = Describe("AtlasDeployment", Label("int", "AtlasDeployment", "deployment-
 
 	Describe("Create deployment, user, delete deployment and check secrets are removed", func() {
 		It("Should Succeed", func() {
-			createdDeployment = akov2.DefaultAWSDeployment(namespace.Name, createdProject.Name)
+			createdDeployment = akov2.DefaultAWSDeployment(namespace.Name, createdProject.Name).Lightweight()
 			By(fmt.Sprintf("Creating the Deployment %s", kube.ObjectKeyFromObject(createdDeployment)), func() {
 				Expect(k8sClient.Create(context.Background(), createdDeployment)).ToNot(HaveOccurred())
 


### PR DESCRIPTION
Should go after #1782 and before the actual addition of the custom ID for managing the Database Users on their own.

This is part of the series of changes drafted by #1769 

### All Submissions:

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
