### PR TITLE
CLOUDP-280230: Simplify and avoid CEL validation repetitions

### DIFF
--- a/api/v1/atlasdatabaseuser_types_test.go
+++ b/api/v1/atlasdatabaseuser_types_test.go
@@ -1,124 +1,19 @@
-package v1 // nolint: dupl
+package v1
 
 import (
 	"testing"
-
-	"github.com/mongodb/mongodb-atlas-kubernetes/v2/api"
-	"github.com/mongodb/mongodb-atlas-kubernetes/v2/api/v1/common"
 )
 
-func TestProjectReference(t *testing.T) {
-	tests := celTestCase{
-		"no project reference is set": {
-			object: &AtlasDatabaseUser{
-				Spec: AtlasDatabaseUserSpec{},
-			},
-			expectedErrors: []string{"spec: Invalid value: \"object\": must define only one project reference through externalProjectRef or projectRef"},
+func TestDatabaseUsersProjectRefCELValidations(t *testing.T) {
+	launchProjectRefCELTests(
+		t,
+		func(pdr *ProjectDualReference) AtlasCustomResource {
+			dbu := AtlasDatabaseUser{}
+			if pdr != nil {
+				setDualRef(dbu.ProjectDualRef(), pdr)
+			}
+			return &dbu
 		},
-		"both project references are set": {
-			object: &AtlasDatabaseUser{
-				Spec: AtlasDatabaseUserSpec{
-					ProjectDualReference: ProjectDualReference{
-						ProjectRef: &common.ResourceRefNamespaced{
-							Name: "my-project",
-						},
-						ExternalProjectRef: &ExternalProjectReference{
-							ID: "my-project-id",
-						},
-					},
-				},
-			},
-			expectedErrors: []string{
-				"spec: Invalid value: \"object\": must define only one project reference through externalProjectRef or projectRef",
-				"spec: Invalid value: \"object\": must define a local connection secret when referencing an external project",
-			},
-		},
-		"external project references is set": {
-			object: &AtlasDatabaseUser{
-				Spec: AtlasDatabaseUserSpec{
-					ProjectDualReference: ProjectDualReference{
-						ExternalProjectRef: &ExternalProjectReference{
-							ID: "my-project-id",
-						},
-					},
-				},
-			},
-			expectedErrors: []string{
-				"spec: Invalid value: \"object\": must define a local connection secret when referencing an external project",
-			},
-		},
-		"kubernetes project references is set": {
-			object: &AtlasDatabaseUser{
-				Spec: AtlasDatabaseUserSpec{
-					ProjectDualReference: ProjectDualReference{
-						ProjectRef: &common.ResourceRefNamespaced{
-							Name: "my-project",
-						},
-					},
-				},
-			},
-		},
-	}
-
-	assertCELValidation(t, "../../config/crd/bases/atlas.mongodb.com_atlasdatabaseusers.yaml", tests)
-}
-
-func TestExternalProjectReferenceConnectionSecret(t *testing.T) {
-	tests := celTestCase{
-		"external project references is set without connection secret": {
-			object: &AtlasDatabaseUser{
-				Spec: AtlasDatabaseUserSpec{
-					ProjectDualReference: ProjectDualReference{
-						ExternalProjectRef: &ExternalProjectReference{
-							ID: "my-project-id",
-						},
-					},
-				},
-			},
-			expectedErrors: []string{
-				"spec: Invalid value: \"object\": must define a local connection secret when referencing an external project",
-			},
-		},
-		"external project references is set with connection secret": {
-			object: &AtlasDatabaseUser{
-				Spec: AtlasDatabaseUserSpec{
-					ProjectDualReference: ProjectDualReference{
-						ExternalProjectRef: &ExternalProjectReference{
-							ID: "my-project-id",
-						},
-						ConnectionSecret: &api.LocalObjectReference{
-							Name: "my-dbuser-connection-secret",
-						},
-					},
-				},
-			},
-		},
-		"kubernetes project references is set without connection secret": {
-			object: &AtlasDatabaseUser{
-				Spec: AtlasDatabaseUserSpec{
-					ProjectDualReference: ProjectDualReference{
-						ProjectRef: &common.ResourceRefNamespaced{
-							Name: "my-project",
-						},
-					},
-				},
-			},
-		},
-		"kubernetes project references is set with connection secret": {
-			object: &AtlasDatabaseUser{
-				Spec: AtlasDatabaseUserSpec{
-					ProjectDualReference: ProjectDualReference{
-						ProjectRef: &common.ResourceRefNamespaced{
-							Name: "my-project",
-						},
-						ConnectionSecret: &api.LocalObjectReference{
-							Name: "my-dbuser-connection-secret",
-						},
-					},
-				},
-			},
-		},
-	}
-
-	assertCELValidation(t, "../../config/crd/bases/atlas.mongodb.com_atlasdatabaseusers.yaml", tests)
+		"../../config/crd/bases/atlas.mongodb.com_atlasdatabaseusers.yaml",
+	)
 }

--- a/api/v1/atlasdeployment_types_test.go
+++ b/api/v1/atlasdeployment_types_test.go
@@ -1,124 +1,19 @@
-package v1 // nolint: dupl
+package v1
 
 import (
 	"testing"
-
-	"github.com/mongodb/mongodb-atlas-kubernetes/v2/api"
-	"github.com/mongodb/mongodb-atlas-kubernetes/v2/api/v1/common"
 )
 
-func TestDeploymentProjectReference(t *testing.T) {
-	tests := celTestCase{
-		"no project reference is set": {
-			object: &AtlasDeployment{
-				Spec: AtlasDeploymentSpec{},
-			},
-			expectedErrors: []string{"spec: Invalid value: \"object\": must define only one project reference through externalProjectRef or projectRef"},
+func TestDedploymentProjectRefCELValidations(t *testing.T) {
+	launchProjectRefCELTests(
+		t,
+		func(pdr *ProjectDualReference) AtlasCustomResource {
+			d := AtlasDeployment{}
+			if pdr != nil {
+				setDualRef(d.ProjectDualRef(), pdr)
+			}
+			return &d
 		},
-		"both project references are set": {
-			object: &AtlasDeployment{
-				Spec: AtlasDeploymentSpec{
-					ProjectDualReference: ProjectDualReference{
-						ProjectRef: &common.ResourceRefNamespaced{
-							Name: "my-project",
-						},
-						ExternalProjectRef: &ExternalProjectReference{
-							ID: "my-project-id",
-						},
-					},
-				},
-			},
-			expectedErrors: []string{
-				"spec: Invalid value: \"object\": must define only one project reference through externalProjectRef or projectRef",
-				"spec: Invalid value: \"object\": must define a local connection secret when referencing an external project",
-			},
-		},
-		"external project references is set": {
-			object: &AtlasDeployment{
-				Spec: AtlasDeploymentSpec{
-					ProjectDualReference: ProjectDualReference{
-						ExternalProjectRef: &ExternalProjectReference{
-							ID: "my-project-id",
-						},
-					},
-				},
-			},
-			expectedErrors: []string{
-				"spec: Invalid value: \"object\": must define a local connection secret when referencing an external project",
-			},
-		},
-		"kubernetes project references is set": {
-			object: &AtlasDeployment{
-				Spec: AtlasDeploymentSpec{
-					ProjectDualReference: ProjectDualReference{
-						ProjectRef: &common.ResourceRefNamespaced{
-							Name: "my-project",
-						},
-					},
-				},
-			},
-		},
-	}
-
-	assertCELValidation(t, "../../config/crd/bases/atlas.mongodb.com_atlasdeployments.yaml", tests)
-}
-
-func TestDeploymentExternalProjectReferenceConnectionSecret(t *testing.T) {
-	tests := celTestCase{
-		"external project references is set without connection secret": {
-			object: &AtlasDeployment{
-				Spec: AtlasDeploymentSpec{
-					ProjectDualReference: ProjectDualReference{
-						ExternalProjectRef: &ExternalProjectReference{
-							ID: "my-project-id",
-						},
-					},
-				},
-			},
-			expectedErrors: []string{
-				"spec: Invalid value: \"object\": must define a local connection secret when referencing an external project",
-			},
-		},
-		"external project references is set with connection secret": {
-			object: &AtlasDeployment{
-				Spec: AtlasDeploymentSpec{
-					ProjectDualReference: ProjectDualReference{
-						ExternalProjectRef: &ExternalProjectReference{
-							ID: "my-project-id",
-						},
-						ConnectionSecret: &api.LocalObjectReference{
-							Name: "my-dbuser-connection-secret",
-						},
-					},
-				},
-			},
-		},
-		"kubernetes project references is set without connection secret": {
-			object: &AtlasDeployment{
-				Spec: AtlasDeploymentSpec{
-					ProjectDualReference: ProjectDualReference{
-						ProjectRef: &common.ResourceRefNamespaced{
-							Name: "my-project",
-						},
-					},
-				},
-			},
-		},
-		"kubernetes project references is set with connection secret": {
-			object: &AtlasDeployment{
-				Spec: AtlasDeploymentSpec{
-					ProjectDualReference: ProjectDualReference{
-						ProjectRef: &common.ResourceRefNamespaced{
-							Name: "my-project",
-						},
-						ConnectionSecret: &api.LocalObjectReference{
-							Name: "my-dbuser-connection-secret",
-						},
-					},
-				},
-			},
-		},
-	}
-
-	assertCELValidation(t, "../../config/crd/bases/atlas.mongodb.com_atlasdeployments.yaml", tests)
+		"../../config/crd/bases/atlas.mongodb.com_atlasdeployments.yaml",
+	)
 }

--- a/api/v1/atlasprivateendpoint_types_test.go
+++ b/api/v1/atlasprivateendpoint_types_test.go
@@ -1,124 +1,19 @@
-package v1 // nolint: dupl
+package v1
 
 import (
 	"testing"
-
-	"github.com/mongodb/mongodb-atlas-kubernetes/v2/api"
-	"github.com/mongodb/mongodb-atlas-kubernetes/v2/api/v1/common"
 )
 
-func TestPrivateEndpointProjectReference(t *testing.T) {
-	tests := celTestCase{
-		"no project reference is set": {
-			object: &AtlasPrivateEndpoint{
-				Spec: AtlasPrivateEndpointSpec{},
-			},
-			expectedErrors: []string{"spec: Invalid value: \"object\": must define only one project reference through externalProjectRef or projectRef"},
+func TestPrivateEndpointProjectRefCELValidations(t *testing.T) {
+	launchProjectRefCELTests(
+		t,
+		func(pdr *ProjectDualReference) AtlasCustomResource {
+			pe := AtlasPrivateEndpoint{}
+			if pdr != nil {
+				setDualRef(pe.ProjectDualRef(), pdr)
+			}
+			return &pe
 		},
-		"both project references are set": {
-			object: &AtlasPrivateEndpoint{
-				Spec: AtlasPrivateEndpointSpec{
-					ProjectDualReference: ProjectDualReference{
-						ProjectRef: &common.ResourceRefNamespaced{
-							Name: "my-project",
-						},
-						ExternalProjectRef: &ExternalProjectReference{
-							ID: "my-project-id",
-						},
-					},
-				},
-			},
-			expectedErrors: []string{
-				"spec: Invalid value: \"object\": must define only one project reference through externalProjectRef or projectRef",
-				"spec: Invalid value: \"object\": must define a local connection secret when referencing an external project",
-			},
-		},
-		"external project references is set": {
-			object: &AtlasPrivateEndpoint{
-				Spec: AtlasPrivateEndpointSpec{
-					ProjectDualReference: ProjectDualReference{
-						ExternalProjectRef: &ExternalProjectReference{
-							ID: "my-project-id",
-						},
-					},
-				},
-			},
-			expectedErrors: []string{
-				"spec: Invalid value: \"object\": must define a local connection secret when referencing an external project",
-			},
-		},
-		"kubernetes project references is set": {
-			object: &AtlasPrivateEndpoint{
-				Spec: AtlasPrivateEndpointSpec{
-					ProjectDualReference: ProjectDualReference{
-						ProjectRef: &common.ResourceRefNamespaced{
-							Name: "my-project",
-						},
-					},
-				},
-			},
-		},
-	}
-
-	assertCELValidation(t, "../../config/crd/bases/atlas.mongodb.com_atlasprivateendpoints.yaml", tests)
-}
-
-func TestPrivateEndpointExternalProjectReferenceConnectionSecret(t *testing.T) {
-	tests := celTestCase{
-		"external project references is set without connection secret": {
-			object: &AtlasPrivateEndpoint{
-				Spec: AtlasPrivateEndpointSpec{
-					ProjectDualReference: ProjectDualReference{
-						ExternalProjectRef: &ExternalProjectReference{
-							ID: "my-project-id",
-						},
-					},
-				},
-			},
-			expectedErrors: []string{
-				"spec: Invalid value: \"object\": must define a local connection secret when referencing an external project",
-			},
-		},
-		"external project references is set with connection secret": {
-			object: &AtlasPrivateEndpoint{
-				Spec: AtlasPrivateEndpointSpec{
-					ProjectDualReference: ProjectDualReference{
-						ExternalProjectRef: &ExternalProjectReference{
-							ID: "my-project-id",
-						},
-						ConnectionSecret: &api.LocalObjectReference{
-							Name: "my-dbuser-connection-secret",
-						},
-					},
-				},
-			},
-		},
-		"kubernetes project references is set without connection secret": {
-			object: &AtlasPrivateEndpoint{
-				Spec: AtlasPrivateEndpointSpec{
-					ProjectDualReference: ProjectDualReference{
-						ProjectRef: &common.ResourceRefNamespaced{
-							Name: "my-project",
-						},
-					},
-				},
-			},
-		},
-		"kubernetes project references is set with connection secret": {
-			object: &AtlasPrivateEndpoint{
-				Spec: AtlasPrivateEndpointSpec{
-					ProjectDualReference: ProjectDualReference{
-						ProjectRef: &common.ResourceRefNamespaced{
-							Name: "my-project",
-						},
-						ConnectionSecret: &api.LocalObjectReference{
-							Name: "my-dbuser-connection-secret",
-						},
-					},
-				},
-			},
-		},
-	}
-
-	assertCELValidation(t, "../../config/crd/bases/atlas.mongodb.com_atlasprivateendpoints.yaml", tests)
+		"../../config/crd/bases/atlas.mongodb.com_atlasprivateendpoints.yaml",
+	)
 }

--- a/api/v1/project_reference_cel_test.go
+++ b/api/v1/project_reference_cel_test.go
@@ -7,36 +7,129 @@ import (
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/runtime"
 
+	"github.com/mongodb/mongodb-atlas-kubernetes/v2/api"
+	"github.com/mongodb/mongodb-atlas-kubernetes/v2/api/v1/common"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/test/helper/cel"
 )
 
-type celTestCase map[string]struct {
-	object         AtlasCustomResource
-	oldObject      AtlasCustomResource
+type CELTestObjectGenFunc func(*ProjectDualReference) AtlasCustomResource
+
+type celValidationTestCase struct {
+	title          string
+	obj, old       AtlasCustomResource
 	expectedErrors []string
 }
 
-func assertCELValidation(t *testing.T, crdPath string, tests celTestCase) {
-	t.Helper()
-
-	validator, err := cel.VersionValidatorFromFile(t, crdPath, "v1")
-	require.NoError(t, err)
-
-	for name, tt := range tests {
-		t.Run(name, func(t *testing.T) {
-			unstructuredObject, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&tt.object)
+func launchProjectRefCELTests(t *testing.T, genObjFunc CELTestObjectGenFunc, crdPath string) {
+	testCases := testCasesFor(genObjFunc)
+	for _, tc := range testCases {
+		t.Run(tc.title, func(t *testing.T) {
+			unstructuredObject, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&tc.obj)
 			require.NoError(t, err)
 
-			unstructuredOldObject, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&tt.oldObject)
+			unstructuredOldObject, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&tc.old)
 			require.NoError(t, err)
 
+			validator, err := cel.VersionValidatorFromFile(t, crdPath, "v1")
+			assert.NoError(t, err)
 			errs := validator(unstructuredObject, unstructuredOldObject)
 
-			require.Equal(t, len(tt.expectedErrors), len(errs))
+			require.Equal(t, len(tc.expectedErrors), len(errs))
 
 			for i, err := range errs {
-				assert.Equal(t, tt.expectedErrors[i], err.Error())
+				assert.Equal(t, tc.expectedErrors[i], err.Error())
 			}
 		})
 	}
+}
+
+func testCasesFor(genObjFunc CELTestObjectGenFunc) []celValidationTestCase {
+	return []celValidationTestCase{
+		{
+			title:          "no project reference is set",
+			obj:            genObjFunc(nil),
+			expectedErrors: []string{"spec: Invalid value: \"object\": must define only one project reference through externalProjectRef or projectRef"},
+		},
+		{
+			title: "both project references are set",
+			obj: genObjFunc(&ProjectDualReference{
+				ProjectRef: &common.ResourceRefNamespaced{
+					Name: "my-project",
+				},
+				ExternalProjectRef: &ExternalProjectReference{
+					ID: "my-project-id",
+				},
+			}),
+			expectedErrors: []string{
+				"spec: Invalid value: \"object\": must define only one project reference through externalProjectRef or projectRef",
+				"spec: Invalid value: \"object\": must define a local connection secret when referencing an external project",
+			},
+		},
+		{
+			title: "external project references is set",
+			obj: genObjFunc(&ProjectDualReference{
+				ExternalProjectRef: &ExternalProjectReference{
+					ID: "my-project-id",
+				},
+			}),
+			expectedErrors: []string{
+				"spec: Invalid value: \"object\": must define a local connection secret when referencing an external project",
+			},
+		},
+		{
+			title: "kubernetes project references is set",
+			obj: genObjFunc(&ProjectDualReference{
+				ProjectRef: &common.ResourceRefNamespaced{
+					Name: "my-project",
+				},
+			}),
+		},
+		{
+			title: "external project references is set without connection secret",
+			obj: genObjFunc(&ProjectDualReference{
+				ExternalProjectRef: &ExternalProjectReference{
+					ID: "my-project-id",
+				},
+			}),
+			expectedErrors: []string{
+				"spec: Invalid value: \"object\": must define a local connection secret when referencing an external project",
+			},
+		},
+		{
+			title: "external project references is set with connection secret",
+			obj: genObjFunc(&ProjectDualReference{
+				ExternalProjectRef: &ExternalProjectReference{
+					ID: "my-project-id",
+				},
+				ConnectionSecret: &api.LocalObjectReference{
+					Name: "my-dbuser-connection-secret",
+				},
+			}),
+		},
+		{
+			title: "kubernetes project references is set without connection secret",
+			obj: genObjFunc(&ProjectDualReference{
+				ProjectRef: &common.ResourceRefNamespaced{
+					Name: "my-project",
+				},
+			}),
+		},
+		{
+			title: "kubernetes project references is set with connection secret",
+			obj: genObjFunc(&ProjectDualReference{
+				ProjectRef: &common.ResourceRefNamespaced{
+					Name: "my-project",
+				},
+				ConnectionSecret: &api.LocalObjectReference{
+					Name: "my-dbuser-connection-secret",
+				},
+			}),
+		},
+	}
+}
+
+func setDualRef(target, source *ProjectDualReference) {
+	target.ConnectionSecret = source.ConnectionSecret
+	target.ExternalProjectRef = source.ExternalProjectRef
+	target.ProjectRef = source.ProjectRef
 }


### PR DESCRIPTION
Avoid repeating the same 8 test cases again and again on each new CRD type using the CEL validations for dual project references.

### All Submissions:

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
