### PR TITLE
CLOUDP-294849: preflight: check manifest image only

### DIFF
--- a/.github/actions/certify-openshift-images/entrypoint.sh
+++ b/.github/actions/certify-openshift-images/entrypoint.sh
@@ -4,25 +4,15 @@ set -eou pipefail
 
 docker login -u mongodb+mongodb_atlas_kubernetes -p "${REGISTRY_PASSWORD}" "${REGISTRY}"
 
-DIGESTS=$(docker manifest inspect "${REGISTRY}/${REPOSITORY}:${VERSION}" | jq -r '.manifests[] | select(.platform.os!="unknown") | .digest')
-mapfile -t PLATFORMS < <(docker manifest inspect "${REGISTRY}/${REPOSITORY}:${VERSION}" | jq -r '.manifests[] | select(.platform.os!="unknown") | .platform.architecture')
-
 submit_flag=--submit
 if [ "${SUBMIT}" == "false" ]; then
   submit_flag=
 fi
 
-INDEX=0
-for DIGEST in $DIGESTS; do
-    echo "Check and Submit result to RedHat Connect"
-    # Send results to RedHat if preflight finished wthout errors
-    preflight check container "${REGISTRY}/${REPOSITORY}@${DIGEST}" \
-      --artifacts "${DIGEST}" \
-      --platform "${PLATFORMS[$INDEX]}" \
-      --pyxis-api-token="${RHCC_TOKEN}" \
-      --certification-project-id="${RHCC_PROJECT}" \
-      --docker-config="${HOME}/.docker/config.json" \
-      ${submit_flag}
-
-  (( INDEX++ )) || true
-done
+echo "Check and Submit result to RedHat Connect"
+# Send results to RedHat if preflight finished wthout errors
+preflight check container "${REGISTRY}/${REPOSITORY}:${VERSION}" \
+  --pyxis-api-token="${RHCC_TOKEN}" \
+  --certification-project-id="${RHCC_PROJECT}" \
+  --docker-config="${HOME}/.docker/config.json" \
+  ${submit_flag}


### PR DESCRIPTION
While investigating why tags are not synced in the RedHat catalogue I found that our certification is actually broken and prevents proper certified images to be displayed at https://catalog.redhat.com/software/container-stacks/detail/606c2c5a7c9ac7d8cc203e51.

While discussing with RedHat support I found that our preflight certification script must be changed to certify the whole manifest image rather than the individual platform images.

This fixes it.

**Proof of work**: I executed the E2E test pointing to commit https://github.com/mongodb/mongodb-atlas-kubernetes/pull/2047/commits/68409dbb39539754f69b38f5a3e6ed3718ee7c43:
<img width="365" alt="image" src="https://github.com/user-attachments/assets/d5ec176e-71e9-4e47-814e-13fefe53c949" />


It yielded the following successful result, see https://github.com/mongodb/mongodb-atlas-kubernetes/actions/runs/12786281981/job/35643041420:

```
time="2025-01-15T10:28:45Z" level=info msg="This image's tag CLOUDP-294849-68409dbb will be paired with digest sha256:dded49b62edb3f64cabe580b091c5ed921ff4f1f7bdeaa0c03fa0cd1fd16a7ab once this image has been published in accordance with Red Hat Certification policy. You may then add or remove any supplemental tags through your Red Hat Connect portal as you see fit."
time="2025-01-15T10:28:45Z" level=info msg="Preflight result: PASSED"
{
    "image": "ghcr.io/mongodb/mongodb-atlas-kubernetes-operator-prerelease:CLOUDP-294849-68409dbb",
    "passed": true,
...
```

### All Submissions:

* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if there is one).
* [ ] Update docs/release-notes/release-notes-template.md if your changes should be included in the release notes for the next release.
