### PR TITLE
CLOUDP-288535: deprecate Identifiable and remove unused implementations

### DIFF
--- a/internal/set/identifiable.go
+++ b/internal/set/identifiable.go
@@ -4,35 +4,41 @@ import (
 	"reflect"
 )
 
-// Identifiable is a simple interface wrapping any object which has some key field which can be used for later
+// DeprecatedIdentifiable is a simple interface wrapping any object which has some key field which can be used for later
 // aggregation operations (grouping, intersection, difference etc)
-type Identifiable interface {
+//
+// Note: this construct is DEPRECATED. Instead, use the translation layer for comparing types.
+type DeprecatedIdentifiable interface {
 	Identifier() interface{}
 }
 
-// Difference returns all 'Identifiable' elements that are in left slice and not in the right one.
+// DeprecatedDifference returns all 'Identifiable' elements that are in left slice and not in the right one.
 // Note, that despite the parameters being declared as 'interface{}' they must contain only the elements implementing
 // 'Identifiable' interface (this is needed to solve lack of covariance in Go).
-func Difference(left, right interface{}) []Identifiable {
+//
+// Note: this construct is DEPRECATED. Instead, use the translation layer for comparing types.
+func DeprecatedDifference(left, right interface{}) []DeprecatedIdentifiable {
 	leftIdentifiers := toIdentifiableSlice(left)
 	rightIdentifiers := toIdentifiableSlice(right)
 
 	return differenceIdentifiable(leftIdentifiers, rightIdentifiers)
 }
 
-// Intersection returns all 'Identifiable' elements from 'left' and 'right' slice that intersect by 'Identifier()' value.
+// DeprecatedIntersection returns all 'Identifiable' elements from 'left' and 'right' slice that intersect by 'Identifier()' value.
 // Each intersection is represented as a tuple of two elements - matching elements from 'left' and 'right'.
 // Note, that despite the parameters being declared as 'interface{}' they must contain only the elements implementing
 // 'Identifiable' interface (this is needed to solve lack of covariance in Go)
-func Intersection(left, right interface{}) [][]Identifiable {
+//
+// Note: this construct is DEPRECATED. Instead, use the translation layer for comparing types.
+func DeprecatedIntersection(left, right interface{}) [][]DeprecatedIdentifiable {
 	leftIdentifiers := toIdentifiableSlice(left)
 	rightIdentifiers := toIdentifiableSlice(right)
 
 	return intersectionIdentifiable(leftIdentifiers, rightIdentifiers)
 }
 
-func differenceIdentifiable(left, right []Identifiable) []Identifiable {
-	result := make([]Identifiable, 0)
+func differenceIdentifiable(left, right []DeprecatedIdentifiable) []DeprecatedIdentifiable {
+	result := make([]DeprecatedIdentifiable, 0)
 	for _, l := range left {
 		found := false
 		for _, r := range right {
@@ -48,12 +54,12 @@ func differenceIdentifiable(left, right []Identifiable) []Identifiable {
 	return result
 }
 
-func intersectionIdentifiable(left, right []Identifiable) [][]Identifiable {
-	result := make([][]Identifiable, 0)
+func intersectionIdentifiable(left, right []DeprecatedIdentifiable) [][]DeprecatedIdentifiable {
+	result := make([][]DeprecatedIdentifiable, 0)
 	for _, l := range left {
 		for _, r := range right {
 			if r.Identifier() == l.Identifier() {
-				result = append(result, []Identifiable{l, r})
+				result = append(result, []DeprecatedIdentifiable{l, r})
 			}
 		}
 	}
@@ -61,12 +67,12 @@ func intersectionIdentifiable(left, right []Identifiable) [][]Identifiable {
 }
 
 // toIdentifiableSlice uses reflection to cast the array
-func toIdentifiableSlice(data interface{}) []Identifiable {
+func toIdentifiableSlice(data interface{}) []DeprecatedIdentifiable {
 	value := reflect.ValueOf(data)
 
-	result := make([]Identifiable, value.Len())
+	result := make([]DeprecatedIdentifiable, value.Len())
 	for i := 0; i < value.Len(); i++ {
-		result[i] = value.Index(i).Interface().(Identifiable)
+		result[i] = value.Index(i).Interface().(DeprecatedIdentifiable)
 	}
 	return result
 }

--- a/internal/set/identifiable_test.go
+++ b/internal/set/identifiable_test.go
@@ -32,19 +32,19 @@ func Test_SetDifference(t *testing.T) {
 	fourRight := newSome("4", "right")
 
 	testCases := []struct {
-		left  []Identifiable
-		right []Identifiable
-		out   []Identifiable
+		left  []DeprecatedIdentifiable
+		right []DeprecatedIdentifiable
+		out   []DeprecatedIdentifiable
 	}{
-		{left: []Identifiable{oneLeft, twoLeft}, right: []Identifiable{twoRight, threeRight}, out: []Identifiable{oneLeft}},
-		{left: []Identifiable{twoRight, threeRight}, right: []Identifiable{oneLeft, twoLeft}, out: []Identifiable{threeRight}},
-		{left: []Identifiable{oneLeft, twoLeft}, right: []Identifiable{threeRight, fourRight}, out: []Identifiable{oneLeft, twoLeft}},
+		{left: []DeprecatedIdentifiable{oneLeft, twoLeft}, right: []DeprecatedIdentifiable{twoRight, threeRight}, out: []DeprecatedIdentifiable{oneLeft}},
+		{left: []DeprecatedIdentifiable{twoRight, threeRight}, right: []DeprecatedIdentifiable{oneLeft, twoLeft}, out: []DeprecatedIdentifiable{threeRight}},
+		{left: []DeprecatedIdentifiable{oneLeft, twoLeft}, right: []DeprecatedIdentifiable{threeRight, fourRight}, out: []DeprecatedIdentifiable{oneLeft, twoLeft}},
 		// Empty
-		{left: []Identifiable{}, right: []Identifiable{threeRight, fourRight}, out: []Identifiable{}},
-		{left: []Identifiable{threeRight, fourRight}, right: []Identifiable{}, out: []Identifiable{threeRight, fourRight}},
+		{left: []DeprecatedIdentifiable{}, right: []DeprecatedIdentifiable{threeRight, fourRight}, out: []DeprecatedIdentifiable{}},
+		{left: []DeprecatedIdentifiable{threeRight, fourRight}, right: []DeprecatedIdentifiable{}, out: []DeprecatedIdentifiable{threeRight, fourRight}},
 		// Nil
-		{left: nil, right: []Identifiable{threeRight, fourRight}, out: []Identifiable{}},
-		{left: []Identifiable{threeRight, fourRight}, right: nil, out: []Identifiable{threeRight, fourRight}},
+		{left: nil, right: []DeprecatedIdentifiable{threeRight, fourRight}, out: []DeprecatedIdentifiable{}},
+		{left: []DeprecatedIdentifiable{threeRight, fourRight}, right: nil, out: []DeprecatedIdentifiable{threeRight, fourRight}},
 	}
 
 	for _, testCase := range testCases {
@@ -64,8 +64,8 @@ func Test_SetDifferenceCovariant(t *testing.T) {
 	leftNotIdentifiable := []someID{oneLeft, twoLeft}
 	rightNotIdentifiable := []someID{twoRight, threeRight}
 
-	assert.Equal(t, []Identifiable{oneLeft}, Difference(leftNotIdentifiable, rightNotIdentifiable))
-	assert.Equal(t, []Identifiable{threeRight}, Difference(rightNotIdentifiable, leftNotIdentifiable))
+	assert.Equal(t, []DeprecatedIdentifiable{oneLeft}, DeprecatedDifference(leftNotIdentifiable, rightNotIdentifiable))
+	assert.Equal(t, []DeprecatedIdentifiable{threeRight}, DeprecatedDifference(rightNotIdentifiable, leftNotIdentifiable))
 }
 
 func Test_SetIntersection(t *testing.T) {
@@ -76,22 +76,22 @@ func Test_SetIntersection(t *testing.T) {
 	fourRight := newSome("4", "right")
 
 	testCases := []struct {
-		left  []Identifiable
-		right []Identifiable
-		out   [][]Identifiable
+		left  []DeprecatedIdentifiable
+		right []DeprecatedIdentifiable
+		out   [][]DeprecatedIdentifiable
 	}{
 		// intersectionIdentifiable on "2"
-		{left: []Identifiable{oneLeft, twoLeft}, right: []Identifiable{twoRight, threeRight}, out: [][]Identifiable{pair(twoLeft, twoRight)}},
-		{left: []Identifiable{twoRight, threeRight}, right: []Identifiable{oneLeft, twoLeft}, out: [][]Identifiable{pair(twoRight, twoLeft)}},
+		{left: []DeprecatedIdentifiable{oneLeft, twoLeft}, right: []DeprecatedIdentifiable{twoRight, threeRight}, out: [][]DeprecatedIdentifiable{pair(twoLeft, twoRight)}},
+		{left: []DeprecatedIdentifiable{twoRight, threeRight}, right: []DeprecatedIdentifiable{oneLeft, twoLeft}, out: [][]DeprecatedIdentifiable{pair(twoRight, twoLeft)}},
 		// No intersection
-		{left: []Identifiable{oneLeft, twoLeft}, right: []Identifiable{threeRight, fourRight}, out: [][]Identifiable{}},
-		{left: []Identifiable{threeRight, fourRight}, right: []Identifiable{oneLeft, twoLeft}, out: [][]Identifiable{}},
+		{left: []DeprecatedIdentifiable{oneLeft, twoLeft}, right: []DeprecatedIdentifiable{threeRight, fourRight}, out: [][]DeprecatedIdentifiable{}},
+		{left: []DeprecatedIdentifiable{threeRight, fourRight}, right: []DeprecatedIdentifiable{oneLeft, twoLeft}, out: [][]DeprecatedIdentifiable{}},
 		// Empty
-		{left: []Identifiable{}, right: []Identifiable{threeRight, fourRight}, out: [][]Identifiable{}},
-		{left: []Identifiable{threeRight, fourRight}, right: []Identifiable{}, out: [][]Identifiable{}},
+		{left: []DeprecatedIdentifiable{}, right: []DeprecatedIdentifiable{threeRight, fourRight}, out: [][]DeprecatedIdentifiable{}},
+		{left: []DeprecatedIdentifiable{threeRight, fourRight}, right: []DeprecatedIdentifiable{}, out: [][]DeprecatedIdentifiable{}},
 		// Nil
-		{left: nil, right: []Identifiable{threeRight, fourRight}, out: [][]Identifiable{}},
-		{left: []Identifiable{threeRight, fourRight}, right: nil, out: [][]Identifiable{}},
+		{left: nil, right: []DeprecatedIdentifiable{threeRight, fourRight}, out: [][]DeprecatedIdentifiable{}},
+		{left: []DeprecatedIdentifiable{threeRight, fourRight}, right: nil, out: [][]DeprecatedIdentifiable{}},
 	}
 
 	for _, testCase := range testCases {
@@ -113,10 +113,10 @@ func Test_SetIntersectionCovariant(t *testing.T) {
 	leftNotIdentifiable := []someID{oneLeft, twoLeft}
 	rightNotIdentifiable := []someID{oneRight, twoRight, threeRight}
 
-	assert.Equal(t, [][]Identifiable{pair(oneLeft, oneRight), pair(twoLeft, twoRight)}, Intersection(leftNotIdentifiable, rightNotIdentifiable))
-	assert.Equal(t, [][]Identifiable{pair(oneRight, oneLeft), pair(twoRight, twoLeft)}, Intersection(rightNotIdentifiable, leftNotIdentifiable))
+	assert.Equal(t, [][]DeprecatedIdentifiable{pair(oneLeft, oneRight), pair(twoLeft, twoRight)}, DeprecatedIntersection(leftNotIdentifiable, rightNotIdentifiable))
+	assert.Equal(t, [][]DeprecatedIdentifiable{pair(oneRight, oneLeft), pair(twoRight, twoLeft)}, DeprecatedIntersection(rightNotIdentifiable, leftNotIdentifiable))
 }
 
-func pair(left, right Identifiable) []Identifiable {
-	return []Identifiable{left, right}
+func pair(left, right DeprecatedIdentifiable) []DeprecatedIdentifiable {
+	return []DeprecatedIdentifiable{left, right}
 }

--- a/pkg/api/v1/atlasdatafederation_types.go
+++ b/pkg/api/v1/atlasdatafederation_types.go
@@ -119,10 +119,6 @@ type DataFederationPE struct {
 	Type       string `json:"type,omitempty"`
 }
 
-func (pe DataFederationPE) Identifier() interface{} {
-	return pe.EndpointID
-}
-
 var _ api.AtlasCustomResource = &AtlasDataFederation{}
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/api/v1/atlasteam_types.go
+++ b/pkg/api/v1/atlasteam_types.go
@@ -18,12 +18,11 @@ package v1
 
 import (
 	"go.mongodb.org/atlas-sdk/v20231115008/admin"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/compat"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/api"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/api/v1/status"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var _ api.AtlasCustomResource = &AtlasTeam{}
@@ -67,10 +66,6 @@ type AtlasTeamList struct {
 
 func init() {
 	SchemeBuilder.Register(&AtlasTeam{}, &AtlasTeamList{})
-}
-
-func (in *AtlasTeam) Identifier() interface{} {
-	return in.Status.ID
 }
 
 func (in *AtlasTeam) GetStatus() api.Status {

--- a/pkg/api/v1/project/integration.go
+++ b/pkg/api/v1/project/integration.go
@@ -4,10 +4,9 @@ import (
 	"context"
 
 	"go.mongodb.org/atlas/mongodbatlas"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/api/v1/common"
-
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type Integration struct {

--- a/pkg/api/v1/project/ipaccesslist.go
+++ b/pkg/api/v1/project/ipaccesslist.go
@@ -1,8 +1,6 @@
 package project
 
 import (
-	"strings"
-
 	"go.mongodb.org/atlas/mongodbatlas"
 
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/compat"
@@ -31,16 +29,6 @@ func (i IPAccessList) ToAtlas() (*mongodbatlas.ProjectIPAccessList, error) {
 	result := &mongodbatlas.ProjectIPAccessList{}
 	err := compat.JSONCopy(result, i)
 	return result, err
-}
-
-// Identifier returns the "id" of the ProjectIPAccessList. Note, that it's an error to specify more than one of these
-// fields - the business layer must validate this beforehand
-func (i IPAccessList) Identifier() interface{} {
-	if strings.Contains(i.CIDRBlock, "/32") {
-		cidrBlock := strings.Replace(i.CIDRBlock, "/32", "", 1) // if CIDRBlock is /32, then it's an IP address
-		return cidrBlock + i.AwsSecurityGroup + i.IPAddress
-	}
-	return i.CIDRBlock + i.AwsSecurityGroup + i.IPAddress
 }
 
 // ************************************ Builder methods *************************************************

--- a/pkg/api/v1/status/privateendpoint.go
+++ b/pkg/api/v1/status/privateendpoint.go
@@ -33,10 +33,6 @@ type GCPEndpoint struct {
 	IPAddress    string `json:"ipAddress"`
 }
 
-func (pe ProjectPrivateEndpoint) Identifier() interface{} {
-	return string(pe.Provider) + TransformRegionToID(pe.Region)
-}
-
 // TransformRegionToID makes the same ID from region and regionName fields for PE Connections to match them
 // it leaves only characters which are letters or numbers starting from 2
 // it also makes a couple swaps and sorts the resulting string

--- a/pkg/controller/atlasproject/cloud_provider_integration.go
+++ b/pkg/controller/atlasproject/cloud_provider_integration.go
@@ -303,10 +303,6 @@ func deleteCloudProviderAccess(workflowCtx *workflow.Context, projectID string, 
 
 type CloudProviderIntegrationIdentifiable akov2.CloudProviderIntegration
 
-func (cpa CloudProviderIntegrationIdentifiable) Identifier() interface{} {
-	return fmt.Sprintf("%s.%s", cpa.ProviderName, cpa.IamAssumedRoleArn)
-}
-
 func convertCloudProviderAccessRole(cpa admin.CloudProviderAccessRole) admin.CloudProviderAccessAWSIAMRole {
 	return admin.CloudProviderAccessAWSIAMRole{
 		Id:            cpa.Id,

--- a/pkg/controller/atlasproject/integrations_test.go
+++ b/pkg/controller/atlasproject/integrations_test.go
@@ -39,7 +39,7 @@ func TestUpdateIntegrationsAtlas(t *testing.T) {
 	calls := 0
 	for _, tc := range []struct {
 		title          string
-		toUpdate       [][]set.Identifiable
+		toUpdate       [][]set.DeprecatedIdentifiable
 		client         *mongodbatlas.Client
 		expectedResult workflow.Result
 		expectedCalls  int
@@ -51,13 +51,13 @@ func TestUpdateIntegrationsAtlas(t *testing.T) {
 
 		{
 			title:          "empty list does nothing",
-			toUpdate:       [][]set.Identifiable{},
+			toUpdate:       [][]set.DeprecatedIdentifiable{},
 			expectedResult: workflow.OK(),
 		},
 
 		{
 			title: "different integrations get updated",
-			toUpdate: set.Intersection(
+			toUpdate: set.DeprecatedIntersection(
 				[]aliasThirdPartyIntegration{
 					{
 						Type:                     "MICROSOFT_TEAMS",
@@ -87,7 +87,7 @@ func TestUpdateIntegrationsAtlas(t *testing.T) {
 
 		{
 			title: "matching integrations get updated anyway",
-			toUpdate: set.Intersection(
+			toUpdate: set.DeprecatedIntersection(
 				[]aliasThirdPartyIntegration{
 					{
 						Type:                     "MICROSOFT_TEAMS",
@@ -117,7 +117,7 @@ func TestUpdateIntegrationsAtlas(t *testing.T) {
 
 		{
 			title: "integrations fail to update and return error",
-			toUpdate: set.Intersection(
+			toUpdate: set.DeprecatedIntersection(
 				[]aliasThirdPartyIntegration{
 					{
 						Type:                     "MICROSOFT_TEAMS",
@@ -163,7 +163,7 @@ func TestUpdateIntegrationsAtlas(t *testing.T) {
 func TestCheckIntegrationsReady(t *testing.T) {
 	for _, tc := range []struct {
 		title     string
-		toCheck   [][]set.Identifiable
+		toCheck   [][]set.DeprecatedIdentifiable
 		requested []project.Integration
 		expected  bool
 	}{
@@ -174,21 +174,21 @@ func TestCheckIntegrationsReady(t *testing.T) {
 
 		{
 			title:     "empty list does nothing",
-			toCheck:   [][]set.Identifiable{},
+			toCheck:   [][]set.DeprecatedIdentifiable{},
 			requested: []project.Integration{},
 			expected:  true,
 		},
 
 		{
 			title:     "when requested list differs in length it bails early",
-			toCheck:   [][]set.Identifiable{},
+			toCheck:   [][]set.DeprecatedIdentifiable{},
 			requested: []project.Integration{{}},
 			expected:  false,
 		},
 
 		{
 			title: "matching integrations are considered applied",
-			toCheck: set.Intersection(
+			toCheck: set.DeprecatedIntersection(
 				[]aliasThirdPartyIntegration{
 					{
 						Type:                     "MICROSOFT_TEAMS",
@@ -210,7 +210,7 @@ func TestCheckIntegrationsReady(t *testing.T) {
 
 		{
 			title: "different integrations are considered also applied",
-			toCheck: set.Intersection(
+			toCheck: set.DeprecatedIntersection(
 				[]aliasThirdPartyIntegration{
 					{
 						Type:                     "MICROSOFT_TEAMS",
@@ -232,7 +232,7 @@ func TestCheckIntegrationsReady(t *testing.T) {
 
 		{
 			title: "matching integrations including prometheus are considered applied",
-			toCheck: set.Intersection(
+			toCheck: set.DeprecatedIntersection(
 				[]aliasThirdPartyIntegration{
 					{
 						Type:                     "MICROSOFT_TEAMS",
@@ -266,7 +266,7 @@ func TestCheckIntegrationsReady(t *testing.T) {
 
 		{
 			title: "matching integrations with a differing prometheus are considered different",
-			toCheck: set.Intersection(
+			toCheck: set.DeprecatedIntersection(
 				[]aliasThirdPartyIntegration{
 					{
 						Type:                     "MICROSOFT_TEAMS",

--- a/pkg/controller/atlasproject/private_endpoint.go
+++ b/pkg/controller/atlasproject/private_endpoint.go
@@ -526,7 +526,7 @@ func getEndpointsNotInAtlas(specPEs []akov2.PrivateEndpoint, atlasPEs []atlasPE)
 }
 
 func getUniqueDifference[ResultType interface{}, OtherType interface{}](left []ResultType, right []OtherType) (uniques []ResultType, counts []int) {
-	difference := set.Difference(left, right)
+	difference := set.DeprecatedDifference(left, right)
 
 	uniqueItems := make(map[string]itemCount)
 	for _, item := range difference {
@@ -556,7 +556,7 @@ type itemCount struct {
 }
 
 func getEndpointsIntersection(specPEs []akov2.PrivateEndpoint, atlasPEs []atlasPE) []intersectionPair {
-	intersection := set.Intersection(specPEs, atlasPEs)
+	intersection := set.DeprecatedIntersection(specPEs, atlasPEs)
 	result := []intersectionPair{}
 	for _, item := range intersection {
 		pair := intersectionPair{}


### PR DESCRIPTION
We want to deprecate the "Identifiable" interface in lieu of the translation layer. It's current construct is too brittle and can cause subtle issues when comparing types, potentially leading to wrong implementations.


### All Submissions:

* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if there is one).
* [ ] Update docs/release-notes/release-notes-template.md if your changes should be included in the release notes for the next release.
