### PR TITLE
CLOUDP-280258: add For() method in all reconcilers for dry-run

### DIFF
--- a/internal/controller/atlasbackupcompliancepolicy/atlasbackupcompliancepolicy_controller.go
+++ b/internal/controller/atlasbackupcompliancepolicy/atlasbackupcompliancepolicy_controller.go
@@ -96,10 +96,14 @@ func (r *AtlasBackupCompliancePolicyReconciler) ensureAtlasBackupCompliancePolic
 	return r.release(workflowCtx, bcp)
 }
 
+func (r *AtlasBackupCompliancePolicyReconciler) For() (client.Object, builder.Predicates) {
+	return &akov2.AtlasBackupCompliancePolicy{}, builder.WithPredicates(r.GlobalPredicates...)
+}
+
 func (r *AtlasBackupCompliancePolicyReconciler) SetupWithManager(mgr ctrl.Manager, skipNameValidation bool) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		Named("AtlasBackupCompliancePolicy").
-		For(&akov2.AtlasBackupCompliancePolicy{}, builder.WithPredicates(r.GlobalPredicates...)).
+		For(r.For()).
 		Watches(
 			&akov2.AtlasProject{},
 			handler.EnqueueRequestsFromMapFunc(r.findBCPForProjects),

--- a/internal/controller/atlascustomrole/atlascustomrole_controller.go
+++ b/internal/controller/atlascustomrole/atlascustomrole_controller.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -188,10 +189,14 @@ func (r *AtlasCustomRoleReconciler) notFound(req ctrl.Request) ctrl.Result {
 	return workflow.TerminateSilently(err).WithoutRetry().ReconcileResult()
 }
 
+func (r *AtlasCustomRoleReconciler) For() (client.Object, builder.Predicates) {
+	return &akov2.AtlasCustomRole{}, builder.WithPredicates(r.GlobalPredicates...)
+}
+
 func (r *AtlasCustomRoleReconciler) SetupWithManager(mgr ctrl.Manager, skipNameValidation bool) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		Named("AtlasCustomRole").
-		For(&akov2.AtlasCustomRole{}, builder.WithPredicates(r.GlobalPredicates...)).
+		For(r.For()).
 		Watches(
 			&corev1.Secret{},
 			handler.EnqueueRequestsFromMapFunc(r.customRolesCredentials()),

--- a/internal/controller/atlasdatabaseuser/atlasdatabaseuser_controller.go
+++ b/internal/controller/atlasdatabaseuser/atlasdatabaseuser_controller.go
@@ -206,10 +206,14 @@ func (r *AtlasDatabaseUserReconciler) ready(ctx *workflow.Context, atlasDatabase
 	return workflow.OK().ReconcileResult()
 }
 
+func (r *AtlasDatabaseUserReconciler) For() (client.Object, builder.Predicates) {
+	return &akov2.AtlasDatabaseUser{}, builder.WithPredicates(r.GlobalPredicates...)
+}
+
 func (r *AtlasDatabaseUserReconciler) SetupWithManager(mgr ctrl.Manager, skipNameValidation bool) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		Named("AtlasDatabaseUser").
-		For(&akov2.AtlasDatabaseUser{}, builder.WithPredicates(r.GlobalPredicates...)).
+		For(r.For()).
 		Watches(
 			&corev1.Secret{},
 			handler.EnqueueRequestsFromMapFunc(r.findAtlasDatabaseUserForSecret),

--- a/internal/controller/atlasdatafederation/datafederation_controller.go
+++ b/internal/controller/atlasdatafederation/datafederation_controller.go
@@ -212,10 +212,14 @@ func (r *AtlasDataFederationReconciler) readProjectResource(ctx context.Context,
 	return workflow.OK()
 }
 
+func (r *AtlasDataFederationReconciler) For() (client.Object, builder.Predicates) {
+	return &akov2.AtlasDataFederation{}, builder.WithPredicates(r.GlobalPredicates...)
+}
+
 func (r *AtlasDataFederationReconciler) SetupWithManager(mgr ctrl.Manager, skipNameValidation bool) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		Named("AtlasDataFederation").
-		For(&akov2.AtlasDataFederation{}, builder.WithPredicates(r.GlobalPredicates...)).
+		For(r.For()).
 		Watches(
 			&akov2.AtlasProject{},
 			handler.EnqueueRequestsFromMapFunc(r.findAtlasDataFederationForProjects),

--- a/internal/controller/atlasdeployment/atlasdeployment_controller.go
+++ b/internal/controller/atlasdeployment/atlasdeployment_controller.go
@@ -381,10 +381,14 @@ func (r *AtlasDeploymentReconciler) unmanage(ctx *workflow.Context, atlasDeploym
 	return workflow.OK().ReconcileResult(), nil
 }
 
+func (r *AtlasDeploymentReconciler) For() (client.Object, builder.Predicates) {
+	return &akov2.AtlasDeployment{}, builder.WithPredicates(r.GlobalPredicates...)
+}
+
 func (r *AtlasDeploymentReconciler) SetupWithManager(mgr ctrl.Manager, skipNameValidation bool) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		Named("AtlasDeployment").
-		For(&akov2.AtlasDeployment{}, builder.WithPredicates(r.GlobalPredicates...)).
+		For(r.For()).
 		Watches(
 			&akov2.AtlasBackupSchedule{},
 			handler.EnqueueRequestsFromMapFunc(r.findDeploymentsForBackupSchedule),

--- a/internal/controller/atlasfederatedauth/atlasfederated_auth_controller.go
+++ b/internal/controller/atlasfederatedauth/atlasfederated_auth_controller.go
@@ -114,10 +114,14 @@ func (r *AtlasFederatedAuthReconciler) Reconcile(ctx context.Context, req ctrl.R
 	return result.ReconcileResult(), nil
 }
 
+func (r *AtlasFederatedAuthReconciler) For() (client.Object, builder.Predicates) {
+	return &akov2.AtlasFederatedAuth{}, builder.WithPredicates(r.GlobalPredicates...)
+}
+
 func (r *AtlasFederatedAuthReconciler) SetupWithManager(mgr ctrl.Manager, skipNameValidation bool) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		Named("AtlasFederatedAuth").
-		For(&akov2.AtlasFederatedAuth{}, builder.WithPredicates(r.GlobalPredicates...)).
+		For(r.For()).
 		Watches(
 			&corev1.Secret{},
 			handler.EnqueueRequestsFromMapFunc(r.findAtlasFederatedAuthForSecret),

--- a/internal/controller/atlasipaccesslist/atlasipaccesslist_controller.go
+++ b/internal/controller/atlasipaccesslist/atlasipaccesslist_controller.go
@@ -67,10 +67,14 @@ func (r *AtlasIPAccessListReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	return r.handleCustomResource(ctx, &ipAccessList), nil
 }
 
+func (r *AtlasIPAccessListReconciler) For() (client.Object, builder.Predicates) {
+	return &akov2.AtlasIPAccessList{}, builder.WithPredicates(r.GlobalPredicates...)
+}
+
 func (r *AtlasIPAccessListReconciler) SetupWithManager(mgr manager.Manager, skipNameValidation bool) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		Named("AtlasIPAccessList").
-		For(&akov2.AtlasIPAccessList{}, builder.WithPredicates(r.GlobalPredicates...)).
+		For(r.For()).
 		Watches(
 			&akov2.AtlasProject{},
 			handler.EnqueueRequestsFromMapFunc(r.ipAccessListForProjectMapFunc()),

--- a/internal/controller/atlasprivateendpoint/atlasprivateendpoint_controller.go
+++ b/internal/controller/atlasprivateendpoint/atlasprivateendpoint_controller.go
@@ -223,10 +223,14 @@ func (r *AtlasPrivateEndpointReconciler) unmanage(ctx *workflow.Context, akoPriv
 	return workflow.Deleted().ReconcileResult(), nil
 }
 
+func (r *AtlasPrivateEndpointReconciler) For() (client.Object, builder.Predicates) {
+	return &akov2.AtlasPrivateEndpoint{}, builder.WithPredicates(r.GlobalPredicates...)
+}
+
 func (r *AtlasPrivateEndpointReconciler) SetupWithManager(mgr ctrl.Manager, skipNameValidation bool) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		Named("AtlasPrivateEndpoint").
-		For(&akov2.AtlasPrivateEndpoint{}, builder.WithPredicates(r.GlobalPredicates...)).
+		For(r.For()).
 		Watches(
 			&akov2.AtlasProject{},
 			handler.EnqueueRequestsFromMapFunc(r.privateEndpointForProjectMapFunc()),

--- a/internal/controller/atlasproject/atlasproject_controller.go
+++ b/internal/controller/atlasproject/atlasproject_controller.go
@@ -252,10 +252,14 @@ func (r *AtlasProjectReconciler) ensureProjectResources(workflowCtx *workflow.Co
 	return results
 }
 
+func (r *AtlasProjectReconciler) For() (client.Object, builder.Predicates) {
+	return &akov2.AtlasProject{}, builder.WithPredicates(r.GlobalPredicates...)
+}
+
 func (r *AtlasProjectReconciler) SetupWithManager(mgr ctrl.Manager, skipNameValidation bool) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		Named("AtlasProject").
-		For(&akov2.AtlasProject{}, builder.WithPredicates(r.GlobalPredicates...)).
+		For(r.For()).
 		Watches(
 			&corev1.Secret{},
 			handler.EnqueueRequestsFromMapFunc(newProjectsMapFunc[corev1.Secret](indexer.AtlasProjectBySecretsIndex, r.Client, r.Log)),

--- a/internal/controller/atlassearchindexconfig/atlassearchindexconfig_controller.go
+++ b/internal/controller/atlassearchindexconfig/atlassearchindexconfig_controller.go
@@ -96,10 +96,14 @@ func (r *AtlasSearchIndexConfigReconciler) Reconcile(ctx context.Context, req ct
 	return r.release(workflowCtx, atlasSearchIndexConfig), nil
 }
 
+func (r *AtlasSearchIndexConfigReconciler) For() (client.Object, builder.Predicates) {
+	return &akov2.AtlasSearchIndexConfig{}, builder.WithPredicates(r.GlobalPredicates...)
+}
+
 func (r *AtlasSearchIndexConfigReconciler) SetupWithManager(mgr ctrl.Manager, skipNameValidation bool) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		Named("AtlasSearchIndexConfig").
-		For(&akov2.AtlasSearchIndexConfig{}, builder.WithPredicates(r.GlobalPredicates...)).
+		For(r.For()).
 		Watches(
 			&akov2.AtlasDeployment{},
 			handler.EnqueueRequestsFromMapFunc(r.findReferencesInAtlasDeployments),

--- a/internal/controller/atlasstream/atlasstream_connection_controller.go
+++ b/internal/controller/atlasstream/atlasstream_connection_controller.go
@@ -96,10 +96,14 @@ func (r *AtlasStreamsConnectionReconciler) ensureAtlasStreamConnection(ctx conte
 	return r.release(workflowCtx, akoStreamConnection)
 }
 
+func (r *AtlasStreamsConnectionReconciler) For() (client.Object, builder.Predicates) {
+	return &akov2.AtlasStreamConnection{}, builder.WithPredicates(r.GlobalPredicates...)
+}
+
 func (r *AtlasStreamsConnectionReconciler) SetupWithManager(mgr ctrl.Manager, skipNameValidation bool) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		Named("AtlasStreamConnection").
-		For(&akov2.AtlasStreamConnection{}, builder.WithPredicates(r.GlobalPredicates...)).
+		For(r.For()).
 		Watches(
 			&akov2.AtlasStreamInstance{},
 			handler.EnqueueRequestsFromMapFunc(r.findStreamConnectionsForStreamInstances),

--- a/internal/controller/atlasstream/atlasstream_instance_controller.go
+++ b/internal/controller/atlasstream/atlasstream_instance_controller.go
@@ -136,10 +136,14 @@ func hasChanged(streamInstance *akov2.AtlasStreamInstance, atlasStreamInstance *
 	return config.Provider != dataProcessRegion.GetCloudProvider() || config.Region != dataProcessRegion.GetRegion()
 }
 
+func (r *AtlasStreamsInstanceReconciler) For() (client.Object, builder.Predicates) {
+	return &akov2.AtlasStreamInstance{}, builder.WithPredicates(r.GlobalPredicates...)
+}
+
 func (r *AtlasStreamsInstanceReconciler) SetupWithManager(mgr ctrl.Manager, skipNameValidation bool) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		Named("AtlasStreamInstance").
-		For(&akov2.AtlasStreamInstance{}, builder.WithPredicates(r.GlobalPredicates...)).
+		For(r.For()).
 		Watches(
 			&akov2.AtlasStreamConnection{},
 			handler.EnqueueRequestsFromMapFunc(r.findStreamInstancesForStreamConnection),


### PR DESCRIPTION
We have to make sure our custom resources controllers support dry run capabilities. We have the necessary metadata already available already during registration in the regular Manager object, namely the runtime object a reconciler is responsible for.

We need the runtime object for the same reasons controller-runtime needs it in the manager. We need to list resources and act on them during dry-run so the runtime object is needed.

This adds a `For()` method for every reconciler to be used during dry-run.

**Note** This is a no-op, however it's fine to merge this after the 2.7 release.

### All Submissions:

* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if there is one).
* [ ] Update docs/release-notes/release-notes-template.md if your changes should be included in the release notes for the next release.
