### PR TITLE
CLOUDP-294932:  Fix contract test skips

### DIFF
--- a/test/helper/contract/contract.go
+++ b/test/helper/contract/contract.go
@@ -2,6 +2,7 @@ package contract
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"

--- a/test/helper/contract/contract.go
+++ b/test/helper/contract/contract.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -48,16 +49,8 @@ func (ct *contractTest) cleanup(ctx context.Context) error {
 }
 
 func RunGoContractTest(ctx context.Context, t *testing.T, name string, contractTest func(ch ContractHelper)) {
-	enabled := control.Enabled("AKO_CONTRACT_TEST")
-	focus := os.Getenv("AKO_CONTRACT_TEST_FOCUS")
-	focused := focus != "" && focus == name
-	if !enabled || !focused {
-		if !focused {
-			t.Skipf("Skipping contract test %q as focus is %q", name, focus)
-		} else {
-			t.Skip("Skipping contract test as AKO_CONTRACT_TEST is unset")
-		}
-		return
+	if err := skipCheck(name, os.Getenv("AKO_CONTRACT_TEST_FOCUS"), control.Enabled("AKO_CONTRACT_TEST")); err != nil {
+		t.Skipf("Skipping contract test: %v", err.Error())
 	}
 	ct := newContractTest(ctx)
 	defer func() {
@@ -66,6 +59,16 @@ func RunGoContractTest(ctx context.Context, t *testing.T, name string, contractT
 	t.Run(name, func(t *testing.T) {
 		contractTest(ct)
 	})
+}
+
+func skipCheck(name, focus string, enabled bool) error {
+	if !enabled {
+		return fmt.Errorf("AKO_CONTRACT_TEST is unset")
+	}
+	if focus != "" && !strings.Contains(name, focus) {
+		return fmt.Errorf("test %q does not contain focus string %q", name, focus)
+	}
+	return nil
 }
 
 func newContractTest(ctx context.Context) *contractTest {

--- a/test/helper/contract/contract.go
+++ b/test/helper/contract/contract.go
@@ -63,7 +63,7 @@ func RunGoContractTest(ctx context.Context, t *testing.T, name string, contractT
 
 func skipCheck(name, focus string, enabled bool) error {
 	if !enabled {
-		return fmt.Errorf("AKO_CONTRACT_TEST is unset")
+		return errors.New("AKO_CONTRACT_TEST is unset")
 	}
 	if focus != "" && !strings.Contains(name, focus) {
 		return fmt.Errorf("test %q does not contain focus string %q", name, focus)

--- a/test/helper/contract/skip_test.go
+++ b/test/helper/contract/skip_test.go
@@ -1,0 +1,67 @@
+package contract
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSkip(t *testing.T) {
+	for _, tc := range []struct {
+		title    string
+		name     string
+		focus    string
+		enabled  bool
+		expected error
+	}{
+		{
+			title:    "empty name, focus and disabled skips all",
+			expected: errors.New("AKO_CONTRACT_TEST is unset"),
+		},
+		{
+			title:   "empty name, focus and enabled does not skip",
+			enabled: true,
+		},
+		{
+			title:    "disabled skips regardles of focus matching",
+			name:     "target",
+			focus:    "target",
+			expected: errors.New("AKO_CONTRACT_TEST is unset"),
+		},
+		{
+			title:   "enabled with no focus does not skip",
+			enabled: true,
+			name:    "target",
+		},
+		{
+			title:   "enabled with no focus does not skip",
+			enabled: true,
+			name:    "target",
+		},
+		{
+			title:    "enabled with non matching focus skips",
+			enabled:  true,
+			name:     "something else",
+			focus:    "target",
+			expected: errors.New("test \"something else\" does not contain focus string \"target\""),
+		},
+		{
+			title:   "enabled with matching focus does not skip",
+			enabled: true,
+			name:    "target",
+			focus:   "target",
+		},
+		{
+			title:   "enabled matching a sub-target focus does not skip",
+			enabled: true,
+			name:    "some target phrase",
+			focus:   "target",
+		},
+	} {
+		t.Run(tc.title, func(t *testing.T) {
+			err := skipCheck(tc.name, tc.focus, tc.enabled)
+			assert.Equal(t, tc.expected, err)
+		})
+	}
+}


### PR DESCRIPTION
Fix bug skipping all contract tests by default and add unit tests to verify fix.

### All Submissions:

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
