### PR TITLE
CLOUDP-293806: internal/controller: add registry

### DIFF
--- a/internal/controller/registry.go
+++ b/internal/controller/registry.go
@@ -1,0 +1,81 @@
+package controller
+
+import (
+	"fmt"
+	"time"
+
+	"go.uber.org/zap"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cluster"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/controller/atlas"
+	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/controller/atlasbackupcompliancepolicy"
+	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/controller/atlascustomrole"
+	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/controller/atlasdatabaseuser"
+	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/controller/atlasdatafederation"
+	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/controller/atlasdeployment"
+	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/controller/atlasfederatedauth"
+	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/controller/atlasprivateendpoint"
+	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/controller/atlasproject"
+	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/controller/atlassearchindexconfig"
+	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/controller/atlasstream"
+	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/featureflags"
+)
+
+type ManagerAware interface {
+	SetupWithManager(mgr ctrl.Manager, skipNameValidation bool) error
+}
+
+type AkoReconciler interface {
+	reconcile.Reconciler
+	ManagerAware
+}
+
+type Registry struct {
+	predicates            []predicate.Predicate
+	deletionProtection    bool
+	independentSyncPeriod time.Duration
+	featureFlags          *featureflags.FeatureFlags
+
+	logger      *zap.Logger
+	reconcilers []AkoReconciler
+}
+
+func NewRegistry(predicates []predicate.Predicate, deletionProtection bool, logger *zap.Logger, independentSyncPeriod time.Duration, featureFlags *featureflags.FeatureFlags) *Registry {
+	return &Registry{
+		predicates:            predicates,
+		deletionProtection:    deletionProtection,
+		logger:                logger,
+		independentSyncPeriod: independentSyncPeriod,
+		featureFlags:          featureFlags,
+	}
+}
+
+func (r *Registry) RegisterWithManager(mgr ctrl.Manager, skipNameValidation bool, ap atlas.Provider) error {
+	r.registerControllers(mgr, ap)
+
+	for _, reconciler := range r.reconcilers {
+		if err := reconciler.SetupWithManager(mgr, skipNameValidation); err != nil {
+			return fmt.Errorf("failed to set up with manager: %w", err)
+		}
+	}
+	return nil
+}
+
+func (r *Registry) registerControllers(c cluster.Cluster, ap atlas.Provider) {
+	var reconcilers []AkoReconciler
+	reconcilers = append(reconcilers, atlasproject.NewAtlasProjectReconciler(c, r.predicates, ap, r.deletionProtection, r.logger))
+	reconcilers = append(reconcilers, atlasdeployment.NewAtlasDeploymentReconciler(c, r.predicates, ap, r.deletionProtection, r.independentSyncPeriod, r.logger))
+	reconcilers = append(reconcilers, atlasdatabaseuser.NewAtlasDatabaseUserReconciler(c, r.predicates, ap, r.deletionProtection, r.independentSyncPeriod, r.featureFlags, r.logger))
+	reconcilers = append(reconcilers, atlasdatafederation.NewAtlasDataFederationReconciler(c, r.predicates, ap, r.deletionProtection, r.logger))
+	reconcilers = append(reconcilers, atlasfederatedauth.NewAtlasFederatedAuthReconciler(c, r.predicates, ap, r.deletionProtection, r.logger))
+	reconcilers = append(reconcilers, atlasstream.NewAtlasStreamsInstanceReconciler(c, r.predicates, ap, r.deletionProtection, r.logger))
+	reconcilers = append(reconcilers, atlasstream.NewAtlasStreamsConnectionReconciler(c, r.predicates, ap, r.deletionProtection, r.logger))
+	reconcilers = append(reconcilers, atlassearchindexconfig.NewAtlasSearchIndexConfigReconciler(c, r.predicates, ap, r.deletionProtection, r.logger))
+	reconcilers = append(reconcilers, atlasbackupcompliancepolicy.NewAtlasBackupCompliancePolicyReconciler(c, r.predicates, ap, r.deletionProtection, r.logger))
+	reconcilers = append(reconcilers, atlascustomrole.NewAtlasCustomRoleReconciler(c, r.predicates, ap, r.deletionProtection, r.independentSyncPeriod, r.logger))
+	reconcilers = append(reconcilers, atlasprivateendpoint.NewAtlasPrivateEndpointReconciler(c, r.predicates, ap, r.deletionProtection, r.logger))
+	r.reconcilers = reconcilers
+}

--- a/test/e2e/configuration_test.go
+++ b/test/e2e/configuration_test.go
@@ -159,10 +159,10 @@ var _ = Describe("Configuration namespaced. Deploy deployment", Label("deploymen
 })
 
 func mainCycle(testData *model.TestDataProvider) {
-	mgr := actions.PrepareOperatorConfigurations(testData)
+	r := actions.PrepareOperatorConfigurations(testData)
 	ctx := context.Background()
 	go func(ctx context.Context) {
-		err := mgr.Start(ctx)
+		err := r.Start(ctx)
 		Expect(err).NotTo(HaveOccurred())
 	}(ctx)
 

--- a/test/e2e/db_users_test.go
+++ b/test/e2e/db_users_test.go
@@ -95,7 +95,7 @@ var _ = Describe("Operator watch all namespace should create connection secrets 
 			Expect(k8s.CreateNamespace(testData.Context, testData.K8SClient, secondNamespace)).To(Succeed())
 			k8s.CreateDefaultSecret(testData.Context, testData.K8SClient, localSecretName, secondNamespace)
 
-			mgr, err := k8s.BuildManager(&k8s.Config{
+			c, err := k8s.BuildCluster(&k8s.Config{
 				GlobalAPISecret: client.ObjectKey{
 					Namespace: config.DefaultOperatorNS,
 					Name:      config.DefaultOperatorGlobalKey,
@@ -109,7 +109,7 @@ var _ = Describe("Operator watch all namespace should create connection secrets 
 			Expect(err).NotTo(HaveOccurred())
 
 			go func(ctx context.Context) context.Context {
-				err := mgr.Start(ctx)
+				err := c.Start(ctx)
 				Expect(err).NotTo(HaveOccurred())
 				return ctx
 			}(testData.Context)
@@ -207,7 +207,7 @@ var _ = Describe("Operator fails if local credentials is mentioned but unavailab
 			Expect(k8s.CreateNamespace(testData.Context, testData.K8SClient, namespace)).NotTo(HaveOccurred())
 			k8s.CreateDefaultSecret(testData.Context, testData.K8SClient, config.DefaultOperatorGlobalKey, namespace)
 
-			mgr, err := k8s.BuildManager(&k8s.Config{
+			c, err := k8s.BuildCluster(&k8s.Config{
 				GlobalAPISecret: client.ObjectKey{
 					Namespace: namespace,
 					Name:      config.DefaultOperatorGlobalKey,
@@ -220,7 +220,7 @@ var _ = Describe("Operator fails if local credentials is mentioned but unavailab
 			Expect(err).NotTo(HaveOccurred())
 
 			go func(ctx context.Context) context.Context {
-				err := mgr.Start(ctx)
+				err := c.Start(ctx)
 				Expect(err).NotTo(HaveOccurred())
 				return ctx
 			}(testData.Context)

--- a/test/e2e/operator_type_wide_test.go
+++ b/test/e2e/operator_type_wide_test.go
@@ -76,7 +76,7 @@ var _ = Describe("Deployment wide operator can work with resources in different 
 			k8s.CreateNamespace(ctx, k8sClient, config.DefaultOperatorNS)
 			k8s.CreateDefaultSecret(ctx, k8sClient, config.DefaultOperatorGlobalKey, config.DefaultOperatorNS)
 
-			mgr, err := k8s.BuildManager(&k8s.Config{
+			c, err := k8s.BuildCluster(&k8s.Config{
 				GlobalAPISecret: client.ObjectKey{
 					Namespace: config.DefaultOperatorNS,
 					Name:      config.DefaultOperatorGlobalKey,
@@ -85,7 +85,7 @@ var _ = Describe("Deployment wide operator can work with resources in different 
 			})
 			Expect(err).NotTo(HaveOccurred())
 			go func(ctx context.Context) context.Context {
-				err := mgr.Start(ctx)
+				err := c.Start(ctx)
 				Expect(err).NotTo(HaveOccurred())
 				return ctx
 			}(ctx)

--- a/test/helper/e2e/actions/deploy/deploy_operator.go
+++ b/test/helper/e2e/actions/deploy/deploy_operator.go
@@ -29,7 +29,7 @@ func MultiNamespaceOperator(data *model.TestDataProvider, watchNamespace []strin
 		for _, ns := range watchNamespace {
 			watchNamespaceMap[ns] = true
 		}
-		mgr, err := k8s.BuildManager(&k8s.Config{
+		c, err := k8s.BuildCluster(&k8s.Config{
 			GlobalAPISecret: client.ObjectKey{
 				Namespace: config.DefaultOperatorNS,
 				Name:      config.DefaultOperatorGlobalKey,
@@ -40,7 +40,7 @@ func MultiNamespaceOperator(data *model.TestDataProvider, watchNamespace []strin
 		Expect(err).Should(Succeed())
 		ctx := context.Background()
 		go func(ctx context.Context) {
-			err = mgr.Start(ctx)
+			err = c.Start(ctx)
 			Expect(err).Should(Succeed(), "Operator should be started")
 		}(ctx)
 		data.ManagerContext = ctx

--- a/test/helper/e2e/actions/project_flow.go
+++ b/test/helper/e2e/actions/project_flow.go
@@ -25,10 +25,10 @@ import (
 
 func ProjectCreationFlow(userData *model.TestDataProvider) {
 	By("Prepare operator configurations", func() {
-		mgr := PrepareOperatorConfigurations(userData)
+		r := PrepareOperatorConfigurations(userData)
 		ctx := context.Background()
 		go func(ctx context.Context) context.Context {
-			err := mgr.Start(ctx)
+			err := r.Start(ctx)
 			Expect(err).NotTo(HaveOccurred())
 			return ctx
 		}(ctx)
@@ -37,9 +37,9 @@ func ProjectCreationFlow(userData *model.TestDataProvider) {
 	})
 }
 
-func PrepareOperatorConfigurations(userData *model.TestDataProvider) manager.Manager {
+func PrepareOperatorConfigurations(userData *model.TestDataProvider) manager.Runnable {
 	CreateNamespaceAndSecrets(userData)
-	mgr, err := k8s.BuildManager(&k8s.Config{
+	c, err := k8s.BuildCluster(&k8s.Config{
 		WatchedNamespaces: map[string]bool{
 			userData.Resources.Namespace: true,
 		},
@@ -52,7 +52,7 @@ func PrepareOperatorConfigurations(userData *model.TestDataProvider) manager.Man
 		FeatureFlags:                featureflags.NewFeatureFlags(os.Environ),
 	})
 	Expect(err).NotTo(HaveOccurred())
-	return mgr
+	return c
 }
 
 func CreateNamespaceAndSecrets(userData *model.TestDataProvider) {

--- a/test/helper/e2e/k8s/operator.go
+++ b/test/helper/e2e/k8s/operator.go
@@ -17,7 +17,7 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/cluster"
 
 	akov2 "github.com/mongodb/mongodb-atlas-kubernetes/v2/api/v1"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/collection"
@@ -30,7 +30,7 @@ var (
 	signalCancelledCtx     context.Context
 )
 
-func BuildManager(initCfg *Config) (manager.Manager, error) {
+func BuildCluster(initCfg *Config) (cluster.Cluster, error) {
 	akoScheme := runtime.NewScheme()
 	utilruntime.Must(scheme.AddToScheme(akoScheme))
 	utilruntime.Must(akov2.AddToScheme(akoScheme))
@@ -151,13 +151,13 @@ func RunManager(withConfigs ...ManagerConfig) (ManagerStart, error) {
 		withConfig(managerConfig)
 	}
 
-	mgr, err := BuildManager(managerConfig)
+	c, err := BuildCluster(managerConfig)
 	if err != nil {
 		return nil, err
 	}
 
 	return func(ctx context.Context) error {
-		err = mgr.Start(ctx)
+		err = c.Start(ctx)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This continues making `Cluster` a first class citizen in our code base and centralises controller registration in a central registry, similar to indexers.

Especially the registry is necessary for the dry-run functionality as all controllers will register in a dedicated dry-run manage object.

### All Submissions:

* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if there is one).
* [ ] Update docs/release-notes/release-notes-template.md if your changes should be included in the release notes for the next release.
