### PR TITLE
CLOUDP-280012: Add http dry run transport for Atlas

### DIFF
--- a/internal/controller/atlas/provider_test.go
+++ b/internal/controller/atlas/provider_test.go
@@ -43,7 +43,7 @@ func TestProvider_Client(t *testing.T) {
 		Build()
 
 	t.Run("should return Atlas API client and organization id using global secret", func(t *testing.T) {
-		p := NewProductionProvider("https://cloud.mongodb.com/", client.ObjectKey{Name: "api-secret", Namespace: "default"}, k8sClient)
+		p := NewProductionProvider("https://cloud.mongodb.com/", client.ObjectKey{Name: "api-secret", Namespace: "default"}, k8sClient, nil)
 
 		c, id, err := p.Client(context.Background(), nil, zaptest.NewLogger(t).Sugar())
 		assert.NoError(t, err)
@@ -52,7 +52,7 @@ func TestProvider_Client(t *testing.T) {
 	})
 
 	t.Run("should return Atlas API client and organization id using connection secret", func(t *testing.T) {
-		p := NewProductionProvider("https://cloud.mongodb.com/", client.ObjectKey{Name: "global-secret", Namespace: "default"}, k8sClient)
+		p := NewProductionProvider("https://cloud.mongodb.com/", client.ObjectKey{Name: "global-secret", Namespace: "default"}, k8sClient, nil)
 
 		c, id, err := p.Client(context.Background(), &client.ObjectKey{Name: "api-secret", Namespace: "default"}, zaptest.NewLogger(t).Sugar())
 		assert.NoError(t, err)
@@ -63,17 +63,17 @@ func TestProvider_Client(t *testing.T) {
 
 func TestProvider_IsCloudGov(t *testing.T) {
 	t.Run("should return false for invalid domain", func(t *testing.T) {
-		p := NewProductionProvider("http://x:namedport", client.ObjectKey{}, nil)
+		p := NewProductionProvider("http://x:namedport", client.ObjectKey{}, nil, nil)
 		assert.False(t, p.IsCloudGov())
 	})
 
 	t.Run("should return false for commercial Atlas domain", func(t *testing.T) {
-		p := NewProductionProvider("https://cloud.mongodb.com/", client.ObjectKey{}, nil)
+		p := NewProductionProvider("https://cloud.mongodb.com/", client.ObjectKey{}, nil, nil)
 		assert.False(t, p.IsCloudGov())
 	})
 
 	t.Run("should return true for Atlas for government domain", func(t *testing.T) {
-		p := NewProductionProvider("https://cloud.mongodbgov.com/", client.ObjectKey{}, nil)
+		p := NewProductionProvider("https://cloud.mongodbgov.com/", client.ObjectKey{}, nil, nil)
 		assert.True(t, p.IsCloudGov())
 	})
 }
@@ -164,7 +164,7 @@ func TestProvider_IsResourceSupported(t *testing.T) {
 
 	for desc, data := range dataProvider {
 		t.Run(desc, func(t *testing.T) {
-			p := NewProductionProvider(data.domain, client.ObjectKey{}, nil)
+			p := NewProductionProvider(data.domain, client.ObjectKey{}, nil, nil)
 			assert.Equal(t, data.expectation, p.IsResourceSupported(data.resource))
 		})
 	}

--- a/internal/controller/atlasbackupcompliancepolicy/atlasbackupcompliancepolicy_controller.go
+++ b/internal/controller/atlasbackupcompliancepolicy/atlasbackupcompliancepolicy_controller.go
@@ -60,7 +60,7 @@ func (r *AtlasBackupCompliancePolicyReconciler) Reconcile(ctx context.Context, r
 	}
 
 	conditions := akov2.InitCondition(bcp, api.FalseCondition(api.ReadyType))
-	workflowCtx := workflow.NewContext(log, conditions, ctx)
+	workflowCtx := workflow.NewContext(log, conditions, ctx, bcp)
 	defer statushandler.Update(workflowCtx, r.Client, r.EventRecorder, bcp)
 
 	isValid := customresource.ValidateResourceVersion(workflowCtx, bcp, r.Log)

--- a/internal/controller/atlascustomrole/atlascustomrole_controller.go
+++ b/internal/controller/atlascustomrole/atlascustomrole_controller.go
@@ -94,7 +94,7 @@ func (r *AtlasCustomRoleReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	r.Log.Infow("-> Starting AtlasCustomRole reconciliation", "spec", atlasCustomRole.Spec, "status",
 		atlasCustomRole.GetStatus())
 	conditions := akov2.InitCondition(atlasCustomRole, api.FalseCondition(api.ReadyType))
-	workflowCtx := workflow.NewContext(r.Log, conditions, ctx)
+	workflowCtx := workflow.NewContext(r.Log, conditions, ctx, atlasCustomRole)
 	defer func() {
 		statushandler.Update(workflowCtx, r.Client, r.EventRecorder, atlasCustomRole)
 		r.Log.Infow("-> Finished AtlasCustomRole reconciliation", "spec", atlasCustomRole.Spec, "status",

--- a/internal/controller/atlascustomrole/atlascustomrole_controller_test.go
+++ b/internal/controller/atlascustomrole/atlascustomrole_controller_test.go
@@ -339,11 +339,11 @@ func TestAtlasCustomRoleReconciler_Reconcile(t *testing.T) {
 							return nil, "", fmt.Errorf("failed to create sdk")
 						}
 						cdrAPI := mockadmin.NewCustomDatabaseRolesApi(t)
-						cdrAPI.EXPECT().GetCustomDatabaseRole(context.Background(), "testProjectID", "TestRoleName").
+						cdrAPI.EXPECT().GetCustomDatabaseRole(mock.Anything, "testProjectID", "TestRoleName").
 							Return(admin.GetCustomDatabaseRoleApiRequest{ApiService: cdrAPI})
 						cdrAPI.EXPECT().GetCustomDatabaseRoleExecute(admin.GetCustomDatabaseRoleApiRequest{ApiService: cdrAPI}).
 							Return(&admin.UserCustomDBRole{}, &http.Response{StatusCode: http.StatusNotFound}, nil)
-						cdrAPI.EXPECT().CreateCustomDatabaseRole(context.Background(), "testProjectID",
+						cdrAPI.EXPECT().CreateCustomDatabaseRole(mock.Anything, "testProjectID",
 							mock.AnythingOfType("*admin.UserCustomDBRole")).
 							Return(admin.CreateCustomDatabaseRoleApiRequest{ApiService: cdrAPI})
 						cdrAPI.EXPECT().CreateCustomDatabaseRoleExecute(admin.CreateCustomDatabaseRoleApiRequest{ApiService: cdrAPI}).

--- a/internal/controller/atlasdatabaseuser/atlasdatabaseuser_controller.go
+++ b/internal/controller/atlasdatabaseuser/atlasdatabaseuser_controller.go
@@ -101,7 +101,7 @@ func (r *AtlasDatabaseUserReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 	r.Log.Infow("-> Starting AtlasDatabaseUser reconciliation", "spec", atlasDatabaseUser.Spec, "status", atlasDatabaseUser.GetStatus())
 	conditions := akov2.InitCondition(atlasDatabaseUser, api.FalseCondition(api.ReadyType))
-	workflowCtx := workflow.NewContext(r.Log, conditions, ctx)
+	workflowCtx := workflow.NewContext(r.Log, conditions, ctx, atlasDatabaseUser)
 	defer func() {
 		statushandler.Update(workflowCtx, r.Client, r.EventRecorder, atlasDatabaseUser)
 	}()

--- a/internal/controller/atlasdatafederation/datafederation_controller.go
+++ b/internal/controller/atlasdatafederation/datafederation_controller.go
@@ -74,7 +74,7 @@ func (r *AtlasDataFederationReconciler) Reconcile(context context.Context, req c
 	}
 
 	conditions := akov2.InitCondition(dataFederation, api.FalseCondition(api.ReadyType))
-	ctx := workflow.NewContext(log, conditions, context)
+	ctx := workflow.NewContext(log, conditions, context, dataFederation)
 	log.Infow("-> Starting AtlasDataFederation reconciliation", "spec", dataFederation.Spec, "status", dataFederation.Status)
 	defer statushandler.Update(ctx, r.Client, r.EventRecorder, dataFederation)
 

--- a/internal/controller/atlasdeployment/atlasdeployment_controller.go
+++ b/internal/controller/atlasdeployment/atlasdeployment_controller.go
@@ -115,7 +115,7 @@ func (r *AtlasDeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	}
 
 	conditions := akov2.InitCondition(atlasDeployment, api.FalseCondition(api.ReadyType))
-	workflowCtx := workflow.NewContext(log, conditions, ctx)
+	workflowCtx := workflow.NewContext(log, conditions, ctx, atlasDeployment)
 	log.Infow("-> Starting AtlasDeployment reconciliation", "spec", atlasDeployment.Spec, "status", atlasDeployment.Status)
 	defer func() {
 		statushandler.Update(workflowCtx, r.Client, r.EventRecorder, atlasDeployment)

--- a/internal/controller/atlasdeployment/atlasdeployment_controller_test.go
+++ b/internal/controller/atlasdeployment/atlasdeployment_controller_test.go
@@ -392,7 +392,7 @@ func TestRegularClusterReconciliation(t *testing.T) {
 		},
 		SdkClientFunc: func(secretRef *client.ObjectKey, log *zap.SugaredLogger) (*admin.APIClient, string, error) {
 			clusterAPI := mockadmin.NewClustersApi(t)
-			clusterAPI.EXPECT().GetCluster(context.Background(), project.ID(), d.GetDeploymentName()).
+			clusterAPI.EXPECT().GetCluster(mock.Anything, project.ID(), d.GetDeploymentName()).
 				Return(admin.GetClusterApiRequest{ApiService: clusterAPI})
 			clusterAPI.EXPECT().GetClusterExecute(mock.AnythingOfType("admin.GetClusterApiRequest")).
 				Return(
@@ -423,7 +423,7 @@ func TestRegularClusterReconciliation(t *testing.T) {
 					&http.Response{},
 					nil,
 				)
-			clusterAPI.EXPECT().GetClusterAdvancedConfiguration(context.Background(), project.ID(), d.GetDeploymentName()).
+			clusterAPI.EXPECT().GetClusterAdvancedConfiguration(mock.Anything, project.ID(), d.GetDeploymentName()).
 				Return(admin.GetClusterAdvancedConfigurationApiRequest{ApiService: clusterAPI})
 			clusterAPI.EXPECT().GetClusterAdvancedConfigurationExecute(mock.AnythingOfType("admin.GetClusterAdvancedConfigurationApiRequest")).
 				Return(
@@ -433,7 +433,7 @@ func TestRegularClusterReconciliation(t *testing.T) {
 				)
 
 			searchAPI := mockadmin.NewAtlasSearchApi(t)
-			searchAPI.EXPECT().GetAtlasSearchDeployment(context.Background(), project.ID(), d.Spec.DeploymentSpec.Name).
+			searchAPI.EXPECT().GetAtlasSearchDeployment(mock.Anything, project.ID(), d.Spec.DeploymentSpec.Name).
 				Return(admin.GetAtlasSearchDeploymentApiRequest{ApiService: searchAPI})
 			searchAPI.EXPECT().GetAtlasSearchDeploymentExecute(mock.Anything).
 				Return(
@@ -452,7 +452,7 @@ func TestRegularClusterReconciliation(t *testing.T) {
 				)
 
 			globalAPI := mockadmin.NewGlobalClustersApi(t)
-			globalAPI.EXPECT().GetManagedNamespace(context.Background(), project.ID(), d.Spec.DeploymentSpec.Name).
+			globalAPI.EXPECT().GetManagedNamespace(mock.Anything, project.ID(), d.Spec.DeploymentSpec.Name).
 				Return(admin.GetManagedNamespaceApiRequest{ApiService: globalAPI})
 			globalAPI.EXPECT().GetManagedNamespaceExecute(mock.Anything).
 				Return(&admin.GeoSharding{}, nil, nil)
@@ -615,13 +615,13 @@ func TestServerlessInstanceReconciliation(t *testing.T) {
 			err := &admin.GenericOpenAPIError{}
 			err.SetModel(admin.ApiError{ErrorCode: pointer.MakePtr(atlas.ServerlessInstanceFromClusterAPI)})
 			clusterAPI := mockadmin.NewClustersApi(t)
-			clusterAPI.EXPECT().GetCluster(context.Background(), project.ID(), d.GetDeploymentName()).
+			clusterAPI.EXPECT().GetCluster(mock.Anything, project.ID(), d.GetDeploymentName()).
 				Return(admin.GetClusterApiRequest{ApiService: clusterAPI})
 			clusterAPI.EXPECT().GetClusterExecute(mock.AnythingOfType("admin.GetClusterApiRequest")).
 				Return(nil, nil, err)
 
 			serverlessAPI := mockadmin.NewServerlessInstancesApi(t)
-			serverlessAPI.EXPECT().GetServerlessInstance(context.Background(), project.ID(), d.GetDeploymentName()).
+			serverlessAPI.EXPECT().GetServerlessInstance(mock.Anything, project.ID(), d.GetDeploymentName()).
 				Return(admin.GetServerlessInstanceApiRequest{ApiService: serverlessAPI})
 			serverlessAPI.EXPECT().GetServerlessInstanceExecute(mock.AnythingOfType("admin.GetServerlessInstanceApiRequest")).
 				Return(
@@ -644,7 +644,7 @@ func TestServerlessInstanceReconciliation(t *testing.T) {
 				)
 
 			speClient := mockadmin.NewServerlessPrivateEndpointsApi(t)
-			speClient.EXPECT().ListServerlessPrivateEndpoints(context.Background(), project.ID(), d.GetDeploymentName()).
+			speClient.EXPECT().ListServerlessPrivateEndpoints(mock.Anything, project.ID(), d.GetDeploymentName()).
 				Return(admin.ListServerlessPrivateEndpointsApiRequest{ApiService: speClient})
 			speClient.EXPECT().ListServerlessPrivateEndpointsExecute(mock.AnythingOfType("admin.ListServerlessPrivateEndpointsApiRequest")).
 				Return(nil, &http.Response{}, nil)
@@ -785,7 +785,7 @@ func TestDeletionReconciliation(t *testing.T) {
 		},
 		SdkClientFunc: func(secretRef *client.ObjectKey, log *zap.SugaredLogger) (*admin.APIClient, string, error) {
 			clusterAPI := mockadmin.NewClustersApi(t)
-			clusterAPI.EXPECT().GetCluster(context.Background(), project.ID(), d.GetDeploymentName()).
+			clusterAPI.EXPECT().GetCluster(mock.Anything, project.ID(), d.GetDeploymentName()).
 				Return(admin.GetClusterApiRequest{ApiService: clusterAPI})
 			clusterAPI.EXPECT().GetClusterExecute(mock.AnythingOfType("admin.GetClusterApiRequest")).
 				Return(
@@ -816,7 +816,7 @@ func TestDeletionReconciliation(t *testing.T) {
 					&http.Response{},
 					nil,
 				)
-			clusterAPI.EXPECT().DeleteCluster(context.Background(), project.ID(), d.GetDeploymentName()).
+			clusterAPI.EXPECT().DeleteCluster(mock.Anything, project.ID(), d.GetDeploymentName()).
 				Return(admin.DeleteClusterApiRequest{ApiService: clusterAPI})
 			clusterAPI.EXPECT().DeleteClusterExecute(mock.AnythingOfType("admin.DeleteClusterApiRequest")).
 				Return(&http.Response{}, nil)
@@ -1163,7 +1163,7 @@ func TestGetProjectFromAtlas(t *testing.T) {
 				},
 				SdkClientFunc: func(secretRef *client.ObjectKey, log *zap.SugaredLogger) (*admin.APIClient, string, error) {
 					projectAPI := mockadmin.NewProjectsApi(t)
-					projectAPI.EXPECT().GetProject(context.Background(), "project-id").
+					projectAPI.EXPECT().GetProject(mock.Anything, "project-id").
 						Return(admin.GetProjectApiRequest{ApiService: projectAPI})
 					projectAPI.EXPECT().GetProjectExecute(mock.AnythingOfType("admin.GetProjectApiRequest")).
 						Return(nil, nil, errors.New("failed to get project"))
@@ -1211,7 +1211,7 @@ func TestGetProjectFromAtlas(t *testing.T) {
 				},
 				SdkClientFunc: func(secretRef *client.ObjectKey, log *zap.SugaredLogger) (*admin.APIClient, string, error) {
 					projectAPI := mockadmin.NewProjectsApi(t)
-					projectAPI.EXPECT().GetProject(context.Background(), "project-id").
+					projectAPI.EXPECT().GetProject(mock.Anything, "project-id").
 						Return(admin.GetProjectApiRequest{ApiService: projectAPI})
 					projectAPI.EXPECT().GetProjectExecute(mock.AnythingOfType("admin.GetProjectApiRequest")).
 						Return(&admin.Group{Id: pointer.MakePtr("project-id")}, nil, nil)
@@ -1557,7 +1557,7 @@ func TestChangeDeploymentType(t *testing.T) {
 				},
 				SdkClientFunc: func(secretRef *client.ObjectKey, log *zap.SugaredLogger) (*admin.APIClient, string, error) {
 					clusterAPI := mockadmin.NewClustersApi(t)
-					clusterAPI.EXPECT().GetCluster(ctx, "abc123", "cluster0").
+					clusterAPI.EXPECT().GetCluster(mock.Anything, "abc123", "cluster0").
 						Return(admin.GetClusterApiRequest{ApiService: clusterAPI})
 					clusterAPI.EXPECT().GetClusterExecute(mock.AnythingOfType("admin.GetClusterApiRequest")).
 						RunAndReturn(
@@ -1573,7 +1573,7 @@ func TestChangeDeploymentType(t *testing.T) {
 
 					serverlessAPI := mockadmin.NewServerlessInstancesApi(t)
 					if !tt.deployment.IsServerless() {
-						serverlessAPI.EXPECT().GetServerlessInstance(ctx, "abc123", "cluster0").
+						serverlessAPI.EXPECT().GetServerlessInstance(mock.Anything, "abc123", "cluster0").
 							Return(admin.GetServerlessInstanceApiRequest{ApiService: serverlessAPI})
 						serverlessAPI.EXPECT().GetServerlessInstanceExecute(mock.AnythingOfType("admin.GetServerlessInstanceApiRequest")).
 							Return(&admin.ServerlessInstanceDescription{Name: pointer.MakePtr("cluster0")}, nil, nil)

--- a/internal/controller/atlasfederatedauth/atlasfederated_auth_controller.go
+++ b/internal/controller/atlasfederatedauth/atlasfederated_auth_controller.go
@@ -70,7 +70,7 @@ func (r *AtlasFederatedAuthReconciler) Reconcile(ctx context.Context, req ctrl.R
 	}
 
 	conditions := akov2.InitCondition(fedauth, api.FalseCondition(api.ReadyType))
-	workflowCtx := workflow.NewContext(log, conditions, ctx)
+	workflowCtx := workflow.NewContext(log, conditions, ctx, fedauth)
 	log.Infow("-> Starting AtlasFederatedAuth reconciliation")
 
 	defer statushandler.Update(workflowCtx, r.Client, r.EventRecorder, fedauth)

--- a/internal/controller/atlasfederatedauth/atlasfederated_auth_controller_test.go
+++ b/internal/controller/atlasfederatedauth/atlasfederated_auth_controller_test.go
@@ -94,7 +94,7 @@ func TestReconcile(t *testing.T) {
 
 		logger := zaptest.NewLogger(t).Sugar()
 		fedAuthAPI := mockadminv20241113001.NewFederatedAuthenticationApi(t)
-		fedAuthAPI.EXPECT().GetFederationSettings(context.Background(), orgID).
+		fedAuthAPI.EXPECT().GetFederationSettings(mock.Anything, orgID).
 			Return(adminv20241113001.GetFederationSettingsApiRequest{ApiService: fedAuthAPI})
 		fedAuthAPI.EXPECT().GetFederationSettingsExecute(mock.Anything).
 			Return(
@@ -108,7 +108,7 @@ func TestReconcile(t *testing.T) {
 				&http.Response{},
 				nil,
 			)
-		fedAuthAPI.EXPECT().ListIdentityProviders(context.Background(), fedSettingsID).
+		fedAuthAPI.EXPECT().ListIdentityProviders(mock.Anything, fedSettingsID).
 			Return(adminv20241113001.ListIdentityProvidersApiRequest{ApiService: fedAuthAPI})
 		fedAuthAPI.EXPECT().ListIdentityProvidersExecute(mock.Anything).
 			Return(
@@ -124,7 +124,7 @@ func TestReconcile(t *testing.T) {
 				&http.Response{},
 				nil,
 			)
-		fedAuthAPI.EXPECT().GetConnectedOrgConfig(context.Background(), fedSettingsID, orgID).
+		fedAuthAPI.EXPECT().GetConnectedOrgConfig(mock.Anything, fedSettingsID, orgID).
 			Return(adminv20241113001.GetConnectedOrgConfigApiRequest{ApiService: fedAuthAPI})
 		fedAuthAPI.EXPECT().GetConnectedOrgConfigExecute(mock.Anything).
 			Return(
@@ -139,7 +139,7 @@ func TestReconcile(t *testing.T) {
 				nil,
 			)
 		groupAPI := mockadmin.NewProjectsApi(t)
-		groupAPI.EXPECT().ListProjects(context.Background()).
+		groupAPI.EXPECT().ListProjects(mock.Anything).
 			Return(admin.ListProjectsApiRequest{ApiService: groupAPI})
 		groupAPI.EXPECT().ListProjectsExecute(mock.Anything).
 			Return(

--- a/internal/controller/atlasprivateendpoint/atlasprivateendpoint_controller.go
+++ b/internal/controller/atlasprivateendpoint/atlasprivateendpoint_controller.go
@@ -88,7 +88,7 @@ func (r *AtlasPrivateEndpointReconciler) ensureCustomResource(ctx context.Contex
 	}
 
 	conditions := api.InitCondition(akoPrivateEndpoint, api.FalseCondition(api.ReadyType))
-	workflowCtx := workflow.NewContext(r.Log, conditions, ctx)
+	workflowCtx := workflow.NewContext(r.Log, conditions, ctx, akoPrivateEndpoint)
 	defer statushandler.Update(workflowCtx, r.Client, r.EventRecorder, akoPrivateEndpoint)
 
 	isValid := customresource.ValidateResourceVersion(workflowCtx, akoPrivateEndpoint, r.Log)

--- a/internal/controller/atlasprivateendpoint/atlasprivateendpoint_controller_test.go
+++ b/internal/controller/atlasprivateendpoint/atlasprivateendpoint_controller_test.go
@@ -318,12 +318,12 @@ func TestEnsureCustomResource(t *testing.T) {
 				},
 				SdkClientFunc: func(secretRef *client.ObjectKey, log *zap.SugaredLogger) (*admin.APIClient, string, error) {
 					projectAPI := mockadmin.NewProjectsApi(t)
-					projectAPI.EXPECT().GetProject(ctx, projectID).Return(admin.GetProjectApiRequest{ApiService: projectAPI})
+					projectAPI.EXPECT().GetProject(mock.Anything, projectID).Return(admin.GetProjectApiRequest{ApiService: projectAPI})
 					projectAPI.EXPECT().GetProjectExecute(mock.AnythingOfType("admin.GetProjectApiRequest")).
 						Return(&admin.Group{Id: &projectID}, nil, nil)
 
 					peAPI := mockadmin.NewPrivateEndpointServicesApi(t)
-					peAPI.EXPECT().GetPrivateEndpointService(ctx, projectID, "AWS", "pe-service-id").
+					peAPI.EXPECT().GetPrivateEndpointService(mock.Anything, projectID, "AWS", "pe-service-id").
 						Return(admin.GetPrivateEndpointServiceApiRequest{ApiService: peAPI})
 					peAPI.EXPECT().GetPrivateEndpointServiceExecute(mock.AnythingOfType("admin.GetPrivateEndpointServiceApiRequest")).
 						Return(

--- a/internal/controller/atlasproject/atlasproject_controller.go
+++ b/internal/controller/atlasproject/atlasproject_controller.go
@@ -115,7 +115,7 @@ func (r *AtlasProjectReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	}
 
 	conditions := akov2.InitCondition(atlasProject, api.FalseCondition(api.ReadyType))
-	workflowCtx := workflow.NewContext(log, conditions, ctx)
+	workflowCtx := workflow.NewContext(log, conditions, ctx, atlasProject)
 	log.Infow("-> Starting AtlasProject reconciliation", "spec", atlasProject.Spec)
 
 	// This update will make sure the status is always updated in case of any errors or successful result

--- a/internal/controller/atlasproject/atlasproject_controller_test.go
+++ b/internal/controller/atlasproject/atlasproject_controller_test.go
@@ -54,7 +54,7 @@ func TestRenconcile(t *testing.T) {
 				notFoundErr := &admin.GenericOpenAPIError{}
 				notFoundErr.SetModel(admin.ApiError{ErrorCode: pointer.MakePtr("NOT_IN_GROUP")})
 				projectsAPI := mockadmin.NewProjectsApi(t)
-				projectsAPI.EXPECT().GetProjectByName(context.Background(), "my-project").
+				projectsAPI.EXPECT().GetProjectByName(mock.Anything, "my-project").
 					Return(admin.GetProjectByNameApiRequest{ApiService: projectsAPI})
 				projectsAPI.EXPECT().GetProjectByNameExecute(mock.AnythingOfType("admin.GetProjectByNameApiRequest")).
 					Return(
@@ -62,7 +62,7 @@ func TestRenconcile(t *testing.T) {
 						&http.Response{},
 						notFoundErr,
 					)
-				projectsAPI.EXPECT().CreateProject(context.Background(), mock.AnythingOfType("*admin.Group")).
+				projectsAPI.EXPECT().CreateProject(mock.Anything, mock.AnythingOfType("*admin.Group")).
 					Return(admin.CreateProjectApiRequest{ApiService: projectsAPI})
 				projectsAPI.EXPECT().CreateProjectExecute(mock.AnythingOfType("admin.CreateProjectApiRequest")).
 					Return(

--- a/internal/controller/atlasproject/team_reconciler.go
+++ b/internal/controller/atlasproject/team_reconciler.go
@@ -40,7 +40,7 @@ func (r *AtlasProjectReconciler) teamReconcile(
 		}
 
 		conditions := akov2.InitCondition(team, api.FalseCondition(api.ReadyType))
-		teamCtx := workflow.NewContext(log, conditions, ctx)
+		teamCtx := workflow.NewContext(log, conditions, ctx, team)
 		log.Infow("-> Starting AtlasTeam reconciliation", "spec", team.Spec)
 		defer statushandler.Update(teamCtx, r.Client, r.EventRecorder, team)
 

--- a/internal/controller/atlasproject/teams.go
+++ b/internal/controller/atlasproject/teams.go
@@ -192,7 +192,7 @@ func (r *AtlasProjectReconciler) updateTeamState(ctx *workflow.Context, project 
 
 	log := r.Log.With("atlasteam", teamRef)
 	conditions := akov2.InitCondition(team, api.FalseCondition(api.ReadyType))
-	teamCtx := workflow.NewContext(log, conditions, ctx.Context)
+	teamCtx := workflow.NewContext(log, conditions, ctx.Context, team)
 
 	if len(assignedProjects) == 0 {
 		if err = customresource.ManageFinalizer(ctx.Context, r.Client, team, customresource.UnsetFinalizer); err != nil {

--- a/internal/controller/atlasproject/teams_test.go
+++ b/internal/controller/atlasproject/teams_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"go.mongodb.org/atlas-sdk/v20231115008/admin"
 	"go.uber.org/zap/zaptest"
 	corev1 "k8s.io/api/core/v1"
@@ -154,10 +155,11 @@ func TestSyncAssignedTeams(t *testing.T) {
 			ctx := &workflow.Context{
 				Log:       logger,
 				SdkClient: atlasClient,
+				Context:   context.Background(),
 			}
 			teamService := func() teams.TeamsService {
 				service := translation.NewTeamsServiceMock(t)
-				service.EXPECT().ListProjectTeams(nil, "projectID").Return([]teams.AssignedTeam{
+				service.EXPECT().ListProjectTeams(mock.Anything, "projectID").Return([]teams.AssignedTeam{
 					{
 						Roles:    []string{"GROUP_OWNER"},
 						TeamID:   team1.Status.ID,
@@ -174,9 +176,9 @@ func TestSyncAssignedTeams(t *testing.T) {
 						TeamName: "teamName_3",
 					},
 				}, nil)
-				service.EXPECT().Unassign(nil, "projectID", "teamID_2").Return(nil)
-				service.EXPECT().Unassign(nil, "projectID", "teamID_3").Return(nil)
-				service.EXPECT().Assign(nil,
+				service.EXPECT().Unassign(mock.Anything, "projectID", "teamID_2").Return(nil)
+				service.EXPECT().Unassign(mock.Anything, "projectID", "teamID_3").Return(nil)
+				service.EXPECT().Assign(mock.Anything,
 					&[]teams.AssignedTeam{
 						{
 							Roles:  []string{"GROUP_READ_ONLY"},

--- a/internal/controller/atlassearchindexconfig/atlassearchindexconfig_controller.go
+++ b/internal/controller/atlassearchindexconfig/atlassearchindexconfig_controller.go
@@ -62,7 +62,7 @@ func (r *AtlasSearchIndexConfigReconciler) Reconcile(ctx context.Context, req ct
 	}
 
 	conditions := api.InitCondition(atlasSearchIndexConfig, api.FalseCondition(api.ReadyType))
-	workflowCtx := workflow.NewContext(log, conditions, ctx)
+	workflowCtx := workflow.NewContext(log, conditions, ctx, atlasSearchIndexConfig)
 	defer statushandler.Update(workflowCtx, r.Client, r.EventRecorder, atlasSearchIndexConfig)
 
 	isValid := customresource.ValidateResourceVersion(workflowCtx, atlasSearchIndexConfig, r.Log)

--- a/internal/controller/atlasstream/atlasstream_connection_controller.go
+++ b/internal/controller/atlasstream/atlasstream_connection_controller.go
@@ -64,7 +64,7 @@ func (r *AtlasStreamsConnectionReconciler) ensureAtlasStreamConnection(ctx conte
 	}
 
 	conditions := api.InitCondition(akoStreamConnection, api.FalseCondition(api.ReadyType))
-	workflowCtx := workflow.NewContext(log, conditions, ctx)
+	workflowCtx := workflow.NewContext(log, conditions, ctx, akoStreamConnection)
 	defer statushandler.Update(workflowCtx, r.Client, r.EventRecorder, akoStreamConnection)
 
 	isValid := customresource.ValidateResourceVersion(workflowCtx, akoStreamConnection, r.Log)

--- a/internal/controller/atlasstream/atlasstream_instance_controller.go
+++ b/internal/controller/atlasstream/atlasstream_instance_controller.go
@@ -74,7 +74,7 @@ func (r *AtlasStreamsInstanceReconciler) ensureAtlasStreamsInstance(ctx context.
 	}
 
 	conditions := api.InitCondition(akoStreamInstance, api.FalseCondition(api.ReadyType))
-	workflowCtx := workflow.NewContext(log, conditions, ctx)
+	workflowCtx := workflow.NewContext(log, conditions, ctx, akoStreamInstance)
 	defer statushandler.Update(workflowCtx, r.Client, r.EventRecorder, akoStreamInstance)
 
 	// check if stream instance is in "invalid" state

--- a/internal/controller/atlasstream/atlasstream_instance_controller_test.go
+++ b/internal/controller/atlasstream/atlasstream_instance_controller_test.go
@@ -458,7 +458,7 @@ func TestEnsureAtlasStreamsInstance(t *testing.T) {
 			Build()
 
 		streamsAPI := mockadmin.NewStreamsApi(t)
-		streamsAPI.EXPECT().GetStreamInstance(context.Background(), "my-project-id", "instance-0").
+		streamsAPI.EXPECT().GetStreamInstance(mock.Anything, "my-project-id", "instance-0").
 			Return(admin.GetStreamInstanceApiRequest{ApiService: streamsAPI})
 		streamsAPI.EXPECT().GetStreamInstanceExecute(mock.AnythingOfType("admin.GetStreamInstanceApiRequest")).
 			Return(nil, &http.Response{}, errors.New("failed to get instance"))
@@ -554,7 +554,7 @@ func TestEnsureAtlasStreamsInstance(t *testing.T) {
 			Build()
 
 		streamsAPI := mockadmin.NewStreamsApi(t)
-		streamsAPI.EXPECT().GetStreamInstance(context.Background(), "my-project-id", "instance-0").
+		streamsAPI.EXPECT().GetStreamInstance(mock.Anything, "my-project-id", "instance-0").
 			Return(admin.GetStreamInstanceApiRequest{ApiService: streamsAPI})
 		streamsAPI.EXPECT().GetStreamInstanceExecute(mock.AnythingOfType("admin.GetStreamInstanceApiRequest")).
 			Return(
@@ -574,7 +574,7 @@ func TestEnsureAtlasStreamsInstance(t *testing.T) {
 				&http.Response{},
 				nil,
 			)
-		streamsAPI.EXPECT().ListStreamConnections(context.Background(), "my-project-id", "instance-0").
+		streamsAPI.EXPECT().ListStreamConnections(mock.Anything, "my-project-id", "instance-0").
 			Return(admin.ListStreamConnectionsApiRequest{ApiService: streamsAPI})
 		streamsAPI.EXPECT().ListStreamConnectionsExecute(mock.AnythingOfType("admin.ListStreamConnectionsApiRequest")).
 			Return(
@@ -665,7 +665,7 @@ func TestEnsureAtlasStreamsInstance(t *testing.T) {
 			Build()
 
 		streamsAPI := mockadmin.NewStreamsApi(t)
-		streamsAPI.EXPECT().GetStreamInstance(context.Background(), "my-project-id", "instance-0").
+		streamsAPI.EXPECT().GetStreamInstance(mock.Anything, "my-project-id", "instance-0").
 			Return(admin.GetStreamInstanceApiRequest{ApiService: streamsAPI})
 		notFound := admin.ApiError{}
 		notFound.SetError(404)
@@ -678,7 +678,7 @@ func TestEnsureAtlasStreamsInstance(t *testing.T) {
 				&http.Response{},
 				&apiError,
 			)
-		streamsAPI.EXPECT().CreateStreamInstance(context.Background(), "my-project-id", mock.AnythingOfType("*admin.StreamsTenant")).
+		streamsAPI.EXPECT().CreateStreamInstance(mock.Anything, "my-project-id", mock.AnythingOfType("*admin.StreamsTenant")).
 			Return(admin.CreateStreamInstanceApiRequest{ApiService: streamsAPI})
 		streamsAPI.EXPECT().CreateStreamInstanceExecute(mock.AnythingOfType("admin.CreateStreamInstanceApiRequest")).
 			Return(
@@ -786,7 +786,7 @@ func TestEnsureAtlasStreamsInstance(t *testing.T) {
 			Build()
 
 		streamsAPI := mockadmin.NewStreamsApi(t)
-		streamsAPI.EXPECT().GetStreamInstance(context.Background(), "my-project-id", "instance-0").
+		streamsAPI.EXPECT().GetStreamInstance(mock.Anything, "my-project-id", "instance-0").
 			Return(admin.GetStreamInstanceApiRequest{ApiService: streamsAPI})
 		streamsAPI.EXPECT().GetStreamInstanceExecute(mock.AnythingOfType("admin.GetStreamInstanceApiRequest")).
 			Return(
@@ -806,7 +806,7 @@ func TestEnsureAtlasStreamsInstance(t *testing.T) {
 				&http.Response{},
 				nil,
 			)
-		streamsAPI.EXPECT().DeleteStreamInstance(context.Background(), "my-project-id", "instance-0").
+		streamsAPI.EXPECT().DeleteStreamInstance(mock.Anything, "my-project-id", "instance-0").
 			Return(admin.DeleteStreamInstanceApiRequest{ApiService: streamsAPI})
 		streamsAPI.EXPECT().DeleteStreamInstanceExecute(mock.AnythingOfType("admin.DeleteStreamInstanceApiRequest")).
 			Return(
@@ -888,7 +888,7 @@ func TestEnsureAtlasStreamsInstance(t *testing.T) {
 			Build()
 
 		streamsAPI := mockadmin.NewStreamsApi(t)
-		streamsAPI.EXPECT().GetStreamInstance(context.Background(), "my-project-id", "instance-0").
+		streamsAPI.EXPECT().GetStreamInstance(mock.Anything, "my-project-id", "instance-0").
 			Return(admin.GetStreamInstanceApiRequest{ApiService: streamsAPI})
 		streamsAPI.EXPECT().GetStreamInstanceExecute(mock.AnythingOfType("admin.GetStreamInstanceApiRequest")).
 			Return(
@@ -908,7 +908,7 @@ func TestEnsureAtlasStreamsInstance(t *testing.T) {
 				&http.Response{},
 				nil,
 			)
-		streamsAPI.EXPECT().UpdateStreamInstance(context.Background(), "my-project-id", "instance-0", mock.AnythingOfType("*admin.StreamsDataProcessRegion")).
+		streamsAPI.EXPECT().UpdateStreamInstance(mock.Anything, "my-project-id", "instance-0", mock.AnythingOfType("*admin.StreamsDataProcessRegion")).
 			Return(admin.UpdateStreamInstanceApiRequest{ApiService: streamsAPI})
 		streamsAPI.EXPECT().UpdateStreamInstanceExecute(mock.AnythingOfType("admin.UpdateStreamInstanceApiRequest")).
 			Return(

--- a/internal/controller/workflow/context.go
+++ b/internal/controller/workflow/context.go
@@ -7,9 +7,11 @@ import (
 	"go.mongodb.org/atlas/mongodbatlas"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/api"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/controller/atlas"
+	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/dryrun"
 )
 
 // Context is a container for some information that is needed on all levels of function calls during reconciliation.
@@ -44,11 +46,11 @@ type Context struct {
 	Context context.Context
 }
 
-func NewContext(log *zap.SugaredLogger, conditions []api.Condition, context context.Context) *Context {
+func NewContext(log *zap.SugaredLogger, conditions []api.Condition, context context.Context, obj runtime.Object) *Context {
 	return &Context{
 		status:  NewStatus(conditions),
 		Log:     log,
-		Context: context,
+		Context: dryrun.WithRuntimeObject(context, obj),
 	}
 }
 

--- a/internal/dryrun/context.go
+++ b/internal/dryrun/context.go
@@ -1,0 +1,27 @@
+package dryrun
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// key defines the package local unique type for context values.
+// In conjunction with context keys it forms a unique identifier.
+// It is unexported to prevent collisions.
+type key int
+
+const (
+	// runtimeObjectKey is the context key for the runtime object to be used for dry run recording.
+	runtimeObjectKey key = iota
+)
+
+// WithRuntimeObject returns a new context that wraps the provided context and contains the provided runtime object.
+func WithRuntimeObject(ctx context.Context, obj runtime.Object) context.Context {
+	return context.WithValue(ctx, runtimeObjectKey, obj)
+}
+
+func runtimeObjectFrom(ctx context.Context) (runtime.Object, bool) {
+	recorder, ok := ctx.Value(runtimeObjectKey).(runtime.Object)
+	return recorder, ok
+}

--- a/internal/dryrun/error.go
+++ b/internal/dryrun/error.go
@@ -1,0 +1,45 @@
+package dryrun
+
+import (
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+type DryRunError struct {
+	GVK                    string
+	Namespace, Name        string
+	EventType, Reason, Msg string
+}
+
+func NewDryRunError(kind schema.ObjectKind, meta metav1.ObjectMetaAccessor, eventtype, reason, messageFmt string, args ...interface{}) error {
+	gvk := "unknown"
+	if kind != nil {
+		gvk = kind.GroupVersionKind().String()
+	}
+
+	namespace, name := "unknown", "unknown"
+	if meta != nil {
+		namespace = meta.GetObjectMeta().GetNamespace()
+		name = meta.GetObjectMeta().GetName()
+	}
+
+	msg := fmt.Sprintf(messageFmt, args...)
+
+	return &DryRunError{
+		GVK:       gvk,
+		Namespace: namespace,
+		Name:      name,
+		EventType: eventtype,
+		Reason:    reason,
+		Msg:       msg,
+	}
+}
+
+func (e *DryRunError) Error() string {
+	return fmt.Sprintf(
+		"DryRun event GVK=%v, Namespace=%v, Name=%v, EventType=%v, Reason=%v, Message=%v",
+		e.GVK, e.Namespace, e.Name, e.EventType, e.Reason, e.Msg,
+	)
+}

--- a/internal/dryrun/transport.go
+++ b/internal/dryrun/transport.go
@@ -1,0 +1,61 @@
+package dryrun
+
+import (
+	"errors"
+	"net/http"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
+)
+
+const DryRunReason = "DryRun"
+
+var verbMap = map[string]string{
+	http.MethodPost:   "create (" + http.MethodPost + ")",
+	http.MethodPut:    "update (" + http.MethodPut + ")",
+	http.MethodPatch:  "update (" + http.MethodPatch + ")",
+	http.MethodDelete: "delete (" + http.MethodDelete + ")",
+}
+
+type DryRunTransport struct {
+	Recorder record.EventRecorder
+	Delegate http.RoundTripper
+}
+
+func NewDryRunTransport(recorder record.EventRecorder, delegate http.RoundTripper) *DryRunTransport {
+	return &DryRunTransport{
+		Recorder: recorder,
+		Delegate: delegate,
+	}
+}
+
+func (t *DryRunTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	switch req.Method {
+	case http.MethodGet:
+	case http.MethodConnect:
+	case http.MethodTrace:
+	case http.MethodHead:
+	default:
+		obj, ok := runtimeObjectFrom(req.Context())
+		if !ok {
+			return nil, errors.New("no object present in context: cannot record dry run without an object")
+		}
+
+		meta, ok := obj.(metav1.ObjectMetaAccessor)
+		if !ok {
+			return nil, errors.New("object does not implement ObjectMetaAccessor")
+		}
+
+		verb, ok := verbMap[req.Method]
+		if !ok {
+			verb = "execute " + req.Method
+		}
+		msg := "Would %v %v"
+		t.Recorder.Eventf(obj, v1.EventTypeNormal, DryRunReason, msg, verb, req.URL.Path)
+
+		return nil, NewDryRunError(obj.GetObjectKind(), meta, v1.EventTypeNormal, DryRunReason, msg, verb, req.URL.Path)
+	}
+
+	return t.Delegate.RoundTrip(req)
+}

--- a/internal/dryrun/transport_test.go
+++ b/internal/dryrun/transport_test.go
@@ -1,0 +1,128 @@
+package dryrun
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/tools/record"
+
+	akov2 "github.com/mongodb/mongodb-atlas-kubernetes/v2/api/v1"
+)
+
+type RoundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (fn RoundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
+}
+
+func TestDryRunTransport(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		req        *http.Request
+		obj        runtime.Object
+		wantEvents []string
+		wantErr    string
+	}{
+		{
+			name: "GET request",
+			req: &http.Request{
+				Method: http.MethodGet,
+			},
+		},
+		{
+			name: "no object",
+			req: &http.Request{
+				Method: http.MethodPost,
+			},
+			wantErr: "no object present in context: cannot record dry run without an object",
+		},
+		{
+			name: "unknown verb",
+			req: &http.Request{
+				Method: "UNKNOWN",
+				URL:    &url.URL{Path: "/test"},
+			},
+			obj: &akov2.AtlasProject{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "bar",
+				},
+			},
+			wantErr: "DryRun event GVK=atlas.mongodb.com/v1, Kind=AtlasProject, Namespace=bar, Name=foo, EventType=Normal, Reason=DryRun, Message=Would execute UNKNOWN /test",
+			wantEvents: []string{
+				"Normal DryRun Would execute UNKNOWN /test",
+			},
+		},
+		{
+			name: "POST request",
+			req: &http.Request{
+				Method: http.MethodPost,
+				URL:    &url.URL{Path: "/test"},
+			},
+			obj:     &akov2.AtlasProject{},
+			wantErr: "DryRun event GVK=atlas.mongodb.com/v1, Kind=AtlasProject, Namespace=, Name=, EventType=Normal, Reason=DryRun, Message=Would create (POST) /test",
+			wantEvents: []string{
+				"Normal DryRun Would create (POST) /test",
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := record.NewFakeRecorder(100)
+			nopDelegate := RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+				return nil, nil
+			})
+			transport := NewDryRunTransport(rec, nopDelegate)
+
+			if tc.obj != nil {
+				scheme := runtime.NewScheme()
+				assert.NoError(t, akov2.AddToScheme(scheme))
+				gvks, _, err := scheme.ObjectKinds(tc.obj)
+				require.NoError(t, err)
+				meta := tc.obj.(schema.ObjectKind)
+				meta.SetGroupVersionKind(gvks[0])
+			}
+
+			req := tc.req.WithContext(WithRuntimeObject(context.Background(), tc.obj))
+			_, err := transport.RoundTrip(req)
+			gotErr := ""
+			if err != nil {
+				gotErr = err.Error()
+			}
+			require.Equal(t, tc.wantErr, gotErr)
+			assertEqualEvents(t, tc.wantEvents, rec.Events)
+		})
+	}
+}
+
+func assertEqualEvents(t *testing.T, expected []string, actual <-chan string) {
+	c := time.After(wait.ForeverTestTimeout)
+	for _, e := range expected {
+		select {
+		case a := <-actual:
+			if e != a {
+				t.Errorf("Expected event %q, got %q", e, a)
+				return
+			}
+		case <-c:
+			t.Errorf("Expected event %q, got nothing", e)
+			// continue iterating to print all expected events
+		}
+	}
+	for {
+		select {
+		case a := <-actual:
+			t.Errorf("Unexpected event: %q", a)
+		default:
+			return // No more events, as expected.
+		}
+	}
+}

--- a/internal/httputil/loggedclient.go
+++ b/internal/httputil/loggedclient.go
@@ -18,6 +18,14 @@ func LoggingTransport(log *zap.SugaredLogger) ClientOpt {
 	}
 }
 
+func NewLoggingTransport(log *zap.SugaredLogger, logBody bool, delegate http.RoundTripper) http.RoundTripper {
+	return &loggedRoundTripper{
+		rt:      delegate,
+		log:     log,
+		logBody: logBody,
+	}
+}
+
 type loggedRoundTripper struct {
 	rt      http.RoundTripper
 	log     *zap.SugaredLogger

--- a/internal/operator/builder.go
+++ b/internal/operator/builder.go
@@ -218,7 +218,7 @@ func (b *Builder) Build(ctx context.Context) (manager.Manager, error) {
 	}
 
 	if b.atlasProvider == nil {
-		b.atlasProvider = atlas.NewProductionProvider(b.atlasDomain, b.apiSecret, mgr.GetClient())
+		b.atlasProvider = atlas.NewProductionProvider(b.atlasDomain, b.apiSecret, mgr.GetClient(), nil)
 	}
 
 	projectReconciler := atlasproject.NewAtlasProjectReconciler(


### PR DESCRIPTION
This adds a dry run transport towards Atlas calls. Note that this contribution is a no-op for now. The operator starts in non-dry-run mode.

### All Submissions:

* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if there is one).
* [ ] Update docs/release-notes/release-notes-template.md if your changes should be included in the release notes for the next release.
