### PR TITLE
CLOUDP-288315: certify-openshift-images: use latest version of preflight

### DIFF
--- a/.github/actions/certify-openshift-images/Dockerfile
+++ b/.github/actions/certify-openshift-images/Dockerfile
@@ -17,7 +17,7 @@ RUN yum-config-manager --add-repo https://download.docker.com/linux/centos/docke
 
 RUN yum clean all
 
-RUN curl -LO https://github.com/redhat-openshift-ecosystem/openshift-preflight/releases/download/1.10.2/preflight-linux-amd64  && \
+RUN curl -LO https://github.com/redhat-openshift-ecosystem/openshift-preflight/releases/latest/download/preflight-linux-amd64  && \
   chmod +x ./preflight-linux-amd64 && \
   mv ./preflight-linux-amd64 /usr/local/bin/preflight
 


### PR DESCRIPTION
This uses the latest version of the RedHat preflight tool for certification.

**Proof of work**: Started E2E tests pointing to this PR:
<img width="363" alt="image" src="https://github.com/user-attachments/assets/1fa51c88-f62d-4d67-94a5-b65a3d0db22e" />

Github Action https://github.com/mongodb/mongodb-atlas-kubernetes/actions/runs/12786964036/job/35645145199 yielded the following result using the latest version of `preflight` (1.11.1):
```
Check and Submit result to RedHat Connect
time="2025-01-15T11:09:01Z" level=info msg="certification library version" version="1.11.1 <commit: f787b66d23c7c29f078c43e2c2f23d32f4c6310e>"
...
```

### All Submissions:

* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if there is one).
* [ ] Update docs/release-notes/release-notes-template.md if your changes should be included in the release notes for the next release.
