### PR TITLE
CLOUDP-274200: internal/cmp: normalize empty/nil slices

### DIFF
--- a/internal/cmp/normalize.go
+++ b/internal/cmp/normalize.go
@@ -94,6 +94,11 @@ func traverseValue(value reflect.Value, f func(slice reflect.Value)) {
 		}
 
 	case reflect.Slice:
+		// initialize empty slices to nil for normalization to be comparable
+		if value.Len() == 0 && value.CanSet() {
+			value.Set(reflect.Zero(value.Type()))
+		}
+
 		// omit zero length slices
 		if value.Len() == 0 {
 			return

--- a/internal/cmp/normalize_test.go
+++ b/internal/cmp/normalize_test.go
@@ -27,6 +27,45 @@ func TestEndlessRecursion(t *testing.T) {
 			},
 		},
 		{
+			name: "settable and addressable nil slice",
+			data: &struct {
+				Slice []string
+			}{
+				Slice: []string{},
+			},
+			want: &struct {
+				Slice []string
+			}{
+				Slice: nil,
+			},
+		},
+		{
+			name: "unsettable nil slice",
+			data: &struct {
+				slice []string
+			}{
+				slice: []string{},
+			},
+			want: &struct {
+				slice []string
+			}{
+				slice: []string{},
+			},
+		},
+		{
+			name: "unaddressable nil slice",
+			data: struct {
+				Slice []string
+			}{
+				Slice: []string{},
+			},
+			want: struct {
+				Slice []string
+			}{
+				Slice: []string{},
+			},
+		},
+		{
 			name: "nested JSON",
 			data: struct {
 				NestedJSON v1apiextensions.JSON


### PR DESCRIPTION
Currently, nil and empty slices are considered to be different. This fixes it.

Note: This is a prerequisite for normalizing data federation.

### All Submissions:

* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if there is one).
* [ ] Update docs/release-notes/release-notes-template.md if your changes should be included in the release notes for the next release.
