### PR TITLE
CLOUDP-261995: watch for AtlasProject resources in AtlasDataFederation controller

### DIFF
--- a/pkg/indexer/atlasdatafederationprojects.go
+++ b/pkg/indexer/atlasdatafederationprojects.go
@@ -1,0 +1,45 @@
+//nolint:dupl
+package indexer
+
+import (
+	"go.uber.org/zap"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	akov2 "github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/api/v1"
+)
+
+const (
+	AtlasDataFederationByProject = "atlasdatafederation.spec.project"
+)
+
+type AtlasDataFederationByProjectIndexer struct {
+	logger *zap.SugaredLogger
+}
+
+func NewAtlasDataFederationByProjectIndexer(logger *zap.Logger) *AtlasDataFederationByProjectIndexer {
+	return &AtlasDataFederationByProjectIndexer{
+		logger: logger.Named(AtlasDatabaseUserByProject).Sugar(),
+	}
+}
+
+func (*AtlasDataFederationByProjectIndexer) Object() client.Object {
+	return &akov2.AtlasDataFederation{}
+}
+
+func (*AtlasDataFederationByProjectIndexer) Name() string {
+	return AtlasDataFederationByProject
+}
+
+func (a *AtlasDataFederationByProjectIndexer) Keys(object client.Object) []string {
+	datafederation, ok := object.(*akov2.AtlasDataFederation)
+	if !ok {
+		a.logger.Errorf("expected *AtlasDataFederation but got %T", object)
+		return nil
+	}
+
+	if datafederation.Spec.Project.IsEmpty() {
+		return nil
+	}
+
+	return []string{datafederation.Spec.Project.GetObject(datafederation.Namespace).String()}
+}

--- a/pkg/indexer/atlasdatafederationprojects_test.go
+++ b/pkg/indexer/atlasdatafederationprojects_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/api/v1/common"
 )
 
-func TestAtlasFederatedAuthBySecretsIndexer(t *testing.T) {
+func TestAtlasDataFederationByProjectIndexer(t *testing.T) {
 	for _, tc := range []struct {
 		name     string
 		object   client.Object
@@ -22,43 +22,43 @@ func TestAtlasFederatedAuthBySecretsIndexer(t *testing.T) {
 	}{
 		{
 			name:   "should return nil on wrong type",
-			object: &akov2.AtlasDatabaseUser{},
+			object: &akov2.AtlasDeployment{},
 		},
 		{
 			name:   "should return nil when there are no references",
-			object: &akov2.AtlasFederatedAuth{},
+			object: &akov2.AtlasDataFederation{},
 		},
 		{
 			name: "should return nil when there is an empty reference",
-			object: &akov2.AtlasFederatedAuth{
-				Spec: akov2.AtlasFederatedAuthSpec{
-					ConnectionSecretRef: common.ResourceRefNamespaced{},
+			object: &akov2.AtlasDataFederation{
+				Spec: akov2.DataFederationSpec{
+					Project: common.ResourceRefNamespaced{},
 				},
 			},
 		},
 		{
 			name: "should return project namespace if name is set only",
-			object: &akov2.AtlasFederatedAuth{
+			object: &akov2.AtlasDataFederation{
 				ObjectMeta: metav1.ObjectMeta{Name: "name", Namespace: "ns"},
-				Spec: akov2.AtlasFederatedAuthSpec{
-					ConnectionSecretRef: common.ResourceRefNamespaced{Name: "someSecret"},
+				Spec: akov2.DataFederationSpec{
+					Project: common.ResourceRefNamespaced{Name: "someProject"},
 				},
 			},
-			wantKeys: []string{"ns/someSecret"},
+			wantKeys: []string{"ns/someProject"},
 		},
 		{
 			name: "should return secret namespace and name if set",
-			object: &akov2.AtlasFederatedAuth{
+			object: &akov2.AtlasDataFederation{
 				ObjectMeta: metav1.ObjectMeta{Name: "name", Namespace: "ns"},
-				Spec: akov2.AtlasFederatedAuthSpec{
-					ConnectionSecretRef: common.ResourceRefNamespaced{Name: "someSecret", Namespace: "secretNamespace"},
+				Spec: akov2.DataFederationSpec{
+					Project: common.ResourceRefNamespaced{Name: "someProject", Namespace: "otherNs"},
 				},
 			},
-			wantKeys: []string{"secretNamespace/someSecret"},
+			wantKeys: []string{"otherNs/someProject"},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			indexer := NewAtlasFederatedAuthBySecretsIndexer(zaptest.NewLogger(t))
+			indexer := NewAtlasDataFederationByProjectIndexer(zaptest.NewLogger(t))
 			keys := indexer.Keys(tc.object)
 			sort.Strings(keys)
 			assert.Equal(t, tc.wantKeys, keys)

--- a/pkg/indexer/indexer.go
+++ b/pkg/indexer/indexer.go
@@ -35,6 +35,7 @@ func RegisterAll(ctx context.Context, mgr manager.Manager, logger *zap.Logger) e
 		NewAtlasDatabaseUserByCredentialIndexer(logger),
 		NewAtlasDeploymentByCredentialIndexer(logger),
 		NewAtlasDatabaseUserByProjectIndexer(ctx, mgr.GetClient(), logger),
+		NewAtlasDataFederationByProjectIndexer(logger),
 	)
 }
 


### PR DESCRIPTION
Currently, the Atlas Data Federation controller does not watch AtlasProject resources. This fixes it.

Note: this builds on top of https://github.com/mongodb/mongodb-atlas-kubernetes/pull/1835

### All Submissions:

* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if there is one).
* [ ] Update docs/release-notes/release-notes-template.md if your changes should be included in the release notes for the next release.
