### PR TITLE
CLOUDP-285690: Fix race condition between schema and events

### DIFF
--- a/test/helper/e2e/k8s/k8s.go
+++ b/test/helper/e2e/k8s/k8s.go
@@ -5,6 +5,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 
@@ -26,12 +27,15 @@ import (
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/test/helper/e2e/utils"
 )
 
+func init() {
+	err := akov2.AddToScheme(scheme.Scheme)
+	if err != nil {
+		log.Fatalf("failed to preload Kubernetes schemas: %v", err)
+	}
+}
+
 func CreateNewClient() (client.Client, error) {
 	cfg, err := k8scfg.GetConfig()
-	if err != nil {
-		return nil, err
-	}
-	err = akov2.AddToScheme(scheme.Scheme)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This initialises the Kubernetes schemas only once in tests, so that race conditions won't happen. Just like in production.

### All Submissions:

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
