### PR TITLE
CLOUDP-275610: Fix devbox updates

### DIFF
--- a/.github/workflows/devbox-update.yml
+++ b/.github/workflows/devbox-update.yml
@@ -56,8 +56,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        PR_URL=$(curl -X POST -H "Authorization: token $GITHUB_TOKEN" \
-        -d '{"title":"Weekly Devbox Update","body":"This PR contains the weekly dependencies update for Devbox.","head":"${{ steps.generate_branch.outputs.BRANCH_NAME }}","base":"origin/CLOUDP-263321/unified-development-environment-devbox"}' \
-        https://api.github.com/repos/${{ github.repository }}/pulls | jq -r '.html_url')
-        echo "Pull request created: $PR_URL"
+        gh pr create --title "Weekly Devbox Update" \
+        --body "This PR contains the weekly dependencies update for Devbox." \
+        && echo "Pull request created"
 


### PR DESCRIPTION
Fixed the PR creating using [gh](https://cli.github.com/), which is available by default in GitHub workflow images.

✅ [Manual tests](https://github.com/mongodb/mongodb-atlas-kubernetes/actions/runs/11127955491/job/30921514716) created [PR #1849](https://github.com/mongodb/mongodb-atlas-kubernetes/pull/1846)

### All Submissions:

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
