### PR TITLE
CLOUDP-296898: use errors for termination

### DIFF
--- a/internal/controller/atlascustomrole/custom_role_test.go
+++ b/internal/controller/atlascustomrole/custom_role_test.go
@@ -2,6 +2,7 @@ package atlascustomrole
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"reflect"
@@ -177,7 +178,7 @@ func Test_roleController_Reconcile(t *testing.T) {
 					Status: status.AtlasCustomRoleStatus{},
 				},
 			},
-			want: workflow.Terminate(workflow.AtlasCustomRoleNotCreated, "unable to create role"),
+			want: workflow.Terminate(workflow.AtlasCustomRoleNotCreated, errors.New("unable to create role")),
 		},
 		{
 			name: "Create custom role with error on Getting roles",
@@ -225,7 +226,7 @@ func Test_roleController_Reconcile(t *testing.T) {
 					Status: status.AtlasCustomRoleStatus{},
 				},
 			},
-			want: workflow.Terminate(workflow.ProjectCustomRolesReady, "unable to Get roles"),
+			want: workflow.Terminate(workflow.ProjectCustomRolesReady, errors.New("unable to Get roles")),
 		},
 		{
 			name: "Update custom role successfully",
@@ -374,7 +375,7 @@ func Test_roleController_Reconcile(t *testing.T) {
 					Status: status.AtlasCustomRoleStatus{},
 				},
 			},
-			want: workflow.Terminate(workflow.AtlasCustomRoleNotUpdated, "unable to update custom role"),
+			want: workflow.Terminate(workflow.AtlasCustomRoleNotUpdated, errors.New("unable to update custom role")),
 		},
 		{
 			name: "Update custom role successfully no update",
@@ -693,7 +694,7 @@ func Test_roleController_Reconcile(t *testing.T) {
 					Status: status.AtlasCustomRoleStatus{},
 				},
 			},
-			want: workflow.Terminate(workflow.AtlasCustomRoleNotDeleted, "unable to delete custom role"),
+			want: workflow.Terminate(workflow.AtlasCustomRoleNotDeleted, errors.New("unable to delete custom role")),
 		},
 	}
 	for _, tt := range tests {
@@ -929,7 +930,7 @@ func Test_handleCustomRole(t *testing.T) {
 					},
 				},
 			},
-			want: workflow.Terminate(workflow.ProjectCustomRolesReady, "the referenced AtlasProject resource 'testProject' doesn't have ID (status.ID is empty)"),
+			want: workflow.Terminate(workflow.ProjectCustomRolesReady, errors.New("the referenced AtlasProject resource 'testProject' doesn't have ID (status.ID is empty)")),
 		},
 		{
 			name: "DO NOT create custom role if external project reference doesn't exist",

--- a/internal/controller/atlasdatabaseuser/atlasdatabaseuser_controller.go
+++ b/internal/controller/atlasdatabaseuser/atlasdatabaseuser_controller.go
@@ -106,14 +106,15 @@ func (r *AtlasDatabaseUserReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 // notFound terminates the reconciliation silently(no updates on conditions) and without retry
 func (r *AtlasDatabaseUserReconciler) notFound(req ctrl.Request) ctrl.Result {
-	r.Log.Infof("Object %s doesn't exist, was it deleted after reconcile request?", req.NamespacedName)
-	return workflow.TerminateSilently().WithoutRetry().ReconcileResult()
+	err := fmt.Errorf("object %s doesn't exist, was it deleted after reconcile request?", req.NamespacedName)
+	r.Log.Infof(err.Error())
+	return workflow.TerminateSilently(err).WithoutRetry().ReconcileResult()
 }
 
 // fail terminates the reconciliation silently(no updates on conditions)
 func (r *AtlasDatabaseUserReconciler) fail(req ctrl.Request, err error) ctrl.Result {
 	r.Log.Errorf("Failed to query object %s: %s", req.NamespacedName, err)
-	return workflow.TerminateSilently().ReconcileResult()
+	return workflow.TerminateSilently(err).ReconcileResult()
 }
 
 // skip prevents the reconciliation to start and successfully return
@@ -132,7 +133,7 @@ func (r *AtlasDatabaseUserReconciler) terminate(
 	err error,
 ) ctrl.Result {
 	r.Log.Errorf("resource %T(%s/%s) failed on condition %s: %s", object, object.GetNamespace(), object.GetName(), condition, err)
-	result := workflow.Terminate(reason, err.Error())
+	result := workflow.Terminate(reason, err)
 	ctx.SetConditionFromResult(condition, result)
 
 	if !retry {

--- a/internal/controller/atlasdatabaseuser/atlasdatabaseuser_controller_test.go
+++ b/internal/controller/atlasdatabaseuser/atlasdatabaseuser_controller_test.go
@@ -174,7 +174,7 @@ func TestNotFound(t *testing.T) {
 		assert.Equal(t, ctrl.Result{}, c.notFound(ctrl.Request{NamespacedName: types.NamespacedName{Name: "object", Namespace: "test"}}))
 		assert.Equal(t, 1, logs.Len())
 		assert.Equal(t, zapcore.Level(0), logs.All()[0].Level)
-		assert.Equal(t, "Object test/object doesn't exist, was it deleted after reconcile request?", logs.All()[0].Message)
+		assert.Equal(t, "object test/object doesn't exist, was it deleted after reconcile request?", logs.All()[0].Message)
 	})
 }
 
@@ -311,7 +311,7 @@ func TestReady(t *testing.T) {
 					return errors.New("failed to set finalizer")
 				},
 			},
-			expectedResult: workflow.Terminate(workflow.AtlasFinalizerNotSet, "").ReconcileResult(),
+			expectedResult: workflow.Terminate(workflow.AtlasFinalizerNotSet, errors.New("")).ReconcileResult(),
 			expectedConditions: []api.Condition{
 				api.FalseCondition(api.DatabaseUserReadyType).
 					WithReason(string(workflow.AtlasFinalizerNotSet)).
@@ -348,7 +348,7 @@ func TestReady(t *testing.T) {
 					return errors.New("failed to set last applied config")
 				},
 			},
-			expectedResult: workflow.Terminate(workflow.Internal, "").ReconcileResult(),
+			expectedResult: workflow.Terminate(workflow.Internal, errors.New("")).ReconcileResult(),
 			expectedConditions: []api.Condition{
 				api.FalseCondition(api.DatabaseUserReadyType).
 					WithReason(string(workflow.Internal)).

--- a/internal/controller/atlasdatafederation/connectionsecrets.go
+++ b/internal/controller/atlasdatafederation/connectionsecrets.go
@@ -19,12 +19,12 @@ func (r *AtlasDataFederationReconciler) ensureConnectionSecrets(ctx *workflow.Co
 	databaseUsers := akov2.AtlasDatabaseUserList{}
 	err := r.Client.List(ctx.Context, &databaseUsers, &client.ListOptions{})
 	if err != nil {
-		return workflow.Terminate(workflow.Internal, err.Error())
+		return workflow.Terminate(workflow.Internal, err)
 	}
 
 	atlasDF, err := federationService.Get(ctx.Context, project.ID(), df.Spec.Name)
 	if err != nil {
-		return workflow.Terminate(workflow.Internal, err.Error())
+		return workflow.Terminate(workflow.Internal, err)
 	}
 
 	connectionHosts := atlasDF.Hostnames
@@ -57,7 +57,7 @@ func (r *AtlasDataFederationReconciler) ensureConnectionSecrets(ctx *workflow.Co
 
 		password, err := dbUser.ReadPassword(ctx.Context, r.Client)
 		if err != nil {
-			return workflow.Terminate(workflow.DeploymentConnectionSecretsNotCreated, err.Error())
+			return workflow.Terminate(workflow.DeploymentConnectionSecretsNotCreated, err)
 		}
 
 		var connURLs []string
@@ -75,7 +75,7 @@ func (r *AtlasDataFederationReconciler) ensureConnectionSecrets(ctx *workflow.Co
 
 		secretName, err := connectionsecret.Ensure(ctx.Context, r.Client, dbUser.Namespace, project.Spec.Name, project.ID(), df.Spec.Name, data)
 		if err != nil {
-			return workflow.Terminate(workflow.DeploymentConnectionSecretsNotCreated, err.Error())
+			return workflow.Terminate(workflow.DeploymentConnectionSecretsNotCreated, err)
 		}
 		secrets = append(secrets, secretName)
 	}

--- a/internal/controller/atlasdatafederation/datafederation.go
+++ b/internal/controller/atlasdatafederation/datafederation.go
@@ -14,18 +14,18 @@ func (r *AtlasDataFederationReconciler) ensureDataFederation(ctx *workflow.Conte
 
 	akoDataFederation, err := datafederation.NewDataFederation(&dataFederation.Spec, projectID, nil)
 	if err != nil {
-		return workflow.Terminate(workflow.Internal, err.Error())
+		return workflow.Terminate(workflow.Internal, err)
 	}
 
 	atlasDataFederation, err := federationService.Get(ctx.Context, projectID, operatorSpec.Name)
 	if err != nil {
 		if !errors.Is(err, datafederation.ErrorNotFound) {
-			return workflow.Terminate(workflow.Internal, err.Error())
+			return workflow.Terminate(workflow.Internal, err)
 		}
 
 		err = federationService.Create(ctx.Context, akoDataFederation)
 		if err != nil {
-			return workflow.Terminate(workflow.DataFederationNotCreatedInAtlas, err.Error())
+			return workflow.Terminate(workflow.DataFederationNotCreatedInAtlas, err)
 		}
 
 		return workflow.InProgress(workflow.DataFederationCreating, "Data Federation is being created")
@@ -37,7 +37,7 @@ func (r *AtlasDataFederationReconciler) ensureDataFederation(ctx *workflow.Conte
 
 	err = federationService.Update(ctx.Context, akoDataFederation)
 	if err != nil {
-		return workflow.Terminate(workflow.DataFederationNotUpdatedInAtlas, err.Error())
+		return workflow.Terminate(workflow.DataFederationNotUpdatedInAtlas, err)
 	}
 
 	return workflow.InProgress(workflow.DataFederationUpdating, "Data Federation is being updated")

--- a/internal/controller/atlasdatafederation/datafederation_controller.go
+++ b/internal/controller/atlasdatafederation/datafederation_controller.go
@@ -65,7 +65,7 @@ func (r *AtlasDataFederationReconciler) Reconcile(context context.Context, req c
 		if !dataFederation.GetDeletionTimestamp().IsZero() {
 			err := customresource.ManageFinalizer(context, r.Client, dataFederation, customresource.UnsetFinalizer)
 			if err != nil {
-				result = workflow.Terminate(workflow.Internal, err.Error())
+				result = workflow.Terminate(workflow.Internal, err)
 				log.Errorw("failed to remove finalizer", "error", err)
 				return result.ReconcileResult(), nil
 			}
@@ -85,7 +85,7 @@ func (r *AtlasDataFederationReconciler) Reconcile(context context.Context, req c
 	}
 
 	if !r.AtlasProvider.IsResourceSupported(dataFederation) {
-		result := workflow.Terminate(workflow.AtlasGovUnsupported, "the AtlasDataFederation is not supported by Atlas for government").
+		result := workflow.Terminate(workflow.AtlasGovUnsupported, errors.New("the AtlasDataFederation is not supported by Atlas for government")).
 			WithoutRetry()
 		ctx.SetConditionFromResult(api.DataFederationReadyType, result)
 		return result.ReconcileResult(), nil
@@ -99,14 +99,14 @@ func (r *AtlasDataFederationReconciler) Reconcile(context context.Context, req c
 
 	endpointService, err := datafederation.NewDatafederationPrivateEndpointService(ctx.Context, r.AtlasProvider, project.ConnectionSecretObjectKey(), log)
 	if err != nil {
-		result = workflow.Terminate(workflow.AtlasAPIAccessNotConfigured, err.Error())
+		result = workflow.Terminate(workflow.AtlasAPIAccessNotConfigured, err)
 		ctx.SetConditionFromResult(api.DatabaseUserReadyType, result)
 		return result.ReconcileResult(), nil
 	}
 
 	dataFederationService, err := datafederation.NewAtlasDataFederationService(ctx.Context, r.AtlasProvider, project.ConnectionSecretObjectKey(), log)
 	if err != nil {
-		result = workflow.Terminate(workflow.AtlasAPIAccessNotConfigured, err.Error())
+		result = workflow.Terminate(workflow.AtlasAPIAccessNotConfigured, err)
 		ctx.SetConditionFromResult(api.DatabaseUserReadyType, result)
 		return result.ReconcileResult(), nil
 	}
@@ -129,12 +129,12 @@ func (r *AtlasDataFederationReconciler) Reconcile(context context.Context, req c
 		if !customresource.HaveFinalizer(dataFederation, customresource.FinalizerLabel) {
 			err = r.Client.Get(context, kube.ObjectKeyFromObject(dataFederation), dataFederation)
 			if err != nil {
-				result = workflow.Terminate(workflow.Internal, err.Error())
+				result = workflow.Terminate(workflow.Internal, err)
 				return result.ReconcileResult(), nil
 			}
 			customresource.SetFinalizer(dataFederation, customresource.FinalizerLabel)
 			if err = r.Client.Update(context, dataFederation); err != nil {
-				result = workflow.Terminate(workflow.Internal, err.Error())
+				result = workflow.Terminate(workflow.Internal, err)
 				log.Errorw("failed to add finalizer", "error", err)
 				return result.ReconcileResult(), nil
 			}
@@ -147,7 +147,7 @@ func (r *AtlasDataFederationReconciler) Reconcile(context context.Context, req c
 
 	err = customresource.ApplyLastConfigApplied(context, dataFederation, r.Client)
 	if err != nil {
-		result = workflow.Terminate(workflow.Internal, err.Error())
+		result = workflow.Terminate(workflow.Internal, err)
 		ctx.SetConditionFromResult(api.DataFederationReadyType, result)
 		log.Error(result.GetMessage())
 
@@ -166,19 +166,19 @@ func (r *AtlasDataFederationReconciler) handleDelete(ctx *workflow.Context, log 
 		} else {
 			if err := r.deleteConnectionSecrets(ctx.Context, dataFederation); err != nil {
 				log.Errorf("failed to remove DataFederation connection secrets from Atlas: %s", err)
-				result := workflow.Terminate(workflow.Internal, err.Error())
+				result := workflow.Terminate(workflow.Internal, err)
 				ctx.SetConditionFromResult(api.DataFederationReadyType, result)
 				return result
 			}
 			if err := r.deleteDataFederationFromAtlas(ctx.Context, service, dataFederation, project, log); err != nil {
 				log.Errorf("failed to remove DataFederation from Atlas: %s", err)
-				result := workflow.Terminate(workflow.Internal, err.Error())
+				result := workflow.Terminate(workflow.Internal, err)
 				ctx.SetConditionFromResult(api.DataFederationReadyType, result)
 				return result
 			}
 		}
 		if err := customresource.ManageFinalizer(ctx.Context, r.Client, dataFederation, customresource.UnsetFinalizer); err != nil {
-			result := workflow.Terminate(workflow.AtlasFinalizerNotRemoved, err.Error())
+			result := workflow.Terminate(workflow.AtlasFinalizerNotRemoved, err)
 			log.Errorw("failed to remove finalizer", "error", err)
 			return result
 		}
@@ -207,7 +207,7 @@ func (r *AtlasDataFederationReconciler) deleteDataFederationFromAtlas(ctx contex
 
 func (r *AtlasDataFederationReconciler) readProjectResource(ctx context.Context, dataFederation *akov2.AtlasDataFederation, project *akov2.AtlasProject) workflow.Result {
 	if err := r.Client.Get(ctx, dataFederation.AtlasProjectObjectKey(), project); err != nil {
-		return workflow.Terminate(workflow.Internal, err.Error())
+		return workflow.Terminate(workflow.Internal, err)
 	}
 	return workflow.OK()
 }

--- a/internal/controller/atlasdatafederation/private_endpoint.go
+++ b/internal/controller/atlasdatafederation/private_endpoint.go
@@ -37,7 +37,7 @@ func (r *AtlasDataFederationReconciler) ensurePrivateEndpoints(ctx *workflow.Con
 
 func (r *AtlasDataFederationReconciler) privateEndpointsFailed(ctx *workflow.Context, err error) workflow.Result {
 	ctx.Log.Errorw("getAllDataFederationPEs error", "err", err.Error())
-	result := workflow.Terminate(workflow.Internal, err.Error())
+	result := workflow.Terminate(workflow.Internal, err)
 	ctx.SetConditionFromResult(api.DataFederationPEReadyType, result)
 	return result
 }

--- a/internal/controller/atlasdeployment/customzonemapping.go
+++ b/internal/controller/atlasdeployment/customzonemapping.go
@@ -31,17 +31,17 @@ func (r *AtlasDeploymentReconciler) syncCustomZoneMapping(service *workflow.Cont
 	logger := service.Log
 	err := verifyZoneMapping(customZoneMappings)
 	if err != nil {
-		return workflow.Terminate(workflow.CustomZoneMappingReady, err.Error())
+		return workflow.Terminate(workflow.CustomZoneMappingReady, err)
 	}
 	existingZoneMapping, err := deploymentService.GetCustomZones(service.Context, groupID, deploymentName)
 	if err != nil {
-		return workflow.Terminate(workflow.CustomZoneMappingReady, fmt.Sprintf("Failed to get zone mapping state: %v", err))
+		return workflow.Terminate(workflow.CustomZoneMappingReady, fmt.Errorf("failed to get zone mapping state: %w", err))
 	}
 	logger.Debugf("Existing zone mapping: %v", existingZoneMapping)
 	var customZoneMappingStatus status.CustomZoneMapping
 	zoneMappingMap, err := deploymentService.GetZoneMapping(service.Context, groupID, deploymentName)
 	if err != nil {
-		return workflow.Terminate(workflow.CustomZoneMappingReady, fmt.Sprintf("Failed to get zone mapping map: %v", err))
+		return workflow.Terminate(workflow.CustomZoneMappingReady, fmt.Errorf("failed to get zone mapping map: %w", err))
 	}
 
 	if shouldAdd, shouldDelete := compareZoneMappingStates(existingZoneMapping, customZoneMappings, zoneMappingMap); shouldDelete || shouldAdd {
@@ -94,7 +94,7 @@ func verifyZoneMapping(desired []akov2.CustomZoneMapping) error {
 
 func checkCustomZoneMapping(customZoneMapping status.CustomZoneMapping) workflow.Result {
 	if customZoneMapping.ZoneMappingState != status.StatusReady {
-		return workflow.Terminate(workflow.CustomZoneMappingReady, fmt.Sprintf("Zone mapping is not ready: %v", customZoneMapping.ZoneMappingErrMessage))
+		return workflow.Terminate(workflow.CustomZoneMappingReady, fmt.Errorf("zone mapping is not ready: %v", customZoneMapping.ZoneMappingErrMessage))
 	}
 	return workflow.OK()
 }

--- a/internal/controller/atlasdeployment/search_nodes.go
+++ b/internal/controller/atlasdeployment/search_nodes.go
@@ -273,7 +273,7 @@ func (s *searchNodeController) progress(state workflow.ConditionReason, fineMsg,
 // terminate transitions to pending state if an error occurred.
 func (s *searchNodeController) terminate(reason workflow.ConditionReason, err error) workflow.Result {
 	s.ctx.Log.Error(err)
-	result := workflow.Terminate(reason, err.Error())
+	result := workflow.Terminate(reason, err)
 	s.ctx.SetConditionFromResult(api.SearchNodesReadyType, result)
 	return result
 }

--- a/internal/controller/atlasdeployment/searchindex.go
+++ b/internal/controller/atlasdeployment/searchindex.go
@@ -129,7 +129,7 @@ func (sr *searchIndexReconcileRequest) terminate(index *searchindex.SearchIndex,
 		status.WithMsg(msg.Error()),
 		status.WithName(index.Name),
 	)))
-	terminate := workflow.Terminate(status.SearchIndexStatusError, msg.Error())
+	terminate := workflow.Terminate(status.SearchIndexStatusError, msg)
 	sr.ctx.SetConditionFromResult(api.SearchIndexesReadyType, terminate)
 	return terminate
 }

--- a/internal/controller/atlasdeployment/searchindexes.go
+++ b/internal/controller/atlasdeployment/searchindexes.go
@@ -134,11 +134,7 @@ func (sr *searchIndexesReconcileRequest) Handle() workflow.Result {
 
 func (sr *searchIndexesReconcileRequest) terminate(reason workflow.ConditionReason, err error) workflow.Result {
 	sr.ctx.Log.Error(err)
-	var errMsg string
-	if err != nil {
-		errMsg = err.Error()
-	}
-	result := workflow.Terminate(reason, errMsg)
+	result := workflow.Terminate(reason, err)
 	sr.ctx.SetConditionFromResult(api.SearchIndexesReadyType, result)
 	return result
 }

--- a/internal/controller/atlasdeployment/serverless_private_endpoint.go
+++ b/internal/controller/atlasdeployment/serverless_private_endpoint.go
@@ -1,6 +1,7 @@
 package atlasdeployment
 
 import (
+	"errors"
 	"fmt"
 
 	"go.mongodb.org/atlas-sdk/v20231115008/admin"
@@ -23,13 +24,13 @@ const (
 
 func ensureServerlessPrivateEndpoints(service *workflow.Context, projectID string, deployment *akov2.AtlasDeployment) workflow.Result {
 	if deployment == nil || deployment.Spec.ServerlessSpec == nil {
-		return workflow.Terminate(workflow.Internal, "serverless deployment spec is empty")
+		return workflow.Terminate(workflow.Internal, errors.New("serverless deployment spec is empty"))
 	}
 
 	deploymentSpec := deployment.Spec.ServerlessSpec
 
 	if isGCPWithPrivateEndpoints(deploymentSpec) {
-		return workflow.Terminate(workflow.AtlasUnsupportedFeature, "serverless private endpoints are not supported for GCP")
+		return workflow.Terminate(workflow.AtlasUnsupportedFeature, errors.New("serverless private endpoints are not supported for GCP"))
 	}
 
 	if isGCPWithoutPrivateEndpoints(deploymentSpec) {
@@ -40,7 +41,7 @@ func ensureServerlessPrivateEndpoints(service *workflow.Context, projectID strin
 	var result workflow.Result
 	switch {
 	case err != nil:
-		result = workflow.Terminate(workflow.ServerlessPrivateEndpointFailed, err.Error())
+		result = workflow.Terminate(workflow.ServerlessPrivateEndpointFailed, err)
 	case err == nil && !finished:
 		result = workflow.InProgress(workflow.ServerlessPrivateEndpointInProgress, "Waiting serverless private endpoint to be configured")
 	default:

--- a/internal/controller/atlasdeployment/serverless_private_endpoint_test.go
+++ b/internal/controller/atlasdeployment/serverless_private_endpoint_test.go
@@ -27,7 +27,7 @@ func TestEnsureServerlessPrivateEndpoints(t *testing.T) {
 
 		assert.Equal(
 			t,
-			workflow.Terminate(workflow.Internal, "serverless deployment spec is empty"),
+			workflow.Terminate(workflow.Internal, errors.New("serverless deployment spec is empty")),
 			result,
 		)
 	})
@@ -37,7 +37,7 @@ func TestEnsureServerlessPrivateEndpoints(t *testing.T) {
 
 		assert.Equal(
 			t,
-			workflow.Terminate(workflow.Internal, "serverless deployment spec is empty"),
+			workflow.Terminate(workflow.Internal, errors.New("serverless deployment spec is empty")),
 			result,
 		)
 	})
@@ -63,7 +63,7 @@ func TestEnsureServerlessPrivateEndpoints(t *testing.T) {
 
 		assert.Equal(
 			t,
-			workflow.Terminate(workflow.AtlasUnsupportedFeature, "serverless private endpoints are not supported for GCP"),
+			workflow.Terminate(workflow.AtlasUnsupportedFeature, errors.New("serverless private endpoints are not supported for GCP")),
 			result,
 		)
 	})
@@ -147,7 +147,7 @@ func TestEnsureServerlessPrivateEndpoints(t *testing.T) {
 
 		assert.Equal(
 			t,
-			workflow.Terminate(workflow.ServerlessPrivateEndpointFailed, "unable to retrieve list of serverless private endpoints from Atlas: connection failed"),
+			workflow.Terminate(workflow.ServerlessPrivateEndpointFailed, errors.New("unable to retrieve list of serverless private endpoints from Atlas: connection failed")),
 			result,
 		)
 	})

--- a/internal/controller/atlasproject/auditing.go
+++ b/internal/controller/atlasproject/auditing.go
@@ -6,7 +6,6 @@ import (
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/api"
 	akov2 "github.com/mongodb/mongodb-atlas-kubernetes/v2/api/v1"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/controller/workflow"
-
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/translation/audit"
 )
 
@@ -62,7 +61,7 @@ func (a *auditController) ready() workflow.Result {
 // terminate ends a state transition if an error occurred.
 func (a *auditController) terminate(reason workflow.ConditionReason, err error) workflow.Result {
 	a.ctx.Log.Error(err)
-	result := workflow.Terminate(reason, err.Error())
+	result := workflow.Terminate(reason, err)
 	a.ctx.SetConditionFromResult(api.AuditingReadyType, result)
 
 	return result

--- a/internal/controller/atlasproject/auditing_test.go
+++ b/internal/controller/atlasproject/auditing_test.go
@@ -50,7 +50,7 @@ func TestAuditController_reconcile(t *testing.T) {
 					return nil, errors.New("failed to get audit log config")
 				},
 			},
-			expectedResult: workflow.Terminate(workflow.Internal, "failed to get audit log config"),
+			expectedResult: workflow.Terminate(workflow.Internal, errors.New("failed to get audit log config")),
 			expectedConditions: []api.Condition{
 				api.FalseCondition(api.AuditingReadyType).
 					WithReason(string(workflow.Internal)).
@@ -71,7 +71,7 @@ func TestAuditController_reconcile(t *testing.T) {
 			audit: &akov2.Auditing{
 				Enabled: true,
 			},
-			expectedResult: workflow.Terminate(workflow.ProjectAuditingReady, "failed to set audit log config"),
+			expectedResult: workflow.Terminate(workflow.ProjectAuditingReady, errors.New("failed to set audit log config")),
 			expectedConditions: []api.Condition{
 				api.FalseCondition(api.AuditingReadyType).
 					WithReason(string(workflow.ProjectAuditingReady)).
@@ -244,7 +244,7 @@ func TestHandleAudit(t *testing.T) {
 
 				return api
 			},
-			expectedResult: workflow.Terminate(workflow.ProjectAuditingReady, "failed to configure audit log"),
+			expectedResult: workflow.Terminate(workflow.ProjectAuditingReady, errors.New("failed to configure audit log")),
 			expectedConditions: []api.Condition{
 				api.FalseCondition(api.AuditingReadyType).
 					WithReason(string(workflow.ProjectAuditingReady)).

--- a/internal/controller/atlasproject/backupcompliancepolicy.go
+++ b/internal/controller/atlasproject/backupcompliancepolicy.go
@@ -194,7 +194,7 @@ func (b *backupComplianceController) progress(state workflow.ConditionReason, fi
 // terminate transitions to pending state if an error occurred.
 func (b *backupComplianceController) terminate(reason workflow.ConditionReason, err error) workflow.Result {
 	b.ctx.Log.Error(err)
-	result := workflow.Terminate(reason, err.Error())
+	result := workflow.Terminate(reason, err)
 	b.ctx.SetConditionFromResult(api.BackupComplianceReadyType, result)
 	return result
 }

--- a/internal/controller/atlasproject/cloud_provider_integration.go
+++ b/internal/controller/atlasproject/cloud_provider_integration.go
@@ -25,7 +25,7 @@ func ensureCloudProviderIntegration(workflowCtx *workflow.Context, project *akov
 
 	allAuthorized, err := syncCloudProviderIntegration(workflowCtx, project.ID(), roleSpecs)
 	if err != nil {
-		result := workflow.Terminate(workflow.ProjectCloudIntegrationsIsNotReadyInAtlas, err.Error())
+		result := workflow.Terminate(workflow.ProjectCloudIntegrationsIsNotReadyInAtlas, err)
 		workflowCtx.SetConditionFromResult(api.CloudProviderIntegrationReadyType, result)
 
 		return result

--- a/internal/controller/atlasproject/custom_roles.go
+++ b/internal/controller/atlasproject/custom_roles.go
@@ -78,7 +78,7 @@ func convertToInternalRoles(roles []akov2.CustomRole) []customroles.CustomRole {
 func ensureCustomRoles(workflowCtx *workflow.Context, project *akov2.AtlasProject) workflow.Result {
 	skipped, err := hasSkippedCustomRoles(project)
 	if err != nil {
-		return workflow.Terminate(workflow.Internal, err.Error())
+		return workflow.Terminate(workflow.Internal, err)
 	}
 
 	if skipped {
@@ -89,7 +89,7 @@ func ensureCustomRoles(workflowCtx *workflow.Context, project *akov2.AtlasProjec
 
 	lastAppliedCustomRoles, err := getLastAppliedCustomRoles(project)
 	if err != nil {
-		return workflow.Terminate(workflow.Internal, err.Error())
+		return workflow.Terminate(workflow.Internal, err)
 	}
 
 	r := roleController{
@@ -100,7 +100,7 @@ func ensureCustomRoles(workflowCtx *workflow.Context, project *akov2.AtlasProjec
 
 	currentAtlasCustomRoles, err := r.service.List(r.ctx.Context, r.project.ID())
 	if err != nil {
-		return workflow.Terminate(workflow.ProjectCustomRolesReady, err.Error())
+		return workflow.Terminate(workflow.ProjectCustomRolesReady, err)
 	}
 
 	akoRoles := make([]customroles.CustomRole, len(project.Spec.CustomRoles))
@@ -301,7 +301,7 @@ func syncCustomRolesStatus(ctx *workflow.Context, desiredCustomRoles []customrol
 	ctx.EnsureStatusOption(status.AtlasProjectSetCustomRolesOption(&statuses))
 
 	if err != nil {
-		return workflow.Terminate(workflow.ProjectCustomRolesReady, fmt.Sprintf("failed to apply changes to custom roles: %s", err.Error()))
+		return workflow.Terminate(workflow.ProjectCustomRolesReady, fmt.Errorf("failed to apply changes to custom roles: %w", err))
 	}
 
 	return workflow.OK()

--- a/internal/controller/atlasproject/encryption_at_rest.go
+++ b/internal/controller/atlasproject/encryption_at_rest.go
@@ -25,7 +25,7 @@ func (r *AtlasProjectReconciler) ensureEncryptionAtRest(workflowCtx *workflow.Co
 
 	if err := readEncryptionAtRestSecrets(r.Client, workflowCtx, encRest, project.Namespace); err != nil {
 		workflowCtx.UnsetCondition(api.EncryptionAtRestReadyType)
-		return workflow.Terminate(workflow.ProjectEncryptionAtRestReady, err.Error())
+		return workflow.Terminate(workflow.ProjectEncryptionAtRestReady, err)
 	}
 
 	result := createOrDeleteEncryptionAtRests(workflowCtx, encryptionAtRestService, project.ID(), encRest)
@@ -142,7 +142,7 @@ func readSecretData(ctx context.Context, kubeClient client.Client, res common.Re
 func createOrDeleteEncryptionAtRests(ctx *workflow.Context, service encryptionatrest.EncryptionAtRestService, projectID string, encRest *encryptionatrest.EncryptionAtRest) workflow.Result {
 	encryptionAtRestsInAtlas, err := service.Get(ctx.Context, projectID)
 	if err != nil {
-		return workflow.Terminate(workflow.Internal, err.Error())
+		return workflow.Terminate(workflow.Internal, err)
 	}
 
 	inSync := encryptionatrest.EqualSpecs(encRest, encryptionAtRestsInAtlas)
@@ -153,10 +153,10 @@ func createOrDeleteEncryptionAtRests(ctx *workflow.Context, service encryptionat
 
 	if encRest != nil {
 		if err := normalizeAwsKms(ctx, projectID, &encRest.AWS); err != nil {
-			return workflow.Terminate(workflow.Internal, err.Error())
+			return workflow.Terminate(workflow.Internal, err)
 		}
 		if err := service.Update(ctx.Context, projectID, *encRest); err != nil {
-			return workflow.Terminate(workflow.Internal, err.Error())
+			return workflow.Terminate(workflow.Internal, err)
 		}
 	}
 

--- a/internal/controller/atlasproject/integrations.go
+++ b/internal/controller/atlasproject/integrations.go
@@ -1,6 +1,7 @@
 package atlasproject
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -34,14 +35,14 @@ func (r *AtlasProjectReconciler) ensureIntegration(workflowCtx *workflow.Context
 func (r *AtlasProjectReconciler) createOrDeleteIntegrations(ctx *workflow.Context, projectID string, project *akov2.AtlasProject) workflow.Result {
 	integrationsInAtlas, err := fetchIntegrations(ctx, projectID)
 	if err != nil {
-		return workflow.Terminate(workflow.ProjectIntegrationInternal, err.Error())
+		return workflow.Terminate(workflow.ProjectIntegrationInternal, err)
 	}
 	integrationsInAtlasAlias := toAliasThirdPartyIntegration(integrationsInAtlas.Results)
 
 	identifiersForDelete := set.DeprecatedDifference(integrationsInAtlasAlias, project.Spec.Integrations)
 	ctx.Log.Debugf("identifiersForDelete: %v", identifiersForDelete)
 	if err := deleteIntegrationsFromAtlas(ctx, projectID, identifiersForDelete); err != nil {
-		return workflow.Terminate(workflow.ProjectIntegrationInternal, err.Error())
+		return workflow.Terminate(workflow.ProjectIntegrationInternal, err)
 	}
 
 	integrationsToUpdate := set.DeprecatedIntersection(integrationsInAtlasAlias, project.Spec.Integrations)
@@ -78,13 +79,13 @@ func (r *AtlasProjectReconciler) updateIntegrationsAtlas(ctx *workflow.Context, 
 		kubeIntegration, err := item[1].(project.Integration).ToAtlas(ctx.Context, r.Client, namespace)
 		if kubeIntegration == nil {
 			ctx.Log.Warnw("Update Integrations", "Can not convert kube integration", err)
-			return workflow.Terminate(workflow.ProjectIntegrationInternal, "Update Integrations: Can not convert kube integration")
+			return workflow.Terminate(workflow.ProjectIntegrationInternal, errors.New("update Integrations: Can not convert kube integration"))
 		}
 		// As integration secrets are redacted from Atlas, we cannot properly compare them,
 		// so as a simple fix we assume changes are always needed at evaluation time
 		ctx.Log.Debugf("Try to update integration: %s", kubeIntegration.Type)
 		if _, _, err := ctx.Client.Integrations.Replace(ctx.Context, projectID, kubeIntegration.Type, kubeIntegration); err != nil {
-			return workflow.Terminate(workflow.ProjectIntegrationRequest, fmt.Sprintf("Can not apply integration: %v", err))
+			return workflow.Terminate(workflow.ProjectIntegrationRequest, fmt.Errorf("cannot apply integration: %w", err))
 		}
 	}
 	return workflow.OK()
@@ -104,7 +105,7 @@ func (r *AtlasProjectReconciler) createIntegrationsInAtlas(ctx *workflow.Context
 	for _, item := range integrations {
 		integration, err := item.(project.Integration).ToAtlas(ctx.Context, r.Client, namespace)
 		if err != nil || integration == nil {
-			return workflow.Terminate(workflow.ProjectIntegrationInternal, fmt.Sprintf("cannot convert integration: %s", err.Error()))
+			return workflow.Terminate(workflow.ProjectIntegrationInternal, fmt.Errorf("cannot convert integration: %w", err))
 		}
 
 		_, resp, err := ctx.Client.Integrations.Create(ctx.Context, projectID, integration.Type, integration)
@@ -112,7 +113,7 @@ func (r *AtlasProjectReconciler) createIntegrationsInAtlas(ctx *workflow.Context
 			ctx.Log.Debugw("Create request failed", "Status", resp.Status, "Integration", integration)
 		}
 		if err != nil {
-			return workflow.Terminate(workflow.ProjectIntegrationRequest, err.Error())
+			return workflow.Terminate(workflow.ProjectIntegrationRequest, err)
 		}
 	}
 	return workflow.OK()

--- a/internal/controller/atlasproject/integrations_test.go
+++ b/internal/controller/atlasproject/integrations_test.go
@@ -141,7 +141,7 @@ func TestUpdateIntegrationsAtlas(t *testing.T) {
 					},
 				},
 			},
-			expectedResult: workflow.Terminate(workflow.ProjectIntegrationRequest, fmt.Sprintf("Can not apply integration: %v", errTest)),
+			expectedResult: workflow.Terminate(workflow.ProjectIntegrationRequest, fmt.Errorf("cannot apply integration: %w", errTest)),
 			expectedCalls:  1,
 		},
 	} {

--- a/internal/controller/atlasproject/ipaccess_list.go
+++ b/internal/controller/atlasproject/ipaccess_list.go
@@ -105,7 +105,7 @@ func (i *ipAccessListController) ready(ipAccessEntries ipaccesslist.IPAccessEntr
 // terminate ends a state transition if an error occurred.
 func (i *ipAccessListController) terminate(reason workflow.ConditionReason, err error) workflow.Result {
 	i.ctx.Log.Error(err)
-	result := workflow.Terminate(reason, err.Error())
+	result := workflow.Terminate(reason, err)
 	i.ctx.SetConditionFromResult(api.IPAccessListReadyType, result)
 
 	return result

--- a/internal/controller/atlasproject/ipaccess_list_test.go
+++ b/internal/controller/atlasproject/ipaccess_list_test.go
@@ -43,7 +43,7 @@ func TestIpAccessListController_reconcile(t *testing.T) {
 					IPAddress: "wrong-ip",
 				},
 			},
-			expectedResult: workflow.Terminate(workflow.Internal, "ip wrong-ip is invalid"),
+			expectedResult: workflow.Terminate(workflow.Internal, errors.New("ip wrong-ip is invalid")),
 			expectedConditions: []api.Condition{
 				api.FalseCondition(api.IPAccessListReadyType).
 					WithReason(string(workflow.Internal)).
@@ -68,7 +68,7 @@ func TestIpAccessListController_reconcile(t *testing.T) {
 
 				return serviceMock
 			},
-			expectedResult: workflow.Terminate(workflow.Internal, "failed to list"),
+			expectedResult: workflow.Terminate(workflow.Internal, errors.New("failed to list")),
 			expectedConditions: []api.Condition{
 				api.FalseCondition(api.IPAccessListReadyType).
 					WithReason(string(workflow.Internal)).
@@ -89,7 +89,7 @@ func TestIpAccessListController_reconcile(t *testing.T) {
 					IPAddress: "192.168.100.200",
 				},
 			},
-			expectedResult: workflow.Terminate(workflow.ProjectIPNotCreatedInAtlas, "failed to add ip access list"),
+			expectedResult: workflow.Terminate(workflow.ProjectIPNotCreatedInAtlas, errors.New("failed to add ip access list")),
 			expectedConditions: []api.Condition{
 				api.FalseCondition(api.IPAccessListReadyType).
 					WithReason(string(workflow.ProjectIPNotCreatedInAtlas)).
@@ -115,7 +115,7 @@ func TestIpAccessListController_reconcile(t *testing.T) {
 				return serviceMock
 			},
 			ipAccessList:   nil,
-			expectedResult: workflow.Terminate(workflow.ProjectIPNotCreatedInAtlas, "failed to delete"),
+			expectedResult: workflow.Terminate(workflow.ProjectIPNotCreatedInAtlas, errors.New("failed to delete")),
 			expectedConditions: []api.Condition{
 				api.FalseCondition(api.IPAccessListReadyType).
 					WithReason(string(workflow.ProjectIPNotCreatedInAtlas)).
@@ -162,7 +162,7 @@ func TestIpAccessListController_reconcile(t *testing.T) {
 			},
 			expectedResult: workflow.Terminate(
 				workflow.Internal,
-				"failed to get status"),
+				errors.New("failed to get status")),
 			expectedConditions: []api.Condition{
 				api.FalseCondition(api.IPAccessListReadyType).
 					WithReason(string(workflow.Internal)).
@@ -214,7 +214,7 @@ func TestIpAccessListController_reconcile(t *testing.T) {
 			},
 			expectedResult: workflow.Terminate(
 				workflow.ProjectIPNotCreatedInAtlas,
-				"atlas didn't succeed in adding this access entry"),
+				errors.New("atlas didn't succeed in adding this access entry")),
 			expectedConditions: []api.Condition{
 				api.FalseCondition(api.IPAccessListReadyType).
 					WithReason(string(workflow.ProjectIPNotCreatedInAtlas)).
@@ -348,7 +348,7 @@ func TestHandleIPAccessList(t *testing.T) {
 					IPAddress: "192.168.100.150",
 				},
 			},
-			expectedResult: workflow.Terminate(workflow.Internal, "failed to get ip access list from Atlas: failed to list"),
+			expectedResult: workflow.Terminate(workflow.Internal, errors.New("failed to get ip access list from Atlas: failed to list")),
 			expectedConditions: []api.Condition{
 				api.FalseCondition(api.IPAccessListReadyType).
 					WithReason(string(workflow.Internal)).

--- a/internal/controller/atlasproject/network_peering.go
+++ b/internal/controller/atlasproject/network_peering.go
@@ -2,6 +2,7 @@ package atlasproject
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -75,7 +76,7 @@ func SyncNetworkPeer(workflowCtx *workflow.Context, groupID string, peerStatuses
 	list, err := GetAllExistedNetworkPeer(workflowCtx.Context, mongoClient.NetworkPeeringApi, groupID)
 	if err != nil {
 		logger.Errorf("failed to get all network peers: %v", err)
-		return workflow.Terminate(workflow.ProjectNetworkPeerIsNotReadyInAtlas, "failed to get all network peers"),
+		return workflow.Terminate(workflow.ProjectNetworkPeerIsNotReadyInAtlas, errors.New("failed to get all network peers")),
 			api.NetworkPeerReadyType
 	}
 
@@ -87,7 +88,7 @@ func SyncNetworkPeer(workflowCtx *workflow.Context, groupID string, peerStatuses
 		errDelete := deletePeerByID(workflowCtx.Context, mongoClient.NetworkPeeringApi, groupID, peerToDelete, logger)
 		if errDelete != nil {
 			logger.Errorf("failed to delete network peer %s: %v", peerToDelete, errDelete)
-			return workflow.Terminate(workflow.ProjectNetworkPeerIsNotReadyInAtlas, "failed to delete network peer"),
+			return workflow.Terminate(workflow.ProjectNetworkPeerIsNotReadyInAtlas, errors.New("failed to delete network peer")),
 				api.NetworkPeerReadyType
 		}
 	}
@@ -97,13 +98,13 @@ func SyncNetworkPeer(workflowCtx *workflow.Context, groupID string, peerStatuses
 	if err != nil {
 		logger.Errorf("failed to update network peer statuses: %v", err)
 		return workflow.Terminate(workflow.ProjectNetworkPeerIsNotReadyInAtlas,
-			"failed to update network peer statuses"), api.NetworkPeerReadyType
+			errors.New("failed to update network peer statuses")), api.NetworkPeerReadyType
 	}
 	err = deleteUnusedContainers(workflowCtx.Context, mongoClient.NetworkPeeringApi, groupID, getPeerIDs(peerStatuses))
 	if err != nil {
 		logger.Errorf("failed to delete unused containers: %v", err)
 		return workflow.Terminate(workflow.ProjectNetworkPeerIsNotReadyInAtlas,
-			fmt.Sprintf("failed to delete unused containers: %s", err)), api.NetworkPeerReadyType
+			fmt.Errorf("failed to delete unused containers: %w", err)), api.NetworkPeerReadyType
 	}
 	return ensurePeerStatus(peerStatuses, len(peerSpecs), logger), api.NetworkPeerReadyType
 }
@@ -183,7 +184,7 @@ func formVPC(peer admin.BaseNetworkPeeringConnectionSettings) string {
 
 func ensurePeerStatus(peerStatuses []status.AtlasNetworkPeer, lenOfSpec int, logger *zap.SugaredLogger) workflow.Result {
 	if len(peerStatuses) != lenOfSpec {
-		return workflow.Terminate(workflow.ProjectNetworkPeerIsNotReadyInAtlas, "not all network peers are ready")
+		return workflow.Terminate(workflow.ProjectNetworkPeerIsNotReadyInAtlas, errors.New("not all network peers are ready"))
 	}
 
 	for _, peerStatus := range peerStatuses {
@@ -191,21 +192,21 @@ func ensurePeerStatus(peerStatuses []status.AtlasNetworkPeer, lenOfSpec int, log
 		case provider.ProviderGCP:
 			if peerStatus.Status != StatusReady {
 				logger.Debugf("network peer %s is not ready .%s.", peerStatus.VPC, peerStatus.Status)
-				return workflow.Terminate(workflow.ProjectNetworkPeerIsNotReadyInAtlas, "not all network peers are ready")
+				return workflow.Terminate(workflow.ProjectNetworkPeerIsNotReadyInAtlas, errors.New("not all network peers are ready"))
 			}
 			if peerStatus.AtlasNetworkName == "" || peerStatus.AtlasGCPProjectID == "" { // We need this information to create the network peer connection
 				logger.Debugf("network peer %s is not ready .%s.", peerStatus.VPC, peerStatus.Status)
-				return workflow.Terminate(workflow.ProjectNetworkPeerIsNotReadyInAtlas, "not all network peers are ready")
+				return workflow.Terminate(workflow.ProjectNetworkPeerIsNotReadyInAtlas, errors.New("not all network peers are ready"))
 			}
 		case provider.ProviderAzure:
 			if peerStatus.Status != StatusReady {
 				logger.Debugf("network peer %s is not ready .%s.", peerStatus.VPC, peerStatus.Status)
-				return workflow.Terminate(workflow.ProjectNetworkPeerIsNotReadyInAtlas, "not all network peers are ready")
+				return workflow.Terminate(workflow.ProjectNetworkPeerIsNotReadyInAtlas, errors.New("not all network peers are ready"))
 			}
 		default:
 			if peerStatus.StatusName != StatusReady {
 				logger.Debugf("network peer %s is not ready .%s.", peerStatus.VPC, peerStatus.StatusName)
-				return workflow.Terminate(workflow.ProjectNetworkPeerIsNotReadyInAtlas, "not all network peers are ready")
+				return workflow.Terminate(workflow.ProjectNetworkPeerIsNotReadyInAtlas, errors.New("not all network peers are ready"))
 			}
 		}
 	}
@@ -551,7 +552,7 @@ func DeleteAllNetworkPeers(ctx context.Context, groupID string, service admin.Ne
 	result := workflow.OK()
 	err := deleteAllNetworkPeers(ctx, groupID, service, logger)
 	if err != nil {
-		result = workflow.Terminate(workflow.ProjectNetworkPeerIsNotReadyInAtlas, "failed to delete NetworkPeers")
+		result = workflow.Terminate(workflow.ProjectNetworkPeerIsNotReadyInAtlas, errors.New("failed to delete NetworkPeers"))
 	}
 	return result
 }

--- a/internal/controller/atlasproject/project.go
+++ b/internal/controller/atlasproject/project.go
@@ -79,7 +79,7 @@ func (r *AtlasProjectReconciler) create(ctx *workflow.Context, orgID string, atl
 
 func (r *AtlasProjectReconciler) terminate(ctx *workflow.Context, errorCondition workflow.ConditionReason, err error) (ctrl.Result, error) {
 	r.Log.Error(err)
-	terminated := workflow.Terminate(errorCondition, err.Error())
+	terminated := workflow.Terminate(errorCondition, err)
 	ctx.SetConditionFromResult(api.ProjectReadyType, terminated)
 
 	return terminated.ReconcileResult(), nil

--- a/internal/controller/atlasproject/project_settings.go
+++ b/internal/controller/atlasproject/project_settings.go
@@ -28,12 +28,12 @@ func syncProjectSettings(ctx *workflow.Context, projectID string, project *akov2
 
 	atlas, err := fetchSettings(ctx, projectID)
 	if err != nil {
-		return workflow.Terminate(workflow.ProjectSettingsReady, err.Error())
+		return workflow.Terminate(workflow.ProjectSettingsReady, err)
 	}
 
 	if !areSettingsInSync(atlas, spec) {
 		if err := patchSettings(ctx, projectID, spec); err != nil {
-			return workflow.Terminate(workflow.ProjectSettingsReady, err.Error())
+			return workflow.Terminate(workflow.ProjectSettingsReady, err)
 		}
 	}
 

--- a/internal/controller/atlasproject/teams.go
+++ b/internal/controller/atlasproject/teams.go
@@ -52,7 +52,7 @@ func (r *AtlasProjectReconciler) ensureAssignedTeams(workflowCtx *workflow.Conte
 	err := r.syncAssignedTeams(workflowCtx, teamsService, project.ID(), project, teamsToAssign)
 	if err != nil {
 		workflowCtx.SetConditionFalse(api.ProjectTeamsReadyType)
-		return workflow.Terminate(workflow.ProjectTeamUnavailable, err.Error())
+		return workflow.Terminate(workflow.ProjectTeamUnavailable, err)
 	}
 
 	workflowCtx.SetConditionTrue(api.ProjectTeamsReadyType)

--- a/internal/controller/connectionsecret/connectionsecrets.go
+++ b/internal/controller/connectionsecret/connectionsecrets.go
@@ -54,7 +54,7 @@ func ReapOrphanConnectionSecrets(ctx context.Context, k8sClient client.Client, p
 func CreateOrUpdateConnectionSecrets(ctx *workflow.Context, k8sClient client.Client, ds deployment.AtlasDeploymentsService, recorder record.EventRecorder, project *project.Project, dbUser akov2.AtlasDatabaseUser) workflow.Result {
 	conns, err := ds.ListDeploymentConnections(ctx.Context, project.ID)
 	if err != nil {
-		return workflow.Terminate(workflow.DatabaseUserConnectionSecretsNotCreated, err.Error())
+		return workflow.Terminate(workflow.DatabaseUserConnectionSecretsNotCreated, err)
 	}
 
 	// ensure secrets for both deployments and advanced deployment.
@@ -83,7 +83,7 @@ func createOrUpdateConnectionSecretsFromDeploymentSecrets(ctx *workflow.Context,
 		}
 		password, err := dbUser.ReadPassword(ctx.Context, k8sClient)
 		if err != nil {
-			return workflow.Terminate(workflow.DatabaseUserConnectionSecretsNotCreated, err.Error())
+			return workflow.Terminate(workflow.DatabaseUserConnectionSecretsNotCreated, err)
 		}
 		data := ConnectionData{
 			DBUserName: dbUser.Spec.Username,
@@ -95,7 +95,7 @@ func createOrUpdateConnectionSecretsFromDeploymentSecrets(ctx *workflow.Context,
 
 		var secretName string
 		if secretName, err = Ensure(ctx.Context, k8sClient, dbUser.Namespace, project.Name, project.ID, di.Name, data); err != nil {
-			return workflow.Terminate(workflow.DatabaseUserConnectionSecretsNotCreated, err.Error())
+			return workflow.Terminate(workflow.DatabaseUserConnectionSecretsNotCreated, err)
 		}
 		secrets = append(secrets, secretName)
 		ctx.Log.Debugw("Ensured connection Secret up-to-date", "secretname", secretName)
@@ -106,7 +106,7 @@ func createOrUpdateConnectionSecretsFromDeploymentSecrets(ctx *workflow.Context,
 	}
 
 	if err := cleanupStaleSecrets(ctx, k8sClient, project.ID, dbUser); err != nil {
-		return workflow.Terminate(workflow.DatabaseUserStaleConnectionSecrets, err.Error())
+		return workflow.Terminate(workflow.DatabaseUserStaleConnectionSecrets, err)
 	}
 
 	if requeue {

--- a/internal/controller/workflow/result.go
+++ b/internal/controller/workflow/result.go
@@ -40,12 +40,12 @@ func Requeue(period time.Duration) Result {
 // This is not an expected termination of the reconciliation process so 'warning' flag is set to 'true'.
 // 'reason' and 'message' indicate the error state and are supposed to be reflected in the `conditions` for the
 // reconciled Custom Resource.
-func Terminate(reason ConditionReason, message string) Result {
+func Terminate(reason ConditionReason, err error) Result {
 	return Result{
 		terminated:   true,
 		requeueAfter: DefaultRetry,
 		reason:       reason,
-		message:      message,
+		message:      err.Error(),
 		warning:      true,
 	}
 }
@@ -77,7 +77,7 @@ func (r Result) IsDeleted() bool {
 
 // TerminateSilently indicates that the reconciliation logic cannot proceed and needs to be finished (and possibly requeued)
 // The status of the reconciled Custom Resource is not supposed to be updated.
-func TerminateSilently() Result {
+func TerminateSilently(err error) Result {
 	return Result{terminated: true, requeueAfter: DefaultRetry}
 }
 


### PR DESCRIPTION
For dry-run we need to be able to notify about errors during dry-run reconciliation. These can be various failure modes like:
- Atlas API not reachable (5xx)
- Connection secrets not being configured correctly
- internal errors

Currently, there is no way to distinguish reconcile results from failure results. This fixes it by adding errors vs. strings to our `Terminate*` methods. Dry-run is going to read out this error, skip on the the internal dry-run errors, and report everything else as an event.

Note: this is also a good intermediate for future optimisation of error return handling in conjunction with idiomatic controller-runtime error handling.

### All Submissions:

* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if there is one).
* [ ] Update docs/release-notes/release-notes-template.md if your changes should be included in the release notes for the next release.
