### PR TITLE
CLOUDP-283049: fix data federation endpoint reconciliation

### DIFF
--- a/internal/translation/datafederation/conversion_endpoints.go
+++ b/internal/translation/datafederation/conversion_endpoints.go
@@ -18,7 +18,7 @@ type DatafederationPrivateEndpointEntry struct {
 	ProjectID string
 }
 
-func NewDatafederationPrivateEndpointEntry(projectID string, pe *akov2.DataFederationPE) *DatafederationPrivateEndpointEntry {
+func NewDataFederationPrivateEndpointEntry(projectID string, pe *akov2.DataFederationPE) *DatafederationPrivateEndpointEntry {
 	if pe == nil {
 		return nil
 	}
@@ -92,11 +92,11 @@ func MapDatafederationPrivateEndpoints(projectID string, df *akov2.AtlasDataFede
 	}
 	for _, pe := range df.Spec.PrivateEndpoints {
 		addEndpoint(pe.EndpointID)
-		result[pe.EndpointID].AKO = NewDatafederationPrivateEndpointEntry(projectID, &pe)
+		result[pe.EndpointID].AKO = NewDataFederationPrivateEndpointEntry(projectID, &pe)
 	}
 	for _, pe := range lastApplied.Spec.PrivateEndpoints {
 		addEndpoint(pe.EndpointID)
-		result[pe.EndpointID].LastApplied = NewDatafederationPrivateEndpointEntry(projectID, &pe)
+		result[pe.EndpointID].LastApplied = NewDataFederationPrivateEndpointEntry(projectID, &pe)
 	}
 
 	return result, nil

--- a/internal/translation/datafederation/conversion_endpoints.go
+++ b/internal/translation/datafederation/conversion_endpoints.go
@@ -1,13 +1,16 @@
 package datafederation
 
 import (
+	"encoding/json"
 	"fmt"
+	"reflect"
 
 	"go.mongodb.org/atlas-sdk/v20231115008/admin"
 
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/cmp"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/pointer"
 	akov2 "github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/api/v1"
+	"github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/controller/customresource"
 )
 
 type DatafederationPrivateEndpointEntry struct {
@@ -15,11 +18,15 @@ type DatafederationPrivateEndpointEntry struct {
 	ProjectID string
 }
 
-func NewDatafederationPrivateEndpointEntry(pe *akov2.DataFederationPE, projectID string) *DatafederationPrivateEndpointEntry {
+func NewDatafederationPrivateEndpointEntry(projectID string, pe *akov2.DataFederationPE) *DatafederationPrivateEndpointEntry {
 	if pe == nil {
 		return nil
 	}
 	return &DatafederationPrivateEndpointEntry{DataFederationPE: pe, ProjectID: projectID}
+}
+
+func (e *DatafederationPrivateEndpointEntry) EqualsTo(target *DatafederationPrivateEndpointEntry) bool {
+	return reflect.DeepEqual(e.DataFederationPE, target.DataFederationPE)
 }
 
 func endpointsFromAtlas(endpoints []admin.PrivateNetworkEndpointIdEntry, projectID string) ([]*DatafederationPrivateEndpointEntry, error) {
@@ -57,4 +64,40 @@ func endpointToAtlas(ep *DatafederationPrivateEndpointEntry) *admin.PrivateNetwo
 		Provider:   pointer.MakePtrOrNil(ep.Provider),
 		Type:       pointer.MakePtrOrNil(ep.Type),
 	}
+}
+
+type DataFederationPrivateEndpoint struct {
+	AKO, Atlas, LastApplied *DatafederationPrivateEndpointEntry
+}
+
+func MapDatafederationPrivateEndpoints(projectID string, df *akov2.AtlasDataFederation, atlasEndpoints []*DatafederationPrivateEndpointEntry) (map[string]*DataFederationPrivateEndpoint, error) {
+	var lastApplied akov2.AtlasDataFederation
+	if ann, ok := df.GetAnnotations()[customresource.AnnotationLastAppliedConfiguration]; ok {
+		err := json.Unmarshal([]byte(ann), &lastApplied.Spec)
+		if err != nil {
+			return nil, fmt.Errorf("error reading data federation from last applied annotation: %w", err)
+		}
+	}
+
+	result := make(map[string]*DataFederationPrivateEndpoint)
+	addEndpoint := func(endpointID string) {
+		if _, ok := result[endpointID]; !ok {
+			result[endpointID] = &DataFederationPrivateEndpoint{}
+		}
+	}
+
+	for _, pe := range atlasEndpoints {
+		addEndpoint(pe.EndpointID)
+		result[pe.EndpointID].Atlas = pe
+	}
+	for _, pe := range df.Spec.PrivateEndpoints {
+		addEndpoint(pe.EndpointID)
+		result[pe.EndpointID].AKO = NewDatafederationPrivateEndpointEntry(projectID, &pe)
+	}
+	for _, pe := range lastApplied.Spec.PrivateEndpoints {
+		addEndpoint(pe.EndpointID)
+		result[pe.EndpointID].LastApplied = NewDatafederationPrivateEndpointEntry(projectID, &pe)
+	}
+
+	return result, nil
 }

--- a/internal/translation/datafederation/conversion_endpoints_test.go
+++ b/internal/translation/datafederation/conversion_endpoints_test.go
@@ -5,7 +5,12 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	fuzz "github.com/google/gofuzz"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	akov2 "github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/api/v1"
+	"github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/controller/customresource"
 )
 
 func TestRoundtrip_DataFederationPE(t *testing.T) {
@@ -25,5 +30,201 @@ func TestRoundtrip_DataFederationPE(t *testing.T) {
 			t.Log(cmp.Diff(fuzzed, fromAtlasResult))
 		}
 		require.True(t, equals)
+	}
+}
+
+func TestMapDatafederationPrivateEndpoints(t *testing.T) {
+	tests := map[string]struct {
+		dataFederation *akov2.AtlasDataFederation
+		endpoints      []*DatafederationPrivateEndpointEntry
+		expectedResult map[string]*DataFederationPrivateEndpoint
+		expectedErr    string
+	}{
+		"failed to parse last config applied annotation": {
+			dataFederation: &akov2.AtlasDataFederation{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						customresource.AnnotationLastAppliedConfiguration: "wrong,",
+					},
+				},
+			},
+			endpoints:      []*DatafederationPrivateEndpointEntry{},
+			expectedResult: nil,
+			expectedErr:    "error reading data federation from last applied annotation: invalid character 'w' looking for beginning of value",
+		},
+		"map without last applied configuration": {
+			dataFederation: &akov2.AtlasDataFederation{
+				Spec: akov2.DataFederationSpec{
+					PrivateEndpoints: []akov2.DataFederationPE{
+						{
+							Provider:   "AWS",
+							Type:       "DATA_LAKE",
+							EndpointID: "vpcpe-123456",
+						},
+						{
+							Provider:   "AZURE",
+							Type:       "DATA_LAKE",
+							EndpointID: "azure/resource/id",
+						},
+					},
+				},
+			},
+			endpoints: []*DatafederationPrivateEndpointEntry{
+				{
+					DataFederationPE: &akov2.DataFederationPE{
+						Provider:   "AWS",
+						Type:       "DATA_LAKE",
+						EndpointID: "vpcpe-123456",
+					},
+					ProjectID: "project-id",
+				},
+				{
+					DataFederationPE: &akov2.DataFederationPE{
+						Provider:   "AZURE",
+						Type:       "DATA_LAKE",
+						EndpointID: "azure/resource/id",
+					},
+					ProjectID: "project-id",
+				},
+			},
+			expectedResult: map[string]*DataFederationPrivateEndpoint{
+				"vpcpe-123456": {
+					AKO: &DatafederationPrivateEndpointEntry{
+						DataFederationPE: &akov2.DataFederationPE{
+							Provider:   "AWS",
+							Type:       "DATA_LAKE",
+							EndpointID: "vpcpe-123456",
+						},
+						ProjectID: "project-id",
+					},
+					Atlas: &DatafederationPrivateEndpointEntry{
+						DataFederationPE: &akov2.DataFederationPE{
+							Provider:   "AWS",
+							Type:       "DATA_LAKE",
+							EndpointID: "vpcpe-123456",
+						},
+						ProjectID: "project-id",
+					},
+					LastApplied: nil,
+				},
+				"azure/resource/id": {
+					AKO: &DatafederationPrivateEndpointEntry{
+						DataFederationPE: &akov2.DataFederationPE{
+							Provider:   "AZURE",
+							Type:       "DATA_LAKE",
+							EndpointID: "azure/resource/id",
+						},
+						ProjectID: "project-id",
+					},
+					Atlas: &DatafederationPrivateEndpointEntry{
+						DataFederationPE: &akov2.DataFederationPE{
+							Provider:   "AZURE",
+							Type:       "DATA_LAKE",
+							EndpointID: "azure/resource/id",
+						},
+						ProjectID: "project-id",
+					},
+					LastApplied: nil,
+				},
+			},
+		},
+		"map with last applied configuration": {
+			dataFederation: &akov2.AtlasDataFederation{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						customresource.AnnotationLastAppliedConfiguration: "{\"name\":\"\",\"privateEndpoints\":[{\"endpointId\":\"vpcpe-123456\"," +
+							"\"provider\":\"AWS\",\"type\":\"DATA_LAKE\"}]}",
+					},
+				},
+				Spec: akov2.DataFederationSpec{
+					PrivateEndpoints: []akov2.DataFederationPE{
+						{
+							Provider:   "AWS",
+							Type:       "DATA_LAKE",
+							EndpointID: "vpcpe-123456",
+						},
+						{
+							Provider:   "AZURE",
+							Type:       "DATA_LAKE",
+							EndpointID: "azure/resource/id",
+						},
+					},
+				},
+			},
+			endpoints: []*DatafederationPrivateEndpointEntry{
+				{
+					DataFederationPE: &akov2.DataFederationPE{
+						Provider:   "AWS",
+						Type:       "DATA_LAKE",
+						EndpointID: "vpcpe-123456",
+					},
+					ProjectID: "project-id",
+				},
+				{
+					DataFederationPE: &akov2.DataFederationPE{
+						Provider:   "AZURE",
+						Type:       "DATA_LAKE",
+						EndpointID: "azure/resource/id",
+					},
+					ProjectID: "project-id",
+				},
+			},
+			expectedResult: map[string]*DataFederationPrivateEndpoint{
+				"vpcpe-123456": {
+					AKO: &DatafederationPrivateEndpointEntry{
+						DataFederationPE: &akov2.DataFederationPE{
+							Provider:   "AWS",
+							Type:       "DATA_LAKE",
+							EndpointID: "vpcpe-123456",
+						},
+						ProjectID: "project-id",
+					},
+					Atlas: &DatafederationPrivateEndpointEntry{
+						DataFederationPE: &akov2.DataFederationPE{
+							Provider:   "AWS",
+							Type:       "DATA_LAKE",
+							EndpointID: "vpcpe-123456",
+						},
+						ProjectID: "project-id",
+					},
+					LastApplied: &DatafederationPrivateEndpointEntry{
+						DataFederationPE: &akov2.DataFederationPE{
+							Provider:   "AWS",
+							Type:       "DATA_LAKE",
+							EndpointID: "vpcpe-123456",
+						},
+						ProjectID: "project-id",
+					},
+				},
+				"azure/resource/id": {
+					AKO: &DatafederationPrivateEndpointEntry{
+						DataFederationPE: &akov2.DataFederationPE{
+							Provider:   "AZURE",
+							Type:       "DATA_LAKE",
+							EndpointID: "azure/resource/id",
+						},
+						ProjectID: "project-id",
+					},
+					Atlas: &DatafederationPrivateEndpointEntry{
+						DataFederationPE: &akov2.DataFederationPE{
+							Provider:   "AZURE",
+							Type:       "DATA_LAKE",
+							EndpointID: "azure/resource/id",
+						},
+						ProjectID: "project-id",
+					},
+					LastApplied: nil,
+				},
+			},
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			m, err := MapDatafederationPrivateEndpoints("project-id", tt.dataFederation, tt.endpoints)
+			if err != nil {
+				assert.EqualError(t, err, tt.expectedErr)
+			}
+			assert.Equal(t, tt.expectedResult, m)
+		})
 	}
 }

--- a/internal/translation/datafederation/conversion_endpoints_test.go
+++ b/internal/translation/datafederation/conversion_endpoints_test.go
@@ -1,7 +1,6 @@
 package datafederation
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -21,7 +20,7 @@ func TestRoundtrip_DataFederationPE(t *testing.T) {
 		toAtlasResult := endpointToAtlas(fuzzed)
 		fromAtlasResult := endpointFromAtlas(toAtlasResult, "")
 
-		equals := reflect.DeepEqual(fuzzed, fromAtlasResult)
+		equals := fuzzed.EqualsTo(fromAtlasResult)
 		if !equals {
 			t.Log(cmp.Diff(fuzzed, fromAtlasResult))
 		}

--- a/pkg/controller/atlasdatafederation/datafederation_controller.go
+++ b/pkg/controller/atlasdatafederation/datafederation_controller.go
@@ -116,8 +116,8 @@ func (r *AtlasDataFederationReconciler) Reconcile(context context.Context, req c
 		return result.ReconcileResult(), nil
 	}
 
-	if result = r.ensurePrivateEndpoints(ctx, project, dataFederation, endpointService); !result.IsOk() {
-		ctx.SetConditionFromResult(api.DataFederationPEReadyType, result)
+	if result = r.ensurePrivateEndpoints(ctx, endpointService, project, dataFederation); !result.IsOk() {
+		ctx.SetConditionFromResult(api.DataFederationReadyType, result)
 		return result.ReconcileResult(), nil
 	}
 
@@ -145,7 +145,7 @@ func (r *AtlasDataFederationReconciler) Reconcile(context context.Context, req c
 		return r.handleDelete(ctx, log, dataFederation, project, dataFederationService).ReconcileResult(), nil
 	}
 
-	err = customresource.ApplyLastConfigApplied(context, project, r.Client)
+	err = customresource.ApplyLastConfigApplied(context, dataFederation, r.Client)
 	if err != nil {
 		result = workflow.Terminate(workflow.Internal, err.Error())
 		ctx.SetConditionFromResult(api.DataFederationReadyType, result)
@@ -154,6 +154,7 @@ func (r *AtlasDataFederationReconciler) Reconcile(context context.Context, req c
 		return result.ReconcileResult(), nil
 	}
 
+	ctx.SetConditionTrue(api.DataFederationReadyType)
 	ctx.SetConditionTrue(api.ReadyType)
 	return workflow.OK().ReconcileResult(), nil
 }

--- a/pkg/controller/atlasdatafederation/private_endpoint_test.go
+++ b/pkg/controller/atlasdatafederation/private_endpoint_test.go
@@ -1,0 +1,167 @@
+package atlasdatafederation
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/mocks/translation"
+	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/translation/datafederation"
+	"github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/api"
+	akov2 "github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/api/v1"
+	"github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/controller/workflow"
+)
+
+func TestEnsurePrivateEndpoints(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		project        *akov2.AtlasProject
+		dataFederation *akov2.AtlasDataFederation
+		service        func(mock *translation.DatafederationPrivateEndpointServiceMock) datafederation.DatafederationPrivateEndpointService
+
+		wantOK         bool
+		wantConditions []api.Condition
+	}{
+		{
+			name: "empty data federation",
+			service: func(m *translation.DatafederationPrivateEndpointServiceMock) datafederation.DatafederationPrivateEndpointService {
+				m.EXPECT().List(mock.Anything, mock.Anything).Return([]*datafederation.DatafederationPrivateEndpointEntry{}, nil)
+				return m
+			},
+			project:        &akov2.AtlasProject{},
+			dataFederation: &akov2.AtlasDataFederation{},
+			wantOK:         true,
+			wantConditions: []api.Condition{},
+		},
+		{
+			name: "error in atlas",
+			service: func(m *translation.DatafederationPrivateEndpointServiceMock) datafederation.DatafederationPrivateEndpointService {
+				m.EXPECT().List(mock.Anything, mock.Anything).Return(nil, errors.New("atlas error"))
+				return m
+			},
+			project:        &akov2.AtlasProject{},
+			dataFederation: &akov2.AtlasDataFederation{},
+			wantOK:         false,
+			wantConditions: []api.Condition{
+				{
+					Type:   "DataFederationPrivateEndpointsReady",
+					Status: "False", Reason: "InternalError", Message: "atlas error",
+				},
+			},
+		},
+		{
+			name: "create entry in atlas",
+			service: func(m *translation.DatafederationPrivateEndpointServiceMock) datafederation.DatafederationPrivateEndpointService {
+				m.EXPECT().List(mock.Anything, mock.Anything).Return(nil, nil)
+				m.EXPECT().Create(mock.Anything, mock.Anything).Return(nil)
+				return m
+			},
+			project: &akov2.AtlasProject{},
+			dataFederation: &akov2.AtlasDataFederation{
+				Spec: akov2.DataFederationSpec{
+					PrivateEndpoints: []akov2.DataFederationPE{
+						{EndpointID: "123", Provider: "foo", Type: "some"},
+					},
+				},
+			},
+			wantOK: true,
+			wantConditions: []api.Condition{
+				{Type: "DataFederationPrivateEndpointsReady", Status: "True"},
+			},
+		},
+		{
+			name: "delete and update entry in atlas",
+			service: func(m *translation.DatafederationPrivateEndpointServiceMock) datafederation.DatafederationPrivateEndpointService {
+				m.EXPECT().List(mock.Anything, mock.Anything).Return([]*datafederation.DatafederationPrivateEndpointEntry{
+					{DataFederationPE: &akov2.DataFederationPE{EndpointID: "123", Provider: "foo", Type: "some"}},
+					{DataFederationPE: &akov2.DataFederationPE{EndpointID: "456", Provider: "bar", Type: "some"}},
+				}, nil)
+				m.EXPECT().Delete(mock.Anything, &datafederation.DatafederationPrivateEndpointEntry{
+					DataFederationPE: &akov2.DataFederationPE{EndpointID: "123", Provider: "foo", Type: "some"},
+				}).Return(nil)
+				m.EXPECT().Create(mock.Anything, &datafederation.DatafederationPrivateEndpointEntry{
+					DataFederationPE: &akov2.DataFederationPE{EndpointID: "123", Provider: "CHANGE", Type: "some"},
+				}).Return(nil)
+				return m
+			},
+			project: &akov2.AtlasProject{},
+			dataFederation: &akov2.AtlasDataFederation{
+				Spec: akov2.DataFederationSpec{
+					PrivateEndpoints: []akov2.DataFederationPE{
+						{EndpointID: "123", Provider: "CHANGE", Type: "some"},
+					},
+				},
+			},
+			wantOK: true,
+			wantConditions: []api.Condition{
+				{Type: "DataFederationPrivateEndpointsReady", Status: "True"},
+			},
+		},
+		{
+			name: "do not delete untracked entry in atlas",
+			service: func(m *translation.DatafederationPrivateEndpointServiceMock) datafederation.DatafederationPrivateEndpointService {
+				m.EXPECT().List(mock.Anything, mock.Anything).Return([]*datafederation.DatafederationPrivateEndpointEntry{
+					{DataFederationPE: &akov2.DataFederationPE{EndpointID: "123", Provider: "foo", Type: "some"}},
+				}, nil)
+				return m
+			},
+			project:        &akov2.AtlasProject{},
+			dataFederation: &akov2.AtlasDataFederation{},
+			wantOK:         true,
+			wantConditions: []api.Condition{},
+		},
+		{
+			name: "delete tracked entry in atlas",
+			service: func(m *translation.DatafederationPrivateEndpointServiceMock) datafederation.DatafederationPrivateEndpointService {
+				m.EXPECT().List(mock.Anything, mock.Anything).Return([]*datafederation.DatafederationPrivateEndpointEntry{
+					{DataFederationPE: &akov2.DataFederationPE{EndpointID: "123", Provider: "foo", Type: "some"}},
+				}, nil)
+				m.EXPECT().Delete(mock.Anything, &datafederation.DatafederationPrivateEndpointEntry{
+					DataFederationPE: &akov2.DataFederationPE{EndpointID: "123", Provider: "foo", Type: "some"},
+				}).Return(nil)
+				return m
+			},
+			project: &akov2.AtlasProject{},
+			dataFederation: &akov2.AtlasDataFederation{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"mongodb.com/last-applied-configuration": `
+{
+  "privateEndpoints": [
+   {
+    "endpointId": "123",
+    "provider": "foo",
+    "type": "some"
+   }
+  ]
+ }`,
+					},
+				},
+			},
+			wantOK:         true,
+			wantConditions: []api.Condition{},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := &workflow.Context{
+				Context: context.Background(),
+				Log:     zaptest.NewLogger(t).Sugar(),
+			}
+
+			reconciler := &AtlasDataFederationReconciler{}
+			result := reconciler.ensurePrivateEndpoints(ctx, tc.service(translation.NewDatafederationPrivateEndpointServiceMock(t)), tc.project, tc.dataFederation)
+			require.Equal(t, tc.wantOK, result.IsOk())
+
+			gotConditions := ctx.Conditions()
+			for i := range ctx.Conditions() {
+				gotConditions[i].LastTransitionTime = metav1.Time{}
+			}
+			require.Equal(t, tc.wantConditions, gotConditions)
+		})
+	}
+}

--- a/pkg/controller/atlasdatafederation/private_endpoint_test.go
+++ b/pkg/controller/atlasdatafederation/private_endpoint_test.go
@@ -55,6 +55,31 @@ func TestEnsurePrivateEndpoints(t *testing.T) {
 			},
 		},
 		{
+			name: "failed when last applied configuration annotation has wrong data",
+			service: func(m *translation.DatafederationPrivateEndpointServiceMock) datafederation.DatafederationPrivateEndpointService {
+				m.EXPECT().List(mock.Anything, mock.Anything).Return(nil, nil)
+
+				return m
+			},
+			project: &akov2.AtlasProject{},
+			dataFederation: &akov2.AtlasDataFederation{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"mongodb.com/last-applied-configuration": "{wrongJson",
+					},
+				},
+			},
+			wantOK: false,
+			wantConditions: []api.Condition{
+				{
+					Type:    "DataFederationPrivateEndpointsReady",
+					Status:  "False",
+					Reason:  "InternalError",
+					Message: "error reading data federation from last applied annotation: invalid character 'w' looking for beginning of object key string",
+				},
+			},
+		},
+		{
 			name: "create entry in atlas",
 			service: func(m *translation.DatafederationPrivateEndpointServiceMock) datafederation.DatafederationPrivateEndpointService {
 				m.EXPECT().List(mock.Anything, mock.Anything).Return(nil, nil)
@@ -72,6 +97,31 @@ func TestEnsurePrivateEndpoints(t *testing.T) {
 			wantOK: true,
 			wantConditions: []api.Condition{
 				{Type: "DataFederationPrivateEndpointsReady", Status: "True"},
+			},
+		},
+		{
+			name: "failed to create entry in atlas",
+			service: func(m *translation.DatafederationPrivateEndpointServiceMock) datafederation.DatafederationPrivateEndpointService {
+				m.EXPECT().List(mock.Anything, mock.Anything).Return(nil, nil)
+				m.EXPECT().Create(mock.Anything, mock.Anything).Return(errors.New("failed to create entry"))
+				return m
+			},
+			project: &akov2.AtlasProject{},
+			dataFederation: &akov2.AtlasDataFederation{
+				Spec: akov2.DataFederationSpec{
+					PrivateEndpoints: []akov2.DataFederationPE{
+						{EndpointID: "123", Provider: "foo", Type: "some"},
+					},
+				},
+			},
+			wantOK: false,
+			wantConditions: []api.Condition{
+				{
+					Type:    "DataFederationPrivateEndpointsReady",
+					Status:  "False",
+					Reason:  "InternalError",
+					Message: "error creating private endpoint: failed to create entry",
+				},
 			},
 		},
 		{
@@ -100,6 +150,90 @@ func TestEnsurePrivateEndpoints(t *testing.T) {
 			wantOK: true,
 			wantConditions: []api.Condition{
 				{Type: "DataFederationPrivateEndpointsReady", Status: "True"},
+			},
+		},
+		{
+			name: "nothing to update in atlas",
+			service: func(m *translation.DatafederationPrivateEndpointServiceMock) datafederation.DatafederationPrivateEndpointService {
+				m.EXPECT().List(mock.Anything, mock.Anything).Return([]*datafederation.DatafederationPrivateEndpointEntry{
+					{DataFederationPE: &akov2.DataFederationPE{EndpointID: "123", Provider: "foo", Type: "some"}},
+				}, nil)
+				return m
+			},
+			project: &akov2.AtlasProject{},
+			dataFederation: &akov2.AtlasDataFederation{
+				Spec: akov2.DataFederationSpec{
+					PrivateEndpoints: []akov2.DataFederationPE{
+						{EndpointID: "123", Provider: "foo", Type: "some"},
+					},
+				},
+			},
+			wantOK: true,
+			wantConditions: []api.Condition{
+				{Type: "DataFederationPrivateEndpointsReady", Status: "True"},
+			},
+		},
+		{
+			name: "failed to delete when updating entry in atlas",
+			service: func(m *translation.DatafederationPrivateEndpointServiceMock) datafederation.DatafederationPrivateEndpointService {
+				m.EXPECT().List(mock.Anything, mock.Anything).Return([]*datafederation.DatafederationPrivateEndpointEntry{
+					{DataFederationPE: &akov2.DataFederationPE{EndpointID: "123", Provider: "foo", Type: "some"}},
+					{DataFederationPE: &akov2.DataFederationPE{EndpointID: "456", Provider: "bar", Type: "some"}},
+				}, nil)
+				m.EXPECT().Delete(mock.Anything, &datafederation.DatafederationPrivateEndpointEntry{
+					DataFederationPE: &akov2.DataFederationPE{EndpointID: "123", Provider: "foo", Type: "some"},
+				}).Return(errors.New("failed to delete entry"))
+				return m
+			},
+			project: &akov2.AtlasProject{},
+			dataFederation: &akov2.AtlasDataFederation{
+				Spec: akov2.DataFederationSpec{
+					PrivateEndpoints: []akov2.DataFederationPE{
+						{EndpointID: "123", Provider: "CHANGE", Type: "some"},
+					},
+				},
+			},
+			wantOK: false,
+			wantConditions: []api.Condition{
+				{
+					Type:    "DataFederationPrivateEndpointsReady",
+					Status:  "False",
+					Reason:  "InternalError",
+					Message: "error deleting private endpoint: failed to delete entry",
+				},
+			},
+		},
+		{
+			name: "failed to create when updating entry in atlas",
+			service: func(m *translation.DatafederationPrivateEndpointServiceMock) datafederation.DatafederationPrivateEndpointService {
+				m.EXPECT().List(mock.Anything, mock.Anything).Return([]*datafederation.DatafederationPrivateEndpointEntry{
+					{DataFederationPE: &akov2.DataFederationPE{EndpointID: "123", Provider: "foo", Type: "some"}},
+					{DataFederationPE: &akov2.DataFederationPE{EndpointID: "456", Provider: "bar", Type: "some"}},
+				}, nil)
+				m.EXPECT().Delete(mock.Anything, &datafederation.DatafederationPrivateEndpointEntry{
+					DataFederationPE: &akov2.DataFederationPE{EndpointID: "123", Provider: "foo", Type: "some"},
+				}).Return(nil)
+				m.EXPECT().Create(mock.Anything, &datafederation.DatafederationPrivateEndpointEntry{
+					DataFederationPE: &akov2.DataFederationPE{EndpointID: "123", Provider: "CHANGE", Type: "some"},
+				}).Return(errors.New("failed to create entry"))
+				return m
+			},
+			project: &akov2.AtlasProject{},
+			dataFederation: &akov2.AtlasDataFederation{
+				Spec: akov2.DataFederationSpec{
+					PrivateEndpoints: []akov2.DataFederationPE{
+						{EndpointID: "123", Provider: "CHANGE", Type: "some"},
+					},
+				},
+			},
+			wantOK: false,
+			wantConditions: []api.Condition{
+				{
+					Type:    "DataFederationPrivateEndpointsReady",
+					Status:  "False",
+					Reason:  "InternalError",
+					Message: "error creating private endpoint: failed to create entry",
+				},
 			},
 		},
 		{
@@ -145,6 +279,44 @@ func TestEnsurePrivateEndpoints(t *testing.T) {
 			},
 			wantOK:         true,
 			wantConditions: []api.Condition{},
+		},
+		{
+			name: "failed to delete tracked entry in atlas",
+			service: func(m *translation.DatafederationPrivateEndpointServiceMock) datafederation.DatafederationPrivateEndpointService {
+				m.EXPECT().List(mock.Anything, mock.Anything).Return([]*datafederation.DatafederationPrivateEndpointEntry{
+					{DataFederationPE: &akov2.DataFederationPE{EndpointID: "123", Provider: "foo", Type: "some"}},
+				}, nil)
+				m.EXPECT().Delete(mock.Anything, &datafederation.DatafederationPrivateEndpointEntry{
+					DataFederationPE: &akov2.DataFederationPE{EndpointID: "123", Provider: "foo", Type: "some"},
+				}).Return(errors.New("failed to delete entry"))
+				return m
+			},
+			project: &akov2.AtlasProject{},
+			dataFederation: &akov2.AtlasDataFederation{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"mongodb.com/last-applied-configuration": `
+{
+  "privateEndpoints": [
+   {
+    "endpointId": "123",
+    "provider": "foo",
+    "type": "some"
+   }
+  ]
+ }`,
+					},
+				},
+			},
+			wantOK: false,
+			wantConditions: []api.Condition{
+				{
+					Type:    "DataFederationPrivateEndpointsReady",
+					Status:  "False",
+					Reason:  "InternalError",
+					Message: "error deleting private endpoint: failed to delete entry",
+				},
+			},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/test/e2e/datafederation_pe_test.go
+++ b/test/e2e/datafederation_pe_test.go
@@ -29,7 +29,7 @@ import (
 
 // AWS NOTES: reserved VPC in eu-west-2, eu-south-1, us-east-1 (due to limitation no more 4 VPC per region)
 
-var _ = FDescribe("DataFederation Private Endpoint", Label("datafederation"), func() {
+var _ = Describe("DataFederation Private Endpoint", Label("datafederation"), func() {
 	var testData *model.TestDataProvider
 	var providerAction cloud.Provider
 	var pe *cloud.PrivateEndpointDetails

--- a/test/e2e/datafederation_pe_test.go
+++ b/test/e2e/datafederation_pe_test.go
@@ -208,13 +208,6 @@ var _ = Describe("DataFederation Private Endpoint", Label("datafederation"), fun
 			// TODO: revisit and cleanup once CLOUDP-280905 is fixed
 			Eventually(func(g Gomega) {
 				_, resp, err := atlasClient.Client.DataFederationApi.
-					DeleteDataFederationPrivateEndpoint(testData.Context, testData.Project.ID(), pe.ID).
-					Execute()
-				g.Expect(err).To(BeNil(), fmt.Sprintf("deletion of private endpoint failed with error %v", err))
-				g.Expect(resp).NotTo(BeNil())
-				g.Expect(resp.StatusCode).To(BeEquivalentTo(http.StatusNoContent))
-
-				_, resp, err = atlasClient.Client.DataFederationApi.
 					DeleteDataFederationPrivateEndpoint(testData.Context, testData.Project.ID(), secondPE.ID).
 					Execute()
 				g.Expect(err).To(BeNil(), fmt.Sprintf("deletion of private endpoint failed with error %v", err))

--- a/test/e2e/datafederation_pe_test.go
+++ b/test/e2e/datafederation_pe_test.go
@@ -99,6 +99,32 @@ var _ = Describe("UserLogin", Label("datafederation"), func() {
 				testData.Project.Name,
 				dataFederationInstanceName,
 				testData.Project.Namespace).WithPrivateEndpoint(pe.ID, "AWS", "DATA_LAKE")
+			createdDataFederation.Spec.Storage = &akov2.Storage{
+				Databases: []akov2.Database{
+					{
+						Name: "test-db-1",
+						Collections: []akov2.Collection{
+							{
+								Name: "test-collection-1",
+								DataSources: []akov2.DataSource{
+									{
+										StoreName: "http-test",
+										Urls: []string{
+											"https://data.cityofnewyork.us/api/views/vfnx-vebw/rows.csv",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Stores: []akov2.Store{
+					{
+						Name:     "http-test",
+						Provider: "http",
+					},
+				},
+			}
 			Expect(testData.K8SClient.Create(context.Background(), createdDataFederation)).ShouldNot(HaveOccurred())
 
 			Eventually(func(g Gomega) {

--- a/test/e2e/datafederation_pe_test.go
+++ b/test/e2e/datafederation_pe_test.go
@@ -213,6 +213,13 @@ var _ = Describe("DataFederation Private Endpoint", Label("datafederation"), fun
 				g.Expect(err).To(BeNil(), fmt.Sprintf("deletion of private endpoint failed with error %v", err))
 				g.Expect(resp).NotTo(BeNil())
 				g.Expect(resp.StatusCode).To(BeEquivalentTo(http.StatusNoContent))
+
+				_, resp, err = atlasClient.Client.DataFederationApi.
+					DeleteDataFederationPrivateEndpoint(testData.Context, testData.Project.ID(), secondPE.ID).
+					Execute()
+				g.Expect(err).To(BeNil(), fmt.Sprintf("deletion of private endpoint failed with error %v", err))
+				g.Expect(resp).NotTo(BeNil())
+				g.Expect(resp.StatusCode).To(BeEquivalentTo(http.StatusNoContent))
 			}).WithTimeout(5 * time.Minute).WithPolling(15 * time.Second).MustPassRepeatedly(2).Should(Succeed())
 		})
 	})


### PR DESCRIPTION
This is an alternative to #1928 and introduces a state machine handling.

It also prevents accidental deletion of data federation private endpoints that are not tracked by AKO.

### All Submissions:

* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if there is one).
* [ ] Update docs/release-notes/release-notes-template.md if your changes should be included in the release notes for the next release.
