### PR TITLE
CLOUDP-271519: Revert Fix data federation e2e test and enable it again

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -186,7 +186,7 @@ jobs:
             "custom-roles",
             "teams",
             "backup-config",
-            "datafederation",
+            "data-federation",
             "deletion-protection",
             "atlas-search-nodes",
             "atlas-search-index",

--- a/test/e2e/datafederation_pe_test.go
+++ b/test/e2e/datafederation_pe_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/api"
 	akov2 "github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/api/v1"
+	"github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/api/v1/provider"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/test/helper/e2e/actions"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/test/helper/e2e/actions/cloud"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/test/helper/e2e/config"
@@ -37,17 +38,6 @@ var _ = Describe("UserLogin", Label("datafederation"), func() {
 		action, err := prepareProviderAction()
 		Expect(err).To(BeNil())
 		providerAction = action
-
-		By("Setting up project", func() {
-			testData = model.DataProvider(
-				"privatelink-aws-1",
-				model.NewEmptyAtlasKeyType().UseDefaultFullAccess(),
-				40000,
-				[]func(*model.TestDataProvider){},
-			).WithProject(data.DefaultProject())
-
-			actions.ProjectCreationFlow(testData)
-		})
 	})
 
 	_ = AfterEach(func() {
@@ -64,63 +54,175 @@ var _ = Describe("UserLogin", Label("datafederation"), func() {
 		})
 	})
 
-	It("Creates a data federation with private endpoint", func(ctx context.Context) {
-		var pe *cloud.PrivateEndpointDetails
-		const dataFederationInstanceName = "test-data-federation-aws"
-
-		//nolint:dupl
-		By("Create private endpoint in AWS", func() {
-			Expect(testData.K8SClient.Get(testData.Context, types.NamespacedName{Name: testData.Project.Name,
-				Namespace: testData.Resources.Namespace}, testData.Project)).To(Succeed())
-
-			vpcId := providerAction.SetupNetwork(
-				"AWS",
-				cloud.WithAWSConfig(&cloud.AWSConfig{Region: config.AWSRegionEU}),
-			)
-			pe = providerAction.SetupPrivateEndpoint(
-				&cloud.AWSPrivateEndpointRequest{
-					ID:     "vpce-" + vpcId,
-					Region: config.AWSRegionEU,
-					// See https://www.mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Data-Federation/operation/createDataFederationPrivateEndpoint
-					ServiceName: "com.amazonaws.vpce.eu-west-2.vpce-svc-052f1840aa0c4f1f9",
+	DescribeTable("Namespaced operators working only with its own namespace with different configuration",
+		func(test *model.TestDataProvider, pe []privateEndpoint) {
+			testData = test
+			actions.ProjectCreationFlow(test)
+			dataFederationFlow(test, providerAction, pe)
+		},
+		Entry("Data Federation can be created with private endpoints", Label("datafederation-pe-aws"),
+			model.DataProvider(
+				"privatelink-aws-1",
+				model.NewEmptyAtlasKeyType().UseDefaultFullAccess(),
+				40000,
+				[]func(*model.TestDataProvider){},
+			).WithProject(data.DefaultProject()),
+			[]privateEndpoint{
+				{
+					provider: "AWS",
+					region:   config.AWSRegionEU,
 				},
-			)
-		})
-
-		By("Creating DataFederation with a PrivateEndpoint", func() {
-			createdDataFederation := akov2.NewDataFederationInstance(
-				testData.Project.Name,
-				dataFederationInstanceName,
-				testData.Project.Namespace).WithPrivateEndpoint(pe.ID, "AWS", "DATA_LAKE")
-			Expect(testData.K8SClient.Create(context.Background(), createdDataFederation)).ShouldNot(HaveOccurred())
-
-			Eventually(func(g Gomega) {
-				df, _, err := atlasClient.Client.DataFederationApi.
-					GetFederatedDatabase(context.Background(), testData.Project.ID(), createdDataFederation.Spec.Name).
-					Execute()
-				g.Expect(err).ShouldNot(HaveOccurred())
-				g.Expect(df).NotTo(BeNil())
-			}).WithTimeout(20 * time.Minute).WithPolling(15 * time.Second).ShouldNot(HaveOccurred())
-		})
-
-		By("Checking the DataFederation is ready", func() {
-			df := &akov2.AtlasDataFederation{}
-			Expect(testData.K8SClient.Get(context.Background(), types.NamespacedName{
-				Namespace: testData.Project.Namespace,
-				Name:      dataFederationInstanceName,
-			}, df)).To(Succeed())
-			Eventually(func() bool {
-				return resources.CheckCondition(testData.K8SClient, df, api.TrueCondition(api.ReadyType))
-			}).WithTimeout(2 * time.Minute).WithPolling(20 * time.Second).Should(BeTrue())
-		})
-
-		By("Delete DataFederation", func() {
-			df := &akov2.AtlasDataFederation{}
-			Expect(testData.K8SClient.Get(context.Background(), types.NamespacedName{
-				Namespace: testData.Project.Namespace,
-				Name:      dataFederationInstanceName,
-			}, df)).To(Succeed())
-			Expect(testData.K8SClient.Delete(testData.Context, df)).Should(Succeed())
-		})
-	})
+			},
+		),
+	)
 })
+
+func dataFederationFlow(userData *model.TestDataProvider, providerAction cloud.Provider, requstedPE []privateEndpoint) {
+	var createdDataFederation *akov2.AtlasDataFederation
+	const dataFederationInstanceName = "test-data-federation-aws"
+
+	By("Create Private Link and the rest users resources", func() {
+		Expect(userData.K8SClient.Get(userData.Context, types.NamespacedName{Name: userData.Project.Name,
+			Namespace: userData.Resources.Namespace}, userData.Project)).To(Succeed())
+		for _, pe := range requstedPE {
+			userData.Project.Spec.PrivateEndpoints = append(userData.Project.Spec.PrivateEndpoints,
+				akov2.PrivateEndpoint{
+					Provider: pe.provider,
+					Region:   pe.region,
+				})
+		}
+		Expect(userData.K8SClient.Update(userData.Context, userData.Project)).To(Succeed())
+	})
+
+	By("Check if project statuses are updating, get project ID", func() {
+		actions.WaitForConditionsToBecomeTrue(userData, api.PrivateEndpointServiceReadyType, api.ReadyType)
+		Expect(AllPEndpointUpdated(userData)).Should(BeTrue(),
+			"Error: Was created a different amount of endpoints")
+		Expect(userData.Project.ID()).ShouldNot(BeEmpty())
+	})
+
+	//nolint:dupl
+	By("Create Endpoint in requested Cloud Provider", func() {
+		Expect(userData.K8SClient.Get(userData.Context, types.NamespacedName{Name: userData.Project.Name,
+			Namespace: userData.Resources.Namespace}, userData.Project)).To(Succeed())
+
+		for idx, peStatusItem := range userData.Project.Status.PrivateEndpoints {
+			privateEndpointID := peStatusItem.ID
+			peName := getPrivateLinkName(privateEndpointID, peStatusItem.Provider, idx)
+			var pe *cloud.PrivateEndpointDetails
+
+			switch peStatusItem.Provider {
+			case provider.ProviderAWS:
+				providerAction.SetupNetwork(
+					peStatusItem.Provider,
+					cloud.WithAWSConfig(&cloud.AWSConfig{Region: peStatusItem.Region}),
+				)
+				pe = providerAction.SetupPrivateEndpoint(
+					&cloud.AWSPrivateEndpointRequest{
+						ID:          peName,
+						Region:      peStatusItem.Region,
+						ServiceName: peStatusItem.ServiceName,
+					},
+				)
+			case provider.ProviderGCP:
+				providerAction.SetupNetwork(
+					peStatusItem.Provider,
+					cloud.WithGCPConfig(&cloud.GCPConfig{Region: peStatusItem.Region}),
+				)
+				pe = providerAction.SetupPrivateEndpoint(
+					&cloud.GCPPrivateEndpointRequest{
+						ID:         peName,
+						Region:     peStatusItem.Region,
+						Targets:    peStatusItem.ServiceAttachmentNames,
+						SubnetName: cloud.Subnet1Name,
+					},
+				)
+			case provider.ProviderAzure:
+				providerAction.SetupNetwork(
+					peStatusItem.Provider,
+					cloud.WithAzureConfig(&cloud.AzureConfig{Region: peStatusItem.Region}),
+				)
+				pe = providerAction.SetupPrivateEndpoint(
+					&cloud.AzurePrivateEndpointRequest{
+						ID:                peName,
+						Region:            peStatusItem.Region,
+						ServiceResourceID: peStatusItem.ServiceResourceID,
+						SubnetName:        cloud.Subnet1Name,
+					},
+				)
+			}
+
+			for i, peItem := range userData.Project.Spec.PrivateEndpoints {
+				if userData.Project.Spec.PrivateEndpoints[i].ID != "" {
+					continue
+				}
+
+				if (peItem.Provider == pe.ProviderName) && (peItem.Region == pe.Region) {
+					peItem.ID = pe.ID
+					peItem.IP = pe.IP
+					peItem.GCPProjectID = pe.GCPProjectID
+					peItem.EndpointGroupName = pe.EndpointGroupName
+
+					if len(pe.Endpoints) > 0 {
+						peItem.Endpoints = make([]akov2.GCPEndpoint, 0, len(pe.Endpoints))
+
+						for _, ep := range pe.Endpoints {
+							peItem.Endpoints = append(
+								peItem.Endpoints,
+								akov2.GCPEndpoint{
+									EndpointName: ep.Name,
+									IPAddress:    ep.IP,
+								},
+							)
+						}
+					}
+
+					userData.Project.Spec.PrivateEndpoints[i] = peItem
+					break
+				}
+			}
+		}
+
+		Expect(userData.K8SClient.Update(userData.Context, userData.Project)).To(Succeed())
+		actions.WaitForConditionsToBecomeTrue(userData, api.PrivateEndpointReadyType, api.ReadyType)
+	})
+
+	By("Check statuses", func() {
+		Expect(userData.K8SClient.Get(userData.Context, types.NamespacedName{Name: userData.Project.Name,
+			Namespace: userData.Resources.Namespace}, userData.Project)).To(Succeed())
+		for _, peStatus := range userData.Project.Status.PrivateEndpoints {
+			Expect(peStatus.Region).ShouldNot(BeEmpty())
+			privateEndpointID := GetPrivateEndpointID(peStatus)
+			Expect(privateEndpointID).ShouldNot(BeEmpty())
+			providerAction.ValidatePrivateEndpointStatus(peStatus.Provider, privateEndpointID, peStatus.Region, len(peStatus.ServiceAttachmentNames))
+		}
+	})
+
+	By("Creating DataFederation with a PrivateEndpoint", func() {
+		peData := userData.Project.Status.PrivateEndpoints[0]
+		createdDataFederation = akov2.NewDataFederationInstance(
+			userData.Project.Name,
+			dataFederationInstanceName,
+			userData.Project.Namespace).WithPrivateEndpoint(GetPrivateEndpointID(peData), "AWS", "DATA_LAKE")
+		Expect(userData.K8SClient.Create(context.Background(), createdDataFederation)).ShouldNot(HaveOccurred())
+
+		Eventually(func(g Gomega) {
+			df, _, err := atlasClient.Client.DataFederationApi.
+				GetFederatedDatabase(context.Background(), userData.Project.ID(), createdDataFederation.Spec.Name).
+				Execute()
+			g.Expect(err).ShouldNot(HaveOccurred())
+			g.Expect(df).NotTo(BeNil())
+		}).WithTimeout(20 * time.Minute).WithPolling(15 * time.Second).ShouldNot(HaveOccurred())
+	})
+
+	By("Checking the DataFederation is ready", func() {
+		df := &akov2.AtlasDataFederation{}
+		Expect(userData.K8SClient.Get(context.Background(), types.NamespacedName{
+			Namespace: userData.Project.Namespace,
+			Name:      dataFederationInstanceName,
+		}, df)).To(Succeed())
+		Eventually(func() bool {
+			return resources.CheckCondition(userData.K8SClient, df, api.TrueCondition(api.ReadyType))
+		}).WithTimeout(2 * time.Minute).WithPolling(20 * time.Second).Should(BeTrue())
+	})
+}

--- a/test/helper/e2e/actions/cloud/aws.go
+++ b/test/helper/e2e/actions/cloud/aws.go
@@ -372,16 +372,6 @@ func (a *AwsAction) createVPC(name, cidr, region string) (string, error) {
 		return "", err
 	}
 
-	_, err = ec2Client.ModifyVpcAttribute(&ec2.ModifyVpcAttributeInput{
-		EnableDnsHostnames: &ec2.AttributeBooleanValue{
-			Value: aws.Bool(true),
-		},
-		VpcId: result.Vpc.VpcId,
-	})
-	if err != nil {
-		return "", err
-	}
-
 	return *result.Vpc.VpcId, nil
 }
 


### PR DESCRIPTION
This reverts mongodb/mongodb-atlas-kubernetes#1799 as it introduces flakes. We need a better understanding on the VPC handling for e2e tests.