### PR TITLE
CLOUDP-296918: fix nil panics in advanced deployment spec

### DIFF
--- a/internal/translation/deployment/conversion_test.go
+++ b/internal/translation/deployment/conversion_test.go
@@ -380,6 +380,210 @@ func TestNormalizeClusterDeployment(t *testing.T) {
 		deployment *Cluster
 		expected   *Cluster
 	}{
+		"nil replication spec": {
+			deployment: &Cluster{
+				AdvancedDeploymentSpec: &akov2.AdvancedDeploymentSpec{
+					ReplicationSpecs: nil,
+				},
+			},
+			expected: &Cluster{
+				AdvancedDeploymentSpec: &akov2.AdvancedDeploymentSpec{
+					ClusterType:              "REPLICASET",
+					EncryptionAtRestProvider: "NONE",
+					MongoDBMajorVersion:      "7.0",
+					VersionReleaseSystem:     "LTS",
+					Paused:                   pointer.MakePtr(false),
+					PitEnabled:               pointer.MakePtr(false),
+					RootCertType:             "ISRGROOTX1",
+					BackupEnabled:            pointer.MakePtr(false),
+					Tags:                     []*akov2.TagSpec{},
+
+					ReplicationSpecs: nil,
+				},
+			},
+		},
+		"nil replication spec entries": {
+			deployment: &Cluster{
+				AdvancedDeploymentSpec: &akov2.AdvancedDeploymentSpec{
+					ReplicationSpecs: []*akov2.AdvancedReplicationSpec{
+						nil, nil, nil,
+					},
+				},
+			},
+			expected: &Cluster{
+				AdvancedDeploymentSpec: &akov2.AdvancedDeploymentSpec{
+					ClusterType:              "REPLICASET",
+					EncryptionAtRestProvider: "NONE",
+					MongoDBMajorVersion:      "7.0",
+					VersionReleaseSystem:     "LTS",
+					Paused:                   pointer.MakePtr(false),
+					PitEnabled:               pointer.MakePtr(false),
+					RootCertType:             "ISRGROOTX1",
+					BackupEnabled:            pointer.MakePtr(false),
+					Tags:                     []*akov2.TagSpec{},
+
+					ReplicationSpecs: []*akov2.AdvancedReplicationSpec{
+						nil, nil, nil,
+					},
+				},
+			},
+		},
+		"nil region configs": {
+			deployment: &Cluster{
+				AdvancedDeploymentSpec: &akov2.AdvancedDeploymentSpec{
+					ReplicationSpecs: []*akov2.AdvancedReplicationSpec{
+						{
+							RegionConfigs: nil,
+						},
+					},
+				},
+			},
+			expected: &Cluster{
+				AdvancedDeploymentSpec: &akov2.AdvancedDeploymentSpec{
+					ClusterType:              "REPLICASET",
+					EncryptionAtRestProvider: "NONE",
+					MongoDBMajorVersion:      "7.0",
+					VersionReleaseSystem:     "LTS",
+					Paused:                   pointer.MakePtr(false),
+					PitEnabled:               pointer.MakePtr(false),
+					RootCertType:             "ISRGROOTX1",
+					BackupEnabled:            pointer.MakePtr(false),
+					Tags:                     []*akov2.TagSpec{},
+
+					ReplicationSpecs: []*akov2.AdvancedReplicationSpec{
+						{
+							NumShards:     1,
+							ZoneName:      "Zone 1",
+							RegionConfigs: nil,
+						},
+					},
+				},
+			},
+		},
+		"nil region config entries": {
+			deployment: &Cluster{
+				AdvancedDeploymentSpec: &akov2.AdvancedDeploymentSpec{
+					ReplicationSpecs: []*akov2.AdvancedReplicationSpec{
+						{
+							RegionConfigs: []*akov2.AdvancedRegionConfig{
+								nil, nil, nil,
+							},
+						},
+					},
+				},
+			},
+			expected: &Cluster{
+				AdvancedDeploymentSpec: &akov2.AdvancedDeploymentSpec{
+					ClusterType:              "REPLICASET",
+					EncryptionAtRestProvider: "NONE",
+					MongoDBMajorVersion:      "7.0",
+					VersionReleaseSystem:     "LTS",
+					Paused:                   pointer.MakePtr(false),
+					PitEnabled:               pointer.MakePtr(false),
+					RootCertType:             "ISRGROOTX1",
+					BackupEnabled:            pointer.MakePtr(false),
+					Tags:                     []*akov2.TagSpec{},
+
+					ReplicationSpecs: []*akov2.AdvancedReplicationSpec{
+						{
+							NumShards: 1,
+							ZoneName:  "Zone 1",
+							RegionConfigs: []*akov2.AdvancedRegionConfig{
+								nil, nil, nil,
+							},
+						},
+					},
+				},
+			},
+		},
+		"nil regionconfig specs": {
+			deployment: &Cluster{
+				AdvancedDeploymentSpec: &akov2.AdvancedDeploymentSpec{
+					ReplicationSpecs: []*akov2.AdvancedReplicationSpec{
+						{
+							RegionConfigs: []*akov2.AdvancedRegionConfig{
+								{
+									AnalyticsSpecs: nil,
+									ElectableSpecs: nil,
+									ReadOnlySpecs:  nil,
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: &Cluster{
+				AdvancedDeploymentSpec: &akov2.AdvancedDeploymentSpec{
+					ClusterType:              "REPLICASET",
+					EncryptionAtRestProvider: "NONE",
+					MongoDBMajorVersion:      "7.0",
+					VersionReleaseSystem:     "LTS",
+					Paused:                   pointer.MakePtr(false),
+					PitEnabled:               pointer.MakePtr(false),
+					RootCertType:             "ISRGROOTX1",
+					BackupEnabled:            pointer.MakePtr(false),
+					Tags:                     []*akov2.TagSpec{},
+
+					ReplicationSpecs: []*akov2.AdvancedReplicationSpec{
+						{
+							NumShards: 1,
+							ZoneName:  "Zone 1",
+							RegionConfigs: []*akov2.AdvancedRegionConfig{
+								{
+									AnalyticsSpecs: nil,
+									ElectableSpecs: nil,
+									ReadOnlySpecs:  nil,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"empty regionconfig specs": {
+			deployment: &Cluster{
+				AdvancedDeploymentSpec: &akov2.AdvancedDeploymentSpec{
+					ReplicationSpecs: []*akov2.AdvancedReplicationSpec{
+						{
+							RegionConfigs: []*akov2.AdvancedRegionConfig{
+								{
+									AnalyticsSpecs: &akov2.Specs{},
+									ElectableSpecs: &akov2.Specs{},
+									ReadOnlySpecs:  &akov2.Specs{},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: &Cluster{
+				AdvancedDeploymentSpec: &akov2.AdvancedDeploymentSpec{
+					ClusterType:              "REPLICASET",
+					EncryptionAtRestProvider: "NONE",
+					MongoDBMajorVersion:      "7.0",
+					VersionReleaseSystem:     "LTS",
+					Paused:                   pointer.MakePtr(false),
+					PitEnabled:               pointer.MakePtr(false),
+					RootCertType:             "ISRGROOTX1",
+					BackupEnabled:            pointer.MakePtr(false),
+					Tags:                     []*akov2.TagSpec{},
+
+					ReplicationSpecs: []*akov2.AdvancedReplicationSpec{
+						{
+							NumShards: 1,
+							ZoneName:  "Zone 1",
+							RegionConfigs: []*akov2.AdvancedRegionConfig{
+								{
+									AnalyticsSpecs: nil,
+									ElectableSpecs: nil,
+									ReadOnlySpecs:  nil,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 		"normalize deployment configuration": {
 			deployment: &Cluster{
 				AdvancedDeploymentSpec: &akov2.AdvancedDeploymentSpec{

--- a/internal/translation/networkpeering/networkpeering.go
+++ b/internal/translation/networkpeering/networkpeering.go
@@ -84,6 +84,9 @@ func (np *networkPeeringService) listPeersForProvider(ctx context.Context, proje
 
 func (np *networkPeeringService) DeletePeer(ctx context.Context, projectID, peerID string) error {
 	_, _, err := np.peeringAPI.DeletePeeringConnection(ctx, projectID, peerID).Execute()
+	if admin.IsErrorCode(err, "PEER_ALREADY_REQUESTED_DELETION") || admin.IsErrorCode(err, "PEER_NOT_FOUND") {
+		return nil // if it was already removed or being removed it is also fine
+	}
 	if err != nil {
 		return fmt.Errorf("failed to delete peering connection for peer %s: %w", peerID, err)
 	}

--- a/test/contract/audit/audit_test.go
+++ b/test/contract/audit/audit_test.go
@@ -19,7 +19,7 @@ func TestDefaultAuditingGet(t *testing.T) {
 	ctx := context.Background()
 	contract.RunGoContractTest(ctx, t, "get default auditing", func(ch contract.ContractHelper) {
 		projectName := utils.RandomName("default-auditing-project")
-		require.NoError(t, ch.AddResources(ctx, time.Minute, contract.DefaultAtlasProject(projectName)))
+		require.NoError(t, ch.AddResources(ctx, 5*time.Minute, contract.DefaultAtlasProject(projectName)))
 		testProjectID, err := ch.ProjectID(ctx, projectName)
 		require.NoError(t, err)
 		as := audit.NewAuditLog(ch.AtlasClient().AuditingApi)
@@ -90,7 +90,7 @@ func TestSyncs(t *testing.T) {
 	}
 	contract.RunGoContractTest(ctx, t, "test syncs", func(ch contract.ContractHelper) {
 		projectName := utils.RandomName("audit-syncs-project")
-		require.NoError(t, ch.AddResources(ctx, time.Minute, contract.DefaultAtlasProject(projectName)))
+		require.NoError(t, ch.AddResources(ctx, 5 * time.Minute, contract.DefaultAtlasProject(projectName)))
 		testProjectID, err := ch.ProjectID(ctx, projectName)
 		require.NoError(t, err)
 		as := audit.NewAuditLog(ch.AtlasClient().AuditingApi)

--- a/test/contract/audit/audit_test.go
+++ b/test/contract/audit/audit_test.go
@@ -90,7 +90,7 @@ func TestSyncs(t *testing.T) {
 	}
 	contract.RunGoContractTest(ctx, t, "test syncs", func(ch contract.ContractHelper) {
 		projectName := utils.RandomName("audit-syncs-project")
-		require.NoError(t, ch.AddResources(ctx, 5 * time.Minute, contract.DefaultAtlasProject(projectName)))
+		require.NoError(t, ch.AddResources(ctx, 5*time.Minute, contract.DefaultAtlasProject(projectName)))
 		testProjectID, err := ch.ProjectID(ctx, projectName)
 		require.NoError(t, err)
 		as := audit.NewAuditLog(ch.AtlasClient().AuditingApi)

--- a/test/contract/networkpeering/networkpeering_test.go
+++ b/test/contract/networkpeering/networkpeering_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.mongodb.org/atlas-sdk/v20231115004/admin"
 
 	akov2 "github.com/mongodb/mongodb-atlas-kubernetes/v2/api/v1"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/translation/networkpeering"
@@ -29,7 +28,7 @@ func TestPeerContainerServiceCRUD(t *testing.T) {
 	ctx := context.Background()
 	contract.RunGoContractTest(ctx, t, "test container CRUD", func(ch contract.ContractHelper) {
 		projectName := utils.RandomName("peer-container-crud-project")
-		require.NoError(t, ch.AddResources(ctx, 5 * time.Minute, contract.DefaultAtlasProject(projectName)))
+		require.NoError(t, ch.AddResources(ctx, 5*time.Minute, contract.DefaultAtlasProject(projectName)))
 		testProjectID, err := ch.ProjectID(ctx, projectName)
 		require.NoError(t, err)
 		nps := networkpeering.NewNetworkPeeringService(ch.AtlasClient().NetworkPeeringApi)
@@ -77,7 +76,7 @@ func TestPeerContainerServiceCRUD(t *testing.T) {
 
 			t.Run(fmt.Sprintf("delete %s container", tc.provider), func(t *testing.T) {
 				time.Sleep(time.Second) // Atlas may reject removal if it happened within a second of creation
-				assert.NoErrorf(t, ignoreRemoved(cs.DeleteContainer(ctx, testProjectID, createdContainer.ID)),
+				assert.NoErrorf(t, cs.DeleteContainer(ctx, testProjectID, createdContainer.ID),
 					"failed cleanup for provider %s Atlas project ID %s and container id %s",
 					tc.provider, testProjectID, createdContainer.ID)
 			})
@@ -251,11 +250,4 @@ func mustHaveEnvVar(t *testing.T, name string) string {
 		t.Fatalf("Unexpected unset env var %q", name)
 	}
 	return value
-}
-
-func ignoreRemoved(err error) error {
-	if admin.IsErrorCode(err, "CLOUD_PROVIDER_CONTAINER_NOT_FOUND") {
-		return nil
-	}
-	return err
 }

--- a/test/contract/networkpeering/networkpeering_test.go
+++ b/test/contract/networkpeering/networkpeering_test.go
@@ -29,7 +29,7 @@ func TestPeerContainerServiceCRUD(t *testing.T) {
 	ctx := context.Background()
 	contract.RunGoContractTest(ctx, t, "test container CRUD", func(ch contract.ContractHelper) {
 		projectName := utils.RandomName("peer-container-crud-project")
-		require.NoError(t, ch.AddResources(ctx, time.Minute, contract.DefaultAtlasProject(projectName)))
+		require.NoError(t, ch.AddResources(ctx, 5 * time.Minute, contract.DefaultAtlasProject(projectName)))
 		testProjectID, err := ch.ProjectID(ctx, projectName)
 		require.NoError(t, err)
 		nps := networkpeering.NewNetworkPeeringService(ch.AtlasClient().NetworkPeeringApi)


### PR DESCRIPTION
Advanced deployment spec conversion in AKO can nil panic in some cases if:

1. ReplicationSpecs field is set but left empty (spec itself is nil)
2. ReplicationSpecs has empty entries (entries are nil)
3. RegionConfigs are nil
4. RegionConfig entries are nil

This is not a blocker but a major as most customers won't leave empty YAML fields so there is a workaround.

### All Submissions:

* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if there is one).
* [ ] Update docs/release-notes/release-notes-template.md if your changes should be included in the release notes for the next release.
