### PR TITLE
CLOUDP-293806: indexer: use cluster rather than manager

### DIFF
--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -6,7 +6,7 @@ import (
 
 	"go.uber.org/zap"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/cluster"
 )
 
 type Indexer interface {
@@ -18,9 +18,9 @@ type Indexer interface {
 // RegisterAll registers all known indexers to the given manager.
 // It uses the given logger to create a new named "indexer" logger,
 // passing that to each indexer.
-func RegisterAll(ctx context.Context, mgr manager.Manager, logger *zap.Logger) error {
+func RegisterAll(ctx context.Context, c cluster.Cluster, logger *zap.Logger) error {
 	logger = logger.Named("indexer")
-	return Register(ctx, mgr,
+	return Register(ctx, c,
 		NewAtlasBackupScheduleByBackupPolicyIndexer(logger),
 		NewAtlasDeploymentByBackupScheduleIndexer(logger),
 		NewAtlasDeploymentBySearchIndexIndexer(logger),
@@ -34,7 +34,7 @@ func RegisterAll(ctx context.Context, mgr manager.Manager, logger *zap.Logger) e
 		NewAtlasDatabaseUserBySecretsIndexer(logger),
 		NewAtlasDatabaseUserByCredentialIndexer(logger),
 		NewAtlasDeploymentByCredentialIndexer(logger),
-		NewAtlasDatabaseUserByProjectIndexer(ctx, mgr.GetClient(), logger),
+		NewAtlasDatabaseUserByProjectIndexer(ctx, c.GetClient(), logger),
 		NewAtlasDataFederationByProjectIndexer(logger),
 		NewAtlasCustomRoleByCredentialIndexer(logger),
 		NewAtlasCustomRoleByProjectIndexer(logger),
@@ -44,9 +44,9 @@ func RegisterAll(ctx context.Context, mgr manager.Manager, logger *zap.Logger) e
 }
 
 // Register registers the given indexers to the given manager's field indexer.
-func Register(ctx context.Context, mgr manager.Manager, indexers ...Indexer) error {
+func Register(ctx context.Context, c cluster.Cluster, indexers ...Indexer) error {
 	for _, indexer := range indexers {
-		err := mgr.GetFieldIndexer().IndexField(ctx, indexer.Object(), indexer.Name(), indexer.Keys)
+		err := c.GetFieldIndexer().IndexField(ctx, indexer.Object(), indexer.Name(), indexer.Keys)
 		if err != nil {
 			return fmt.Errorf("error registering indexer %q: %w", indexer.Name(), err)
 		}


### PR DESCRIPTION
controller-runtime's `Manager` satisfies the `Cluster` (https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.20.0/pkg/cluster#Cluster) interface.

We are going to need the `Cluster` primitive for dry-run functionality and need to register indexers for this use case. This changes the signature to accept `Cluster` for indexer registration.

### All Submissions:

* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if there is one).
* [ ] Update docs/release-notes/release-notes-template.md if your changes should be included in the release notes for the next release.
