### PR TITLE
CLOUDP-289101: Changes CRD shortname for private endpoint

### DIFF
--- a/config/crd/bases/atlas.mongodb.com_atlasprivateendpoints.yaml
+++ b/config/crd/bases/atlas.mongodb.com_atlasprivateendpoints.yaml
@@ -14,7 +14,7 @@ spec:
     listKind: AtlasPrivateEndpointList
     plural: atlasprivateendpoints
     shortNames:
-    - pe
+    - ape
     singular: atlasprivateendpoint
   scope: Namespaced
   versions:

--- a/pkg/api/v1/atlasprivateendpoint_types.go
+++ b/pkg/api/v1/atlasprivateendpoint_types.go
@@ -113,7 +113,7 @@ type GCPPrivateEndpoint struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +groupName:=atlas.mongodb.com
-// +kubebuilder:resource:categories=atlas,shortName=pe
+// +kubebuilder:resource:categories=atlas,shortName=ape
 // +kubebuilder:printcolumn:name="Provider",type=string,JSONPath=`.spec.provider`
 // +kubebuilder:printcolumn:name="Region",type=string,JSONPath=`.spec.region`
 // +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`


### PR DESCRIPTION
Changes CRD shortname for private endpoint from `pe` to `ape` to stay inline with convention of starting atlas resource shortnames with 'a'. Relevant manifests have been regenerated.

Connected ticket: [CLOUDP-289101](https://jira.mongodb.org/browse/CLOUDP-289101)

### All Submissions:

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if there is one).
* [ ] Update docs/release-notes/release-notes-template.md if your changes should be included in the release notes for the next release.
