### PR TITLE
CLOUDP-271519: test/e2e: use dedicated VPC for datafederation and wait for VPC deletion

### DIFF
--- a/test/e2e/datafederation_pe_test.go
+++ b/test/e2e/datafederation_pe_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/test/helper/e2e/config"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/test/helper/e2e/data"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/test/helper/e2e/model"
+	"github.com/mongodb/mongodb-atlas-kubernetes/v2/test/helper/e2e/utils"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/test/helper/resources"
 )
 
@@ -75,7 +76,11 @@ var _ = Describe("UserLogin", Label("datafederation"), func() {
 
 			vpcId := providerAction.SetupNetwork(
 				"AWS",
-				cloud.WithAWSConfig(&cloud.AWSConfig{Region: config.AWSRegionEU}),
+				cloud.WithAWSConfig(&cloud.AWSConfig{
+					VPC:           utils.RandomName("datafederation-private-endpoint"),
+					Region:        config.AWSRegionEU,
+					EnableCleanup: true,
+				}),
 			)
 			pe = providerAction.SetupPrivateEndpoint(
 				&cloud.AWSPrivateEndpointRequest{


### PR DESCRIPTION
Instead of reverting https://github.com/mongodb/mongodb-atlas-kubernetes/pull/1807 this PR tries to unflake the data federation e2e test by creating a dedicated VPC.

In addition it adds logic to wait for the deletion of VPC endpoints.

### All Submissions:

* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if there is one).
* [ ] Update docs/release-notes/release-notes-template.md if your changes should be included in the release notes for the next release.
