### PR TITLE
CLOUDP-237043: Use separated secret envs

### DIFF
--- a/.github/workflows/cleanup-all.yml
+++ b/.github/workflows/cleanup-all.yml
@@ -1,8 +1,6 @@
-name: Clean Atlas organization
+name: Clean All Atlas organizations
 
 on:
-  schedule:
-    - cron: "*/30 7-22 * * 1-5"
   workflow_dispatch:
     inputs:
       lifetime:
@@ -10,99 +8,14 @@ on:
         type: number
         default: 1
         required: true
-      commercial:
-        description: "Clean commercial Atlas environments"
-        type: boolean
-        default: true
-        required: true
-      government:
-        description: "Clean government Atlas environments"
-        type: boolean
-        default: true
-        required: true
-
-concurrency:
-  group: cleanup
 
 jobs:
-  calculate-targets:
-    name: Calculate targets for execution
-    runs-on: ubuntu-latest
-    outputs:
-      targets: ${{ steps.set-targets.outputs.targets }}
-    steps:
-      - id: set-targets
-        name: Set Targets
-        env:
-          EVENT: ${{ github.event_name }}
-          COMMERCIAL: ${{ inputs.commercial }}
-          GOVERNMENT: ${{ inputs.government }}
-        run: |
-          if [ "$EVENT" == "schedule" ]; then
-            echo 'targets=["CloudQA", "CloudGovQA"]' >> $GITHUB_OUTPUT
-            exit 0
-          fi
-          
-          ENVS=()
-          
-          if [ "$COMMERCIAL" == true ]; then
-            ENVS+=("CloudQA")
-          fi
-          
-          if [ "$GOVERNMENT" == true ]; then
-            ENVS+=("CloudGovQA")
-          fi
+  clean-tests:
+    uses: ./.github/workflows/cleanup-test.yml
+    with:
+      lifetime: 1
 
-          JSON=$(printf '%s\n' "${ENVS[@]}" | jq -R . | jq -cs .)
-          
-          echo "targets=$JSON" >> $GITHUB_OUTPUT
-
-  cleanup:
-    name: Cleanup Atlas Cloud
-    runs-on: ubuntu-latest
-    needs:
-      - calculate-targets
-    strategy:
-      matrix:
-        target: ${{ fromJSON(needs.calculate-targets.outputs.targets) }}
-    steps:
-      - name: Checkout codebase
-        uses: actions/checkout@v4
-
-      - name: Install devbox
-        uses: jetify-com/devbox-install-action@v0.11.0
-        with:
-          enable-cache: 'true'
-
-      - name: Build clean tool
-        run: |
-         devbox run -- 'cd tools/clean && go build .'
-
-      - name: Persist GCP credentials
-        id: gcp-cred
-        env:
-          GCP_SA_CRED: ${{ secrets.GCP_SA_CRED_NEW_TEST }}
-        run: |
-          echo $GCP_SA_CRED > ~/gcp_sa_cred.json
-          
-          echo credentials=$(realpath ~/gcp_sa_cred.json) >> $GITHUB_OUTPUT
-
-      - name: Run cleaner
-        env:
-          MCLI_OPS_MANAGER_URL: ${{ matrix.target == 'CloudQA' && 'https://cloud-qa.mongodb.com/' || 'https://cloud-qa.mongodbgov.com/' }}
-          MCLI_PUBLIC_API_KEY: ${{ matrix.target == 'CloudQA' && secrets.ATLAS_PUBLIC_KEY || secrets.ATLAS_GOV_PUBLIC_KEY}}
-          MCLI_PRIVATE_API_KEY: ${{ matrix.target == 'CloudQA' && secrets.ATLAS_PRIVATE_KEY || secrets.ATLAS_GOV_PRIVATE_KEY }}
-          MCLI_ORG_ID: ${{ matrix.target == 'CloudQA' && secrets.ATLAS_ORG_ID || secrets.ATLAS_GOV_ORG_ID }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          GOOGLE_APPLICATION_CREDENTIALS: ${{ steps.gcp-cred.outputs.credentials }}
-          GOOGLE_PROJECT_ID: atlasoperator
-          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID_NEW_TEST }}
-          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET_NEW_TEST }}
-          AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-          AZURE_RESOURCE_GROUP_NAME: svet-test
-          PROJECT_LIFETIME: ${{ inputs.lifetime || 1 }}
-        run: |
-         devbox run -- 'cd tools/clean && ./clean atlas'
-         
+  clean-gov-tests:
+    uses: ./.github/workflows/cleanup-gov-test.yml
+    with:
+      lifetime: 1

--- a/.github/workflows/cleanup-gov-test.yml
+++ b/.github/workflows/cleanup-gov-test.yml
@@ -58,9 +58,9 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           GOOGLE_APPLICATION_CREDENTIALS: ${{ steps.gcp-cred.outputs.credentials }}
           GOOGLE_PROJECT_ID: atlasoperator
-          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID_NEW_TEST }}
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
           AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET_NEW_TEST }}
+          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
           AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           AZURE_RESOURCE_GROUP_NAME: svet-test
           PROJECT_LIFETIME: ${{ inputs.lifetime || 1 }}

--- a/.github/workflows/cleanup-gov-test.yml
+++ b/.github/workflows/cleanup-gov-test.yml
@@ -1,0 +1,68 @@
+name: Clean Atlas Gov organization
+
+on:
+  schedule:
+    - cron: "*/87 7-22 * * 1-5"
+  workflow_dispatch:
+    inputs:
+      lifetime:
+        description: "Lifetime of project in hours"
+        type: number
+        default: 1
+        required: true
+  workflow_call:
+    inputs:
+      lifetime:
+        description: "Lifetime of project in hours"
+        type: number
+        default: 1
+        required: true
+
+concurrency:
+  group: cleanup-gov-test
+
+jobs:
+  cleanup:
+    environment: gov-test
+    name: Cleanup Atlas Gov Cloud
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout codebase
+        uses: actions/checkout@v4
+
+      - name: Install devbox
+        uses: jetify-com/devbox-install-action@v0.11.0
+        with:
+          enable-cache: 'true'
+
+      - name: Build clean tool
+        run: |
+         devbox run -- 'cd tools/clean && go build .'
+
+      - name: Persist GCP credentials
+        id: gcp-cred
+        env:
+          GCP_SA_CRED: ${{ secrets.GCP_SA_CRED }}
+        run: |
+          echo $GCP_SA_CRED > ~/gcp_sa_cred.json
+
+          echo credentials=$(realpath ~/gcp_sa_cred.json) >> $GITHUB_OUTPUT
+
+      - name: Run cleaner
+        env:
+          MCLI_OPS_MANAGER_URL: 'https://cloud-qa.mongodbgov.com/'
+          MCLI_PUBLIC_API_KEY: ${{ secrets.ATLAS_GOV_PUBLIC_KEY }}
+          MCLI_PRIVATE_API_KEY: ${{ secrets.ATLAS_GOV_PRIVATE_KEY }}
+          MCLI_ORG_ID: ${{ secrets.ATLAS_GOV_ORG_ID }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          GOOGLE_APPLICATION_CREDENTIALS: ${{ steps.gcp-cred.outputs.credentials }}
+          GOOGLE_PROJECT_ID: atlasoperator
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID_NEW_TEST }}
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET_NEW_TEST }}
+          AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          AZURE_RESOURCE_GROUP_NAME: svet-test
+          PROJECT_LIFETIME: ${{ inputs.lifetime || 1 }}
+        run: |
+         devbox run -- 'cd tools/clean && ./clean atlas'

--- a/.github/workflows/cleanup-test.yml
+++ b/.github/workflows/cleanup-test.yml
@@ -58,9 +58,9 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           GOOGLE_APPLICATION_CREDENTIALS: ${{ steps.gcp-cred.outputs.credentials }}
           GOOGLE_PROJECT_ID: atlasoperator
-          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID_NEW_TEST }}
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
           AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET_NEW_TEST }}
+          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
           AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           AZURE_RESOURCE_GROUP_NAME: svet-test
           PROJECT_LIFETIME: ${{ inputs.lifetime || 1 }}

--- a/.github/workflows/cleanup-test.yml
+++ b/.github/workflows/cleanup-test.yml
@@ -1,0 +1,68 @@
+name: Clean Atlas organization
+
+on:
+  schedule:
+    - cron: "*/30 7-22 * * 1-5"
+  workflow_dispatch:
+    inputs:
+      lifetime:
+        description: "Lifetime of project in hours"
+        type: number
+        default: 1
+        required: true
+  workflow_call:
+    inputs:
+      lifetime:
+        description: "Lifetime of project in hours"
+        type: number
+        default: 1
+        required: true
+
+concurrency:
+  group: cleanup-test
+
+jobs:
+  cleanup:
+    environment: test
+    name: Cleanup Atlas Cloud
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout codebase
+        uses: actions/checkout@v4
+
+      - name: Install devbox
+        uses: jetify-com/devbox-install-action@v0.11.0
+        with:
+          enable-cache: 'true'
+
+      - name: Build clean tool
+        run: |
+         devbox run -- 'cd tools/clean && go build .'
+
+      - name: Persist GCP credentials
+        id: gcp-cred
+        env:
+          GCP_SA_CRED: ${{ secrets.GCP_SA_CRED }}
+        run: |
+          echo $GCP_SA_CRED > ~/gcp_sa_cred.json
+
+          echo credentials=$(realpath ~/gcp_sa_cred.json) >> $GITHUB_OUTPUT
+
+      - name: Run cleaner
+        env:
+          MCLI_OPS_MANAGER_URL: 'https://cloud-qa.mongodb.com/'
+          MCLI_PUBLIC_API_KEY: ${{ secrets.ATLAS_PUBLIC_KEY }}
+          MCLI_PRIVATE_API_KEY: ${{ secrets.ATLAS_PRIVATE_KEY }}
+          MCLI_ORG_ID: ${{ secrets.ATLAS_ORG_ID }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          GOOGLE_APPLICATION_CREDENTIALS: ${{ steps.gcp-cred.outputs.credentials }}
+          GOOGLE_PROJECT_ID: atlasoperator
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID_NEW_TEST }}
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET_NEW_TEST }}
+          AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          AZURE_RESOURCE_GROUP_NAME: svet-test
+          PROJECT_LIFETIME: ${{ inputs.lifetime || 1 }}
+        run: |
+         devbox run -- 'cd tools/clean && ./clean atlas'

--- a/.github/workflows/openshift-upgrade-test.yaml
+++ b/.github/workflows/openshift-upgrade-test.yaml
@@ -29,6 +29,7 @@ concurrency:
 jobs:
   e2e-tests:
     name: Upgrade test on Openshift
+    environment: openshift-test
     runs-on: ubuntu-latest
     if: ${{ vars.SKIP_OPENSHIFT != 'true' }}
     steps:

--- a/.github/workflows/release-openshift.yaml
+++ b/.github/workflows/release-openshift.yaml
@@ -8,6 +8,7 @@ on:
 jobs:
   release-openshift:
     name: "Create Pull request for openshift release"
+    environment: openshift-test
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/test-contract.yml
+++ b/.github/workflows/test-contract.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   contract:
     name: Contract Tests
+    environment: test
     runs-on: ubuntu-latest
     steps:
       - name: Check out code

--- a/.github/workflows/test-e2e-gov.yml
+++ b/.github/workflows/test-e2e-gov.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   e2e-gov:
     name: E2E Gov tests
+    environment: gov-test
     runs-on: ubuntu-latest
     steps:
       - name: Check out code

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -11,7 +11,6 @@ on:
 
 jobs:
   compute:
-    environment: test
     name: "Compute test matrix"
     runs-on: ubuntu-latest
     outputs:
@@ -29,6 +28,7 @@ jobs:
           cat "${GITHUB_OUTPUT}"
   prepare-e2e:
     name: Prepare E2E configuration and image
+    environment: release
     runs-on: ubuntu-latest
     env:
       REPOSITORY: ${{ github.repository_owner }}/mongodb-atlas-kubernetes-operator-prerelease
@@ -135,6 +135,7 @@ jobs:
           forked: ${{ inputs.forked }}
   e2e:
     name: E2E tests
+    environment: test
     needs: [compute, prepare-e2e, prepare-e2e-bundle]
     runs-on: ubuntu-latest
     env:
@@ -253,8 +254,6 @@ jobs:
           K8S_PLATFORM: "${{ steps.properties.outputs.k8s_platform }}"
           K8S_VERSION: "${{ steps.properties.outputs.k8s_version }}"
           TEST_NAME: "${{ matrix.test }}"
-          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_ACCOUNT_ARN_LIST: ${{ secrets.AWS_ACCOUNT_ARN_LIST }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -257,11 +257,11 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_ACCOUNT_ARN_LIST: ${{ secrets.AWS_ACCOUNT_ARN_LIST }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID_NEW_TEST }}
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
           AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET_NEW_TEST }}
+          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
           AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-          GCP_SA_CRED: ${{ secrets.GCP_SA_CRED_NEW_TEST }}
+          GCP_SA_CRED: ${{ secrets.GCP_SA_CRED }}
           DATADOG_KEY: ${{ secrets.DATADOG_KEY }}
           PAGER_DUTY_SERVICE_KEY: ${{ secrets.PAGER_DUTY_SERVICE_KEY }}
         run: |

--- a/.github/workflows/test-int.yml
+++ b/.github/workflows/test-int.yml
@@ -12,6 +12,7 @@ on:
 jobs:
   int-test:
     name: Integration tests
+    environment: test
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
There are now 4 separated credentials environments:
- `test` for test credentials which need to access Atlas QA and cloud envs.
- `gov-test` for test credentials on Atlas QA Gov and cloud envs.
- `openshift-test` for test credentials on the team Openshift cluster with access to quay.io images.
- `release` for release credentials to sign and publish Operator releases.

Changes:
- Cleanup split into **cleanup-test** and **cleanup-gov-test** with different set of credentials and scheduled. Cleanup all can still can both.
- Rest of workflow jobs have been constrained to their respective environments.

---
✅ [Test daily build to test release creds](https://github.com/mongodb/mongodb-atlas-kubernetes/actions/runs/11139819534/job/30957272977)
Cloud tests already exercise **test**, **gov-test** and **openshift-test** envs.

### All Submissions:

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
