### PR TITLE
CLOUDP-293806: internal/controller: wire cluster rather than manager

### DIFF
--- a/internal/controller/atlasbackupcompliancepolicy/atlasbackupcompliancepolicy_controller.go
+++ b/internal/controller/atlasbackupcompliancepolicy/atlasbackupcompliancepolicy_controller.go
@@ -11,9 +11,9 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/cluster"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -109,16 +109,16 @@ func (r *AtlasBackupCompliancePolicyReconciler) SetupWithManager(mgr ctrl.Manage
 }
 
 func NewAtlasBackupCompliancePolicyReconciler(
-	mgr manager.Manager,
+	c cluster.Cluster,
 	predicates []predicate.Predicate,
 	atlasProvider atlas.Provider,
 	deletionProtection bool,
 	logger *zap.Logger,
 ) *AtlasBackupCompliancePolicyReconciler {
 	return &AtlasBackupCompliancePolicyReconciler{
-		Scheme:                   mgr.GetScheme(),
-		Client:                   mgr.GetClient(),
-		EventRecorder:            mgr.GetEventRecorderFor("AtlasBackupCompliancePolicy"),
+		Scheme:                   c.GetScheme(),
+		Client:                   c.GetClient(),
+		EventRecorder:            c.GetEventRecorderFor("AtlasBackupCompliancePolicy"),
 		GlobalPredicates:         predicates,
 		Log:                      logger.Named("controllers").Named("AtlasBackupCompliancePolicy").Sugar(),
 		AtlasProvider:            atlasProvider,

--- a/internal/controller/atlascustomrole/atlascustomrole_controller.go
+++ b/internal/controller/atlascustomrole/atlascustomrole_controller.go
@@ -12,9 +12,9 @@ import (
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/cluster"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -43,7 +43,7 @@ type AtlasCustomRoleReconciler struct {
 }
 
 func NewAtlasCustomRoleReconciler(
-	mgr manager.Manager,
+	c cluster.Cluster,
 	predicates []predicate.Predicate,
 	atlasProvider atlas.Provider,
 	deletionProtection bool,
@@ -52,11 +52,11 @@ func NewAtlasCustomRoleReconciler(
 ) *AtlasCustomRoleReconciler {
 	return &AtlasCustomRoleReconciler{
 		AtlasReconciler: reconciler.AtlasReconciler{
-			Client: mgr.GetClient(),
+			Client: c.GetClient(),
 			Log:    logger.Named("controllers").Named("AtlasCustomRoles").Sugar(),
 		},
-		Scheme:                   mgr.GetScheme(),
-		EventRecorder:            mgr.GetEventRecorderFor("AtlasCustomRoles"),
+		Scheme:                   c.GetScheme(),
+		EventRecorder:            c.GetEventRecorderFor("AtlasCustomRoles"),
 		AtlasProvider:            atlasProvider,
 		GlobalPredicates:         predicates,
 		ObjectDeletionProtection: deletionProtection,

--- a/internal/controller/atlasdatabaseuser/atlasdatabaseuser_controller.go
+++ b/internal/controller/atlasdatabaseuser/atlasdatabaseuser_controller.go
@@ -31,9 +31,9 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/cluster"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -271,7 +271,7 @@ func (r *AtlasDatabaseUserReconciler) databaseUsersForCredentialMapFunc() handle
 }
 
 func NewAtlasDatabaseUserReconciler(
-	mgr manager.Manager,
+	c cluster.Cluster,
 	predicates []predicate.Predicate,
 	atlasProvider atlas.Provider,
 	deletionProtection bool,
@@ -281,12 +281,12 @@ func NewAtlasDatabaseUserReconciler(
 ) *AtlasDatabaseUserReconciler {
 	return &AtlasDatabaseUserReconciler{
 		AtlasReconciler: reconciler.AtlasReconciler{
-			Client: mgr.GetClient(),
+			Client: c.GetClient(),
 			Log:    logger.Named("controllers").Named("AtlasDatabaseUser").Sugar(),
 		},
 		AtlasProvider:            atlasProvider,
-		Scheme:                   mgr.GetScheme(),
-		EventRecorder:            mgr.GetEventRecorderFor("AtlasDatabaseUser"),
+		Scheme:                   c.GetScheme(),
+		EventRecorder:            c.GetEventRecorderFor("AtlasDatabaseUser"),
 		GlobalPredicates:         predicates,
 		ObjectDeletionProtection: deletionProtection,
 		independentSyncPeriod:    independentSyncPeriod,

--- a/internal/controller/atlasdatafederation/datafederation_controller.go
+++ b/internal/controller/atlasdatafederation/datafederation_controller.go
@@ -14,9 +14,9 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/cluster"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -253,16 +253,16 @@ func (r *AtlasDataFederationReconciler) findAtlasDataFederationForProjects(ctx c
 }
 
 func NewAtlasDataFederationReconciler(
-	mgr manager.Manager,
+	c cluster.Cluster,
 	predicates []predicate.Predicate,
 	atlasProvider atlas.Provider,
 	deletionProtection bool,
 	logger *zap.Logger,
 ) *AtlasDataFederationReconciler {
 	return &AtlasDataFederationReconciler{
-		Scheme:                   mgr.GetScheme(),
-		Client:                   mgr.GetClient(),
-		EventRecorder:            mgr.GetEventRecorderFor("AtlasDataFederation"),
+		Scheme:                   c.GetScheme(),
+		Client:                   c.GetClient(),
+		EventRecorder:            c.GetEventRecorderFor("AtlasDataFederation"),
 		GlobalPredicates:         predicates,
 		Log:                      logger.Named("controllers").Named("AtlasDataFederation").Sugar(),
 		AtlasProvider:            atlasProvider,

--- a/internal/controller/atlasdeployment/atlasdeployment_controller.go
+++ b/internal/controller/atlasdeployment/atlasdeployment_controller.go
@@ -32,9 +32,9 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/cluster"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -407,7 +407,7 @@ func (r *AtlasDeploymentReconciler) SetupWithManager(mgr ctrl.Manager, skipNameV
 }
 
 func NewAtlasDeploymentReconciler(
-	mgr manager.Manager,
+	c cluster.Cluster,
 	predicates []predicate.Predicate,
 	atlasProvider atlas.Provider,
 	deletionProtection bool,
@@ -418,11 +418,11 @@ func NewAtlasDeploymentReconciler(
 
 	return &AtlasDeploymentReconciler{
 		AtlasReconciler: reconciler.AtlasReconciler{
-			Client: mgr.GetClient(),
+			Client: c.GetClient(),
 			Log:    suggaredLogger,
 		},
-		Scheme:                   mgr.GetScheme(),
-		EventRecorder:            mgr.GetEventRecorderFor("AtlasDeployment"),
+		Scheme:                   c.GetScheme(),
+		EventRecorder:            c.GetEventRecorderFor("AtlasDeployment"),
 		GlobalPredicates:         predicates,
 		AtlasProvider:            atlasProvider,
 		ObjectDeletionProtection: deletionProtection,

--- a/internal/controller/atlasfederatedauth/atlasfederated_auth_controller.go
+++ b/internal/controller/atlasfederatedauth/atlasfederated_auth_controller.go
@@ -13,9 +13,9 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/cluster"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -163,16 +163,16 @@ func (r *AtlasFederatedAuthReconciler) findAtlasFederatedAuthForSecret(ctx conte
 }
 
 func NewAtlasFederatedAuthReconciler(
-	mgr manager.Manager,
+	c cluster.Cluster,
 	predicates []predicate.Predicate,
 	atlasProvider atlas.Provider,
 	deletionProtection bool,
 	logger *zap.Logger,
 ) *AtlasFederatedAuthReconciler {
 	return &AtlasFederatedAuthReconciler{
-		Scheme:                   mgr.GetScheme(),
-		Client:                   mgr.GetClient(),
-		EventRecorder:            mgr.GetEventRecorderFor("AtlasFederatedAuth"),
+		Scheme:                   c.GetScheme(),
+		Client:                   c.GetClient(),
+		EventRecorder:            c.GetEventRecorderFor("AtlasFederatedAuth"),
 		GlobalPredicates:         predicates,
 		Log:                      logger.Named("controllers").Named("AtlasFederatedAuth").Sugar(),
 		AtlasProvider:            atlasProvider,

--- a/internal/controller/atlasprivateendpoint/atlasprivateendpoint_controller.go
+++ b/internal/controller/atlasprivateendpoint/atlasprivateendpoint_controller.go
@@ -31,9 +31,9 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/cluster"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -284,7 +284,7 @@ func (r *AtlasPrivateEndpointReconciler) privateEndpointForCredentialMapFunc() h
 }
 
 func NewAtlasPrivateEndpointReconciler(
-	mgr manager.Manager,
+	c cluster.Cluster,
 	predicates []predicate.Predicate,
 	atlasProvider atlas.Provider,
 	deletionProtection bool,
@@ -292,11 +292,11 @@ func NewAtlasPrivateEndpointReconciler(
 ) *AtlasPrivateEndpointReconciler {
 	return &AtlasPrivateEndpointReconciler{
 		AtlasReconciler: reconciler.AtlasReconciler{
-			Client: mgr.GetClient(),
+			Client: c.GetClient(),
 			Log:    logger.Named("controllers").Named("AtlasPrivateEndpoint").Sugar(),
 		},
-		Scheme:                   mgr.GetScheme(),
-		EventRecorder:            mgr.GetEventRecorderFor("AtlasPrivateEndpoint"),
+		Scheme:                   c.GetScheme(),
+		EventRecorder:            c.GetEventRecorderFor("AtlasPrivateEndpoint"),
 		AtlasProvider:            atlasProvider,
 		GlobalPredicates:         predicates,
 		ObjectDeletionProtection: deletionProtection,

--- a/internal/controller/atlasproject/atlasproject_controller.go
+++ b/internal/controller/atlasproject/atlasproject_controller.go
@@ -30,9 +30,9 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/cluster"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -270,16 +270,16 @@ func (r *AtlasProjectReconciler) SetupWithManager(mgr ctrl.Manager, skipNameVali
 }
 
 func NewAtlasProjectReconciler(
-	mgr manager.Manager,
+	c cluster.Cluster,
 	predicates []predicate.Predicate,
 	atlasProvider atlas.Provider,
 	deletionProtection bool,
 	logger *zap.Logger,
 ) *AtlasProjectReconciler {
 	return &AtlasProjectReconciler{
-		Scheme:                   mgr.GetScheme(),
-		Client:                   mgr.GetClient(),
-		EventRecorder:            mgr.GetEventRecorderFor("AtlasProject"),
+		Scheme:                   c.GetScheme(),
+		Client:                   c.GetClient(),
+		EventRecorder:            c.GetEventRecorderFor("AtlasProject"),
 		GlobalPredicates:         predicates,
 		Log:                      logger.Named("controllers").Named("AtlasProject").Sugar(),
 		AtlasProvider:            atlasProvider,

--- a/internal/controller/atlassearchindexconfig/atlassearchindexconfig_controller.go
+++ b/internal/controller/atlassearchindexconfig/atlassearchindexconfig_controller.go
@@ -11,9 +11,9 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/cluster"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -109,16 +109,16 @@ func (r *AtlasSearchIndexConfigReconciler) SetupWithManager(mgr ctrl.Manager, sk
 }
 
 func NewAtlasSearchIndexConfigReconciler(
-	mgr manager.Manager,
+	c cluster.Cluster,
 	predicates []predicate.Predicate,
 	atlasProvider atlas.Provider,
 	deletionProtection bool,
 	logger *zap.Logger,
 ) *AtlasSearchIndexConfigReconciler {
 	return &AtlasSearchIndexConfigReconciler{
-		Scheme:                   mgr.GetScheme(),
-		Client:                   mgr.GetClient(),
-		EventRecorder:            mgr.GetEventRecorderFor("AtlasSearchIndexConfig"),
+		Scheme:                   c.GetScheme(),
+		Client:                   c.GetClient(),
+		EventRecorder:            c.GetEventRecorderFor("AtlasSearchIndexConfig"),
 		GlobalPredicates:         predicates,
 		Log:                      logger.Named("controllers").Named("AtlasSearchIndexConfig").Sugar(),
 		AtlasProvider:            atlasProvider,

--- a/internal/controller/atlasstream/atlasstream_connection_controller.go
+++ b/internal/controller/atlasstream/atlasstream_connection_controller.go
@@ -11,9 +11,9 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/cluster"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -109,16 +109,16 @@ func (r *AtlasStreamsConnectionReconciler) SetupWithManager(mgr ctrl.Manager, sk
 }
 
 func NewAtlasStreamsConnectionReconciler(
-	mgr manager.Manager,
+	c cluster.Cluster,
 	predicates []predicate.Predicate,
 	atlasProvider atlas.Provider,
 	deletionProtection bool,
 	logger *zap.Logger,
 ) *AtlasStreamsConnectionReconciler {
 	return &AtlasStreamsConnectionReconciler{
-		Scheme:                   mgr.GetScheme(),
-		Client:                   mgr.GetClient(),
-		EventRecorder:            mgr.GetEventRecorderFor("AtlasStreamsConnection"),
+		Scheme:                   c.GetScheme(),
+		Client:                   c.GetClient(),
+		EventRecorder:            c.GetEventRecorderFor("AtlasStreamsConnection"),
 		GlobalPredicates:         predicates,
 		Log:                      logger.Named("controllers").Named("AtlasStreamsConnection").Sugar(),
 		AtlasProvider:            atlasProvider,

--- a/internal/controller/atlasstream/atlasstream_instance_controller.go
+++ b/internal/controller/atlasstream/atlasstream_instance_controller.go
@@ -13,9 +13,9 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/cluster"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -155,16 +155,16 @@ func (r *AtlasStreamsInstanceReconciler) SetupWithManager(mgr ctrl.Manager, skip
 }
 
 func NewAtlasStreamsInstanceReconciler(
-	mgr manager.Manager,
+	c cluster.Cluster,
 	predicates []predicate.Predicate,
 	atlasProvider atlas.Provider,
 	deletionProtection bool,
 	logger *zap.Logger,
 ) *AtlasStreamsInstanceReconciler {
 	return &AtlasStreamsInstanceReconciler{
-		Scheme:                   mgr.GetScheme(),
-		Client:                   mgr.GetClient(),
-		EventRecorder:            mgr.GetEventRecorderFor("AtlasStreamsInstance"),
+		Scheme:                   c.GetScheme(),
+		Client:                   c.GetClient(),
+		EventRecorder:            c.GetEventRecorderFor("AtlasStreamsInstance"),
 		GlobalPredicates:         predicates,
 		Log:                      logger.Named("controllers").Named("AtlasStreamsInstance").Sugar(),
 		AtlasProvider:            atlasProvider,


### PR DESCRIPTION
This wires the `Cluster` object into all of our controllers. This just works because `Manager` satisfies the `Cluster` interface.

We need this for dry-run as reconcilers will be invoked with a pure `Cluster` object instance in that use case.

### All Submissions:

* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if there is one).
* [ ] Update docs/release-notes/release-notes-template.md if your changes should be included in the release notes for the next release.
