### PR TITLE
CLOUDP-280225: Refactor integration secret checks

### DIFF
--- a/pkg/controller/atlasproject/integrations_test.go
+++ b/pkg/controller/atlasproject/integrations_test.go
@@ -35,25 +35,6 @@ func TestToAlias(t *testing.T) {
 	assert.Equal(t, sample[0].Region, result[0].Region)
 }
 
-func TestAreIntegrationsEqual(t *testing.T) {
-	atlasDef := aliasThirdPartyIntegration{
-		Type:   "DATADOG",
-		APIKey: "****************************4e6f",
-		Region: "EU",
-	}
-	specDef := aliasThirdPartyIntegration{
-		Type:   "DATADOG",
-		APIKey: "actual-valid-id*************4e6f",
-		Region: "EU",
-	}
-
-	areEqual := integrationsApplied(&atlasDef, &specDef)
-	assert.True(t, areEqual, "Identical objects should be equal")
-
-	areEqual = areIntegrationsEqual(&atlasDef, &specDef)
-	assert.False(t, areEqual, "Should fail if the last 4 characters of APIKey do not match")
-}
-
 func TestUpdateIntegrationsAtlas(t *testing.T) {
 	calls := 0
 	for _, tc := range []struct {


### PR DESCRIPTION
Atlas redacts integrations secrets for security reasons, which means we cannot:
- Compare them to check whether they need to be re-applied or not.
- Detect whether or not applied secrets got properly set.

This change preserves that behaviour without assuming any extension to this behaviour coming any time soon. A proper fix will have to come from Atlas, for instance, sending a hash of the secret that allows comparison by applying the same on the client side.

### All Submissions:

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
