### PR TITLE
CLOUDP-281207: Tag main on release merge

### DIFF
--- a/.github/workflows/release-post-merge.yml
+++ b/.github/workflows/release-post-merge.yml
@@ -62,6 +62,8 @@ jobs:
       CERTIFY: ${{ github.event.inputs.certify || 'true' }}
       RELEASE_TO_GITHUB: ${{ github.event.inputs.release_to_github || 'true' }}
       TAG: ${{ inputs.tag || github.head_ref || github.ref_name }}
+    outputs:
+      version: ${{ steps.tag.outputs.version }}
     steps:
       - name: Free disk space
         run: | 
@@ -223,3 +225,11 @@ jobs:
           asset_path: ./atlas-operator-all-in-one-${{ steps.tag.outputs.version }}.tar.gz
           asset_name: atlas-operator-all-in-one-${{ steps.tag.outputs.version }}.tar.gz
           asset_content_type: application/tgz
+
+  sboms-pr:
+    needs:
+    - create-release
+    uses: ./.github/workflows/sboms-pr.yaml
+    secrets: inherit
+    with:
+      version: ${{ needs.create-release.outputs.version }}

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -4,18 +4,24 @@ on:
   pull_request:
     types:
     - closed
+  workflow_dispatch:
+    inputs:
+      branch:
+        type: string
+        description: "Name of existing branch to tag for release"
+        default: main
+        required: true
 
 jobs:
   tag:
-    if: (github.event.pull_request.merged == true && (startsWith(github.head_ref, 'release/') || startsWith(github.head_ref, 'pre-release/')))
+    if: (github.event.pull_request.merged == true && (startsWith(github.head_ref, 'release/') || startsWith(github.head_ref, 'pre-release/'))) || (github.event_name == 'workflow_dispatch')
     environment: release
     name: Tag Release
     runs-on: ubuntu-latest
     env:
-      BRANCH: ${{ github.head_ref }}
+      BRANCH: ${{ github.event.inputs.branch || 'main' }}
     outputs:
       tag: ${{ steps.tag.outputs.tag }}
-      version: ${{ steps.tag.outputs.version }}
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -33,7 +39,6 @@ jobs:
           git tag "${tag}"
           git push origin "${tag}"
           echo "tag=${tag}" >> "$GITHUB_OUTPUT"
-          echo "version=${version}" >> "$GITHUB_OUTPUT"
           cat "$GITHUB_OUTPUT"
 
   release-post-merge:
@@ -43,11 +48,3 @@ jobs:
     secrets: inherit
     with:
       tag: ${{ needs.tag.outputs.tag }}
-
-  sboms-pr:
-    needs:
-    - release-post-merge
-    uses: ./.github/workflows/sboms-pr.yaml
-    secrets: inherit
-    with:
-      version: ${{ needs.tag.outputs.version }}


### PR DESCRIPTION
With `Automatically delete head branches` ON we no longer accumulate merged branches, but the tag workflow broke, because the merged branch was deleted before the workflow could tag it.

This fix:

1. Tags the just merged `main` branch instead of the removed merged branch.
2. Allows to call tag manually, in which case the branch to tag for release is an input parameter defaulting to `main`.
3. The SBOM PR in triggered by the release workflow completion. The version is taken as an output from the release.

### All Submissions:

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
