### PR TITLE
CLOUDP-297660: resolve project kube references via name in Atlas

### DIFF
--- a/internal/controller/atlascustomrole/atlascustomrole_controller.go
+++ b/internal/controller/atlascustomrole/atlascustomrole_controller.go
@@ -128,12 +128,12 @@ func (r *AtlasCustomRoleReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	if err != nil {
 		return r.fail(req, err), nil
 	}
-	atlasSdkClient, orgID, err := r.AtlasProvider.SdkClient(workflowCtx.Context, credentials, workflowCtx.Log)
+	atlasSdkClient, _, err := r.AtlasProvider.SdkClient(workflowCtx.Context, credentials, workflowCtx.Log)
 	if err != nil {
 		return r.terminate(workflowCtx, atlasCustomRole, api.ProjectCustomRolesReadyType, workflow.AtlasAPIAccessNotConfigured, true, err), nil
 	}
 	service := customroles.NewCustomRoles(atlasSdkClient.CustomDatabaseRolesApi)
-	project, err := r.ResolveProject(ctx, atlasSdkClient, atlasCustomRole, orgID)
+	project, err := r.ResolveProject(ctx, atlasSdkClient, atlasCustomRole)
 	if err != nil {
 		return r.terminate(workflowCtx, atlasCustomRole, api.ProjectCustomRolesReadyType, workflow.AtlasAPIAccessNotConfigured, true, err), nil
 	}

--- a/internal/controller/atlasdatabaseuser/databaseuser.go
+++ b/internal/controller/atlasdatabaseuser/databaseuser.go
@@ -48,7 +48,7 @@ func (r *AtlasDatabaseUserReconciler) handleDatabaseUser(ctx *workflow.Context, 
 	if err != nil {
 		return r.terminate(ctx, atlasDatabaseUser, api.DatabaseUserReadyType, workflow.AtlasAPIAccessNotConfigured, true, err)
 	}
-	sdkClient, orgID, err := r.AtlasProvider.SdkClient(ctx.Context, credentials, r.Log)
+	sdkClient, _, err := r.AtlasProvider.SdkClient(ctx.Context, credentials, r.Log)
 	if err != nil {
 		return r.terminate(ctx, atlasDatabaseUser, api.DatabaseUserReadyType, workflow.AtlasAPIAccessNotConfigured, true, err)
 	}
@@ -58,7 +58,7 @@ func (r *AtlasDatabaseUserReconciler) handleDatabaseUser(ctx *workflow.Context, 
 	}
 	dbUserService := dbuser.NewAtlasUsers(sdkClient.DatabaseUsersApi)
 	deploymentService := deployment.NewAtlasDeployments(sdkClient.ClustersApi, sdkClient.ServerlessInstancesApi, sdkClient.GlobalClustersApi, sdkClientSet.SdkClient20241113001.FlexClustersApi, r.AtlasProvider.IsCloudGov())
-	atlasProject, err := r.ResolveProject(ctx.Context, sdkClient, atlasDatabaseUser, orgID)
+	atlasProject, err := r.ResolveProject(ctx.Context, sdkClient, atlasDatabaseUser)
 	if err != nil {
 		return r.terminate(ctx, atlasDatabaseUser, api.DatabaseUserReadyType, workflow.AtlasAPIAccessNotConfigured, true, err)
 	}

--- a/internal/controller/atlasdatabaseuser/databaseuser_test.go
+++ b/internal/controller/atlasdatabaseuser/databaseuser_test.go
@@ -13,7 +13,6 @@ import (
 	"go.mongodb.org/atlas-sdk/v20231115008/admin"
 	"go.mongodb.org/atlas-sdk/v20231115008/mockadmin"
 	adminv20241113001 "go.mongodb.org/atlas-sdk/v20241113001/admin"
-
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 	corev1 "k8s.io/api/core/v1"
@@ -2236,20 +2235,27 @@ func DefaultTestProvider(t *testing.T) *atlasmock.TestProvider {
 		},
 		SdkClientFunc: func(secretRef *client.ObjectKey, log *zap.SugaredLogger) (*admin.APIClient, string, error) {
 			userAPI := mockadmin.NewDatabaseUsersApi(t)
-			userAPI.EXPECT().GetDatabaseUser(context.Background(), "", "admin", "user1").
+			userAPI.EXPECT().GetDatabaseUser(context.Background(), "my-project", "admin", "user1").
 				Return(admin.GetDatabaseUserApiRequest{ApiService: userAPI})
 			userAPI.EXPECT().GetDatabaseUserExecute(mock.AnythingOfType("admin.GetDatabaseUserApiRequest")).
 				Return(nil, nil, nil)
-			userAPI.EXPECT().CreateDatabaseUser(context.Background(), "", mock.AnythingOfType("*admin.CloudDatabaseUser")).
+			userAPI.EXPECT().CreateDatabaseUser(context.Background(), "my-project", mock.AnythingOfType("*admin.CloudDatabaseUser")).
 				Return(admin.CreateDatabaseUserApiRequest{ApiService: userAPI})
 			userAPI.EXPECT().CreateDatabaseUserExecute(mock.AnythingOfType("admin.CreateDatabaseUserApiRequest")).
 				Return(&admin.CloudDatabaseUser{}, nil, nil)
 
 			clusterAPI := mockadmin.NewClustersApi(t)
 
+			projectAPI := mockadmin.NewProjectsApi(t)
+			projectAPI.EXPECT().GetProjectByName(mock.Anything, "my-project").
+				Return(admin.GetProjectByNameApiRequest{ApiService: projectAPI})
+			projectAPI.EXPECT().GetProjectByNameExecute(mock.Anything).
+				Return(&admin.Group{Id: pointer.MakePtr("my-project")}, nil, nil)
+
 			return &admin.APIClient{
 				ClustersApi:      clusterAPI,
 				DatabaseUsersApi: userAPI,
+				ProjectsApi:      projectAPI,
 			}, "", nil
 		},
 		SdkSetClientFunc: func(secretRef *client.ObjectKey, log *zap.SugaredLogger) (*atlas.ClientSet, string, error) {

--- a/internal/controller/atlasdeployment/atlasdeployment_controller.go
+++ b/internal/controller/atlasdeployment/atlasdeployment_controller.go
@@ -136,7 +136,7 @@ func (r *AtlasDeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	if err != nil {
 		return r.terminate(workflowCtx, workflow.AtlasAPIAccessNotConfigured, err)
 	}
-	sdkClient, orgID, err := r.AtlasProvider.SdkClient(workflowCtx.Context, credentials, r.Log)
+	sdkClient, _, err := r.AtlasProvider.SdkClient(workflowCtx.Context, credentials, r.Log)
 	if err != nil {
 		return r.terminate(workflowCtx, workflow.AtlasAPIAccessNotConfigured, err)
 	}
@@ -152,7 +152,7 @@ func (r *AtlasDeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	}
 	projectService := project.NewProjectAPIService(sdkClient.ProjectsApi)
 	deploymentService := deployment.NewAtlasDeployments(sdkClient.ClustersApi, sdkClient.ServerlessInstancesApi, sdkClient.GlobalClustersApi, sdkClientSet.SdkClient20241113001.FlexClustersApi, r.AtlasProvider.IsCloudGov())
-	atlasProject, err := r.ResolveProject(workflowCtx.Context, sdkClient, atlasDeployment, orgID)
+	atlasProject, err := r.ResolveProject(workflowCtx.Context, sdkClient, atlasDeployment)
 	if err != nil {
 		return r.terminate(workflowCtx, workflow.AtlasAPIAccessNotConfigured, err)
 	}

--- a/internal/controller/atlasdeployment/atlasdeployment_controller_test.go
+++ b/internal/controller/atlasdeployment/atlasdeployment_controller_test.go
@@ -465,6 +465,12 @@ func TestRegularClusterReconciliation(t *testing.T) {
 					nil,
 				)
 
+			projectAPI := mockadmin.NewProjectsApi(t)
+			projectAPI.EXPECT().GetProjectByName(mock.Anything, "MyProject").
+				Return(admin.GetProjectByNameApiRequest{ApiService: projectAPI})
+			projectAPI.EXPECT().GetProjectByNameExecute(mock.Anything).
+				Return(&admin.Group{Id: pointer.MakePtr("abc123")}, nil, nil)
+
 			globalAPI := mockadmin.NewGlobalClustersApi(t)
 			globalAPI.EXPECT().GetManagedNamespace(mock.Anything, project.ID(), d.Spec.DeploymentSpec.Name).
 				Return(admin.GetManagedNamespaceApiRequest{ApiService: globalAPI})
@@ -476,6 +482,7 @@ func TestRegularClusterReconciliation(t *testing.T) {
 				AtlasSearchApi:         searchAPI,
 				ServerlessInstancesApi: mockadmin.NewServerlessInstancesApi(t),
 				GlobalClustersApi:      globalAPI,
+				ProjectsApi:            projectAPI,
 			}, orgID, nil
 		},
 		ClientFunc: func(secretRef *client.ObjectKey, log *zap.SugaredLogger) (*mongodbatlas.Client, string, error) {
@@ -665,10 +672,17 @@ func TestServerlessInstanceReconciliation(t *testing.T) {
 			speClient.EXPECT().ListServerlessPrivateEndpointsExecute(mock.AnythingOfType("admin.ListServerlessPrivateEndpointsApiRequest")).
 				Return(nil, &http.Response{}, nil)
 
+			projectAPI := mockadmin.NewProjectsApi(t)
+			projectAPI.EXPECT().GetProjectByName(mock.Anything, "MyProject").
+				Return(admin.GetProjectByNameApiRequest{ApiService: projectAPI})
+			projectAPI.EXPECT().GetProjectByNameExecute(mock.Anything).
+				Return(&admin.Group{Id: pointer.MakePtr("abc123")}, nil, nil)
+
 			return &admin.APIClient{
 				ClustersApi:                   clusterAPI,
 				ServerlessInstancesApi:        serverlessAPI,
 				ServerlessPrivateEndpointsApi: speClient,
+				ProjectsApi:                   projectAPI,
 			}, orgID, nil
 		},
 		ClientFunc: func(secretRef *client.ObjectKey, log *zap.SugaredLogger) (*mongodbatlas.Client, string, error) {
@@ -784,9 +798,17 @@ func TestFlexClusterReconciliation(t *testing.T) {
 		SdkClientFunc: func(secretRef *client.ObjectKey, log *zap.SugaredLogger) (*admin.APIClient, string, error) {
 			clusterAPI := mockadmin.NewClustersApi(t)
 			serverlessAPI := mockadmin.NewServerlessInstancesApi(t)
+
+			projectAPI := mockadmin.NewProjectsApi(t)
+			projectAPI.EXPECT().GetProjectByName(mock.Anything, "MyProject").
+				Return(admin.GetProjectByNameApiRequest{ApiService: projectAPI})
+			projectAPI.EXPECT().GetProjectByNameExecute(mock.Anything).
+				Return(&admin.Group{Id: pointer.MakePtr("abc123")}, nil, nil)
+
 			return &admin.APIClient{
 				ClustersApi:            clusterAPI,
 				ServerlessInstancesApi: serverlessAPI,
+				ProjectsApi:            projectAPI,
 			}, orgID, nil
 		},
 		ClientFunc: func(secretRef *client.ObjectKey, log *zap.SugaredLogger) (*mongodbatlas.Client, string, error) {
@@ -961,9 +983,16 @@ func TestDeletionReconciliation(t *testing.T) {
 			clusterAPI.EXPECT().DeleteClusterExecute(mock.AnythingOfType("admin.DeleteClusterApiRequest")).
 				Return(&http.Response{}, nil)
 
+			projectAPI := mockadmin.NewProjectsApi(t)
+			projectAPI.EXPECT().GetProjectByName(mock.Anything, "MyProject").
+				Return(admin.GetProjectByNameApiRequest{ApiService: projectAPI})
+			projectAPI.EXPECT().GetProjectByNameExecute(mock.Anything).
+				Return(&admin.Group{Id: pointer.MakePtr("abc123")}, nil, nil)
+
 			return &admin.APIClient{
 				ClustersApi:            clusterAPI,
 				ServerlessInstancesApi: mockadmin.NewServerlessInstancesApi(t),
+				ProjectsApi:            projectAPI,
 			}, orgID, nil
 		},
 		ClientFunc: func(secretRef *client.ObjectKey, log *zap.SugaredLogger) (*mongodbatlas.Client, string, error) {
@@ -1311,7 +1340,16 @@ func TestChangeDeploymentType(t *testing.T) {
 					err.SetError("wrong API")
 					serverlessAPI.EXPECT().GetServerlessInstanceExecute(mock.Anything).Return(nil, nil, err)
 
-					return &admin.APIClient{ServerlessInstancesApi: serverlessAPI}, "org-id", nil
+					projectAPI := mockadmin.NewProjectsApi(t)
+					projectAPI.EXPECT().GetProjectByName(mock.Anything, "MyProject").
+						Return(admin.GetProjectByNameApiRequest{ApiService: projectAPI})
+					projectAPI.EXPECT().GetProjectByNameExecute(mock.Anything).
+						Return(&admin.Group{Id: pointer.MakePtr("abc123")}, nil, nil)
+
+					return &admin.APIClient{
+						ServerlessInstancesApi: serverlessAPI,
+						ProjectsApi:            projectAPI,
+					}, "org-id", nil
 				},
 			},
 		},
@@ -1359,7 +1397,17 @@ func TestChangeDeploymentType(t *testing.T) {
 					err.SetModel(admin.ApiError{ErrorCode: pointer.MakePtr(atlas.ServerlessInstanceFromClusterAPI)})
 					err.SetError("wrong API")
 					clusterAPI.EXPECT().GetClusterExecute(mock.Anything).Return(nil, nil, err)
-					return &admin.APIClient{ClustersApi: clusterAPI}, "org-id", nil
+
+					projectAPI := mockadmin.NewProjectsApi(t)
+					projectAPI.EXPECT().GetProjectByName(mock.Anything, "MyProject").
+						Return(admin.GetProjectByNameApiRequest{ApiService: projectAPI})
+					projectAPI.EXPECT().GetProjectByNameExecute(mock.Anything).
+						Return(&admin.Group{Id: pointer.MakePtr("abc123")}, nil, nil)
+
+					return &admin.APIClient{
+						ClustersApi: clusterAPI,
+						ProjectsApi: projectAPI,
+					}, "org-id", nil
 				},
 			},
 		},

--- a/internal/controller/atlasipaccesslist/state.go
+++ b/internal/controller/atlasipaccesslist/state.go
@@ -45,11 +45,11 @@ func (r *AtlasIPAccessListReconciler) handleCustomResource(ctx context.Context, 
 	if err != nil {
 		return r.terminate(workflowCtx, ipAccessList, api.ReadyType, workflow.AtlasAPIAccessNotConfigured, err)
 	}
-	sdkClient, orgID, err := r.AtlasProvider.SdkClient(ctx, credentials, r.Log)
+	sdkClient, _, err := r.AtlasProvider.SdkClient(ctx, credentials, r.Log)
 	if err != nil {
 		return r.terminate(workflowCtx, ipAccessList, api.ReadyType, workflow.AtlasAPIAccessNotConfigured, err)
 	}
-	atlasProject, err := r.ResolveProject(ctx, sdkClient, ipAccessList, orgID)
+	atlasProject, err := r.ResolveProject(ctx, sdkClient, ipAccessList)
 	if err != nil {
 		return r.terminate(workflowCtx, ipAccessList, api.ReadyType, workflow.AtlasAPIAccessNotConfigured, err)
 	}

--- a/internal/controller/atlasprivateendpoint/atlasprivateendpoint_controller.go
+++ b/internal/controller/atlasprivateendpoint/atlasprivateendpoint_controller.go
@@ -102,11 +102,11 @@ func (r *AtlasPrivateEndpointReconciler) ensureCustomResource(ctx context.Contex
 	if err != nil {
 		return r.terminate(workflowCtx, akoPrivateEndpoint, nil, api.ReadyType, workflow.AtlasAPIAccessNotConfigured, err)
 	}
-	sdkClient, orgID, err := r.AtlasProvider.SdkClient(ctx, credentials, r.Log)
+	sdkClient, _, err := r.AtlasProvider.SdkClient(ctx, credentials, r.Log)
 	if err != nil {
 		return r.terminate(workflowCtx, akoPrivateEndpoint, nil, api.ReadyType, workflow.AtlasAPIAccessNotConfigured, err)
 	}
-	atlasProject, err := r.ResolveProject(ctx, sdkClient, akoPrivateEndpoint, orgID)
+	atlasProject, err := r.ResolveProject(ctx, sdkClient, akoPrivateEndpoint)
 	if err != nil {
 		return r.terminate(workflowCtx, akoPrivateEndpoint, nil, api.ReadyType, workflow.AtlasAPIAccessNotConfigured, err)
 	}

--- a/internal/controller/atlasproject/project.go
+++ b/internal/controller/atlasproject/project.go
@@ -14,13 +14,14 @@ import (
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/controller/customresource"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/controller/workflow"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/indexer"
+	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/translation"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/translation/project"
 )
 
 // handleProject creates the project if it doesn't exist yet. Returns the project ID
 func (r *AtlasProjectReconciler) handleProject(ctx *workflow.Context, orgID string, atlasProject *akov2.AtlasProject, services *AtlasProjectServices) (ctrl.Result, error) {
 	projectInAtlas, err := services.projectService.GetProjectByName(ctx.Context, atlasProject.Spec.Name)
-	if err != nil {
+	if err != nil && !errors.Is(err, translation.ErrNotFound) {
 		return r.terminate(ctx, workflow.ProjectNotCreatedInAtlas, err)
 	}
 

--- a/internal/controller/reconciler/reconciler.go
+++ b/internal/controller/reconciler/reconciler.go
@@ -8,9 +8,8 @@ import (
 	"go.uber.org/zap"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/translation/project"
-
 	akov2 "github.com/mongodb/mongodb-atlas-kubernetes/v2/api/v1"
+	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/translation/project"
 )
 
 type AtlasReconciler struct {
@@ -18,16 +17,16 @@ type AtlasReconciler struct {
 	Log    *zap.SugaredLogger
 }
 
-func (r *AtlasReconciler) ResolveProject(ctx context.Context, sdkClient *admin.APIClient, pro project.ProjectReferrerObject, orgID string) (*project.Project, error) {
+func (r *AtlasReconciler) ResolveProject(ctx context.Context, sdkClient *admin.APIClient, pro project.ProjectReferrerObject) (*project.Project, error) {
+	projectsService := project.NewProjectAPIService(sdkClient.ProjectsApi)
 	pdr := pro.ProjectDualRef()
 	if pdr.ProjectRef != nil {
-		project, err := r.projectFromKube(ctx, pro, orgID)
+		project, err := r.projectFromKube(ctx, pro, projectsService)
 		if err != nil {
 			return nil, fmt.Errorf("failed to query Kubernetes: %w", err)
 		}
 		return project, nil
 	}
-	projectsService := project.NewProjectAPIService(sdkClient.ProjectsApi)
 	prj, err := r.projectFromAtlas(ctx, projectsService, pdr)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get Project from Atlas by ID: %w", err)
@@ -35,12 +34,12 @@ func (r *AtlasReconciler) ResolveProject(ctx context.Context, sdkClient *admin.A
 	return prj, nil
 }
 
-func (r *AtlasReconciler) projectFromKube(ctx context.Context, pro project.ProjectReferrerObject, orgID string) (*project.Project, error) {
+func (r *AtlasReconciler) projectFromKube(ctx context.Context, pro project.ProjectReferrerObject, service project.ProjectService) (*project.Project, error) {
 	kubeProject, err := r.fetchProject(ctx, pro)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get Project from Kubernetes: %w", err)
 	}
-	return project.NewProject(kubeProject, orgID), nil
+	return service.GetProjectByName(ctx, kubeProject.Spec.Name)
 }
 
 func (r *AtlasReconciler) projectFromAtlas(ctx context.Context, projectsService project.ProjectService, pdr *akov2.ProjectDualReference) (*project.Project, error) {

--- a/internal/translation/errors.go
+++ b/internal/translation/errors.go
@@ -1,0 +1,22 @@
+/*
+Copyright 2025 MongoDB.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package translation
+
+import "errors"
+
+// ErrNotFound is the error returned if no entity could be found.
+var ErrNotFound = errors.New("not found")

--- a/internal/translation/project/project_test.go
+++ b/internal/translation/project/project_test.go
@@ -23,7 +23,7 @@ func TestGetProjectByName(t *testing.T) {
 		api      func() admin.ProjectsApi
 		name     string
 		expected *Project
-		err      error
+		err      string
 	}{
 		"should fail to retrieve project from atlas": {
 			api: func() admin.ProjectsApi {
@@ -36,9 +36,9 @@ func TestGetProjectByName(t *testing.T) {
 				return sdk
 			},
 			name: "my-project",
-			err:  errors.New("fail to retrieve project from atlas"),
+			err:  "fail to retrieve project from atlas",
 		},
-		"should return nil when project was not found": {
+		"should return error when project was not found": {
 			api: func() admin.ProjectsApi {
 				sdk := mockadmin.NewProjectsApi(t)
 				sdk.EXPECT().GetProjectByName(context.Background(), "my-project").
@@ -49,6 +49,7 @@ func TestGetProjectByName(t *testing.T) {
 				return sdk
 			},
 			name: "my-project",
+			err:  "not found\n",
 		},
 		"should return project": {
 			api: func() admin.ProjectsApi {
@@ -99,7 +100,11 @@ func TestGetProjectByName(t *testing.T) {
 				projectAPI: tt.api(),
 			}
 			p, err := service.GetProjectByName(context.Background(), tt.name)
-			require.Equal(t, tt.err, err)
+			gotErr := ""
+			if err != nil {
+				gotErr = err.Error()
+			}
+			require.Equal(t, tt.err, gotErr)
 			assert.Equal(t, tt.expected, p)
 		})
 	}


### PR DESCRIPTION
We need to resolve Atlas Projects by name rather than by the status ID in all reconcilers. This is necessary for the upgrade case for both dry-run and the regular upgrade case of AKO.

In the case of regular AKO operator we save a whole unnecessary no-op re-enqueue event just to save the ID in the status.

In the case of dry-run we solve the upgrade case by being able to reference Atlas Projects before mutating state in Kubernetes in the first place.

Since Atlas Project names must be unique in Atlas itself, we can look up the `.spec.name`. attribute if Atlas Projects are being referenced via Kube references.

**NOTE: This MUST NOT be merged before we release 2.7 to avoid risk. This needs soak time**

### All Submissions:

* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if there is one).
* [ ] Update docs/release-notes/release-notes-template.md if your changes should be included in the release notes for the next release.
