### PR TITLE
CLOUDP-280230: Fix network peering old tests settings

### DIFF
--- a/test/e2e/network_peering_test.go
+++ b/test/e2e/network_peering_test.go
@@ -74,11 +74,13 @@ var _ = Describe("NetworkPeering", Label("networkpeering"), func() {
 			).WithProject(data.DefaultProject()),
 			[]akov2.NetworkPeer{
 				{
-					ProviderName:        provider.ProviderAWS,
+					ProviderName: provider.ProviderAWS,
+					// Container config
+					ContainerRegion: config.AWSRegionUS,
+					AtlasCIDRBlock:  "10.8.0.0/22",
+					// Peering config
 					AccepterRegionName:  config.AWSRegionUS,
-					ContainerRegion:     config.AWSRegionUS,
 					RouteTableCIDRBlock: "10.0.0.0/24",
-					AtlasCIDRBlock:      "10.8.0.0/22",
 				},
 			},
 		),
@@ -92,11 +94,13 @@ var _ = Describe("NetworkPeering", Label("networkpeering"), func() {
 			).WithProject(data.DefaultProject()),
 			[]akov2.NetworkPeer{
 				{
-					ProviderName:        provider.ProviderAWS,
+					ProviderName: provider.ProviderAWS,
+					// Container config
+					ContainerRegion: config.AWSRegionUS,
+					AtlasCIDRBlock:  "10.8.0.0/22",
+					// Peering config
 					AccepterRegionName:  config.AWSRegionEU,
-					ContainerRegion:     config.AWSRegionUS,
 					RouteTableCIDRBlock: "10.0.0.0/24",
-					AtlasCIDRBlock:      "10.8.0.0/22",
 				},
 			},
 		),
@@ -110,17 +114,22 @@ var _ = Describe("NetworkPeering", Label("networkpeering"), func() {
 			).WithProject(data.DefaultProject()),
 			[]akov2.NetworkPeer{
 				{
-					ProviderName:        provider.ProviderAWS,
+					ProviderName: provider.ProviderAWS,
+					// Container config
+					ContainerRegion: config.AWSRegionUS,
+					AtlasCIDRBlock:  "10.8.0.0/22",
+					// Peering config
 					AccepterRegionName:  config.AWSRegionEU,
-					ContainerRegion:     config.AWSRegionUS,
 					RouteTableCIDRBlock: "192.168.0.0/16",
-					AtlasCIDRBlock:      "10.8.0.0/22",
 				},
 				{
-					ProviderName:        provider.ProviderAWS,
+					ProviderName: provider.ProviderAWS,
+					// Container config
+					// Missing ContainerRegion would match AccepterRegionName
+					AtlasCIDRBlock: "10.8.0.0/22",
+					// Peering config
 					AccepterRegionName:  config.AWSRegionUS,
 					RouteTableCIDRBlock: "10.0.0.0/24",
-					AtlasCIDRBlock:      "10.8.0.0/22",
 				},
 			},
 		),
@@ -134,12 +143,12 @@ var _ = Describe("NetworkPeering", Label("networkpeering"), func() {
 			).WithProject(data.DefaultProject()),
 			[]akov2.NetworkPeer{
 				{
-					ProviderName:        provider.ProviderGCP,
-					AccepterRegionName:  config.GCPRegion,
-					RouteTableCIDRBlock: "192.168.0.0/16",
-					AtlasCIDRBlock:      "10.8.0.0/18",
-					NetworkName:         newRandomName(GCPVPCName),
-					GCPProjectID:        cloud.GoogleProjectID,
+					ProviderName: provider.ProviderGCP,
+					// Container config (no region setting for GCP)
+					AtlasCIDRBlock: "10.8.0.0/18",
+					// Peering config
+					GCPProjectID: cloud.GoogleProjectID,
+					NetworkName:  newRandomName(GCPVPCName),
 				},
 			},
 		),
@@ -153,13 +162,15 @@ var _ = Describe("NetworkPeering", Label("networkpeering"), func() {
 			).WithProject(data.DefaultProject()),
 			[]akov2.NetworkPeer{
 				{
-					ProviderName:        provider.ProviderAzure,
-					AccepterRegionName:  "US_EAST_2",
-					AtlasCIDRBlock:      "192.168.248.0/21",
-					VNetName:            newRandomName(AzureVPCName),
+					ProviderName: provider.ProviderAzure,
+					// Container config
+					ContainerRegion: "US_EAST_2",
+					AtlasCIDRBlock:  "192.168.248.0/21",
+					// Peering config
 					AzureSubscriptionID: os.Getenv(SubscriptionID),
-					ResourceGroupName:   cloud.ResourceGroupName,
 					AzureDirectoryID:    os.Getenv(DirectoryID),
+					ResourceGroupName:   cloud.ResourceGroupName,
+					VNetName:            newRandomName(AzureVPCName),
 				},
 			},
 		),


### PR DESCRIPTION
Order and clean up the test fields to reflect proper usage of the CRD API:
- Remove `RouteTableCIDRBlock` from the GCP test, as it is not used by GCP.
- Remove `AccepterRegionName` from GCP test, as it is has no effect in GCP.
- Replace `AccepterRegionName` with `ContainerRegion` in the Azure test. Even though accepter region acts as a fallback value when container region is not set, it is more correct to use the actual container region field, specially since the accepter region name is an AWS only concept in the API.
- Order the setting fields in all tests to clarify which ones refer to the container configuration and which others affect the peering connection on the app/client side.

### All Submissions:

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
