### PR TITLE
CLOUDP-294831: Use random project names on contract tests

### DIFF
--- a/test/contract/audit/audit_test.go
+++ b/test/contract/audit/audit_test.go
@@ -18,7 +18,7 @@ import (
 func TestDefaultAuditingGet(t *testing.T) {
 	ctx := context.Background()
 	contract.RunGoContractTest(ctx, t, "get default auditing", func(ch contract.ContractHelper) {
-		projectName := "default-auditing-project"
+		projectName := utils.RandomName("default-auditing-project")
 		require.NoError(t, ch.AddResources(ctx, time.Minute, contract.DefaultAtlasProject(projectName)))
 		testProjectID, err := ch.ProjectID(ctx, projectName)
 		require.NoError(t, err)

--- a/test/contract/ipaccesslist/ipaccesslist_test.go
+++ b/test/contract/ipaccesslist/ipaccesslist_test.go
@@ -14,12 +14,13 @@ import (
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/api/v1/project"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/translation/ipaccesslist"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/test/helper/contract"
+	"github.com/mongodb/mongodb-atlas-kubernetes/v2/test/helper/e2e/utils"
 )
 
 func TestList(t *testing.T) {
 	ctx := context.Background()
 	contract.RunGoContractTest(ctx, t, "get default auditing", func(ch contract.ContractHelper) {
-		projectName := "default-auditing-project"
+		projectName := utils.RandomName("default-auditing-project")
 
 		prj := contract.DefaultAtlasProject(projectName).(*akov2.AtlasProject)
 


### PR DESCRIPTION
We should use random project names in contract tests to avoid conflicts.

### All Submissions:

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
