### PR TITLE
CLOUDP-298237: Implement greediness deactivation and skips

### DIFF
--- a/internal/controller/atlasproject/project.go
+++ b/internal/controller/atlasproject/project.go
@@ -102,7 +102,7 @@ func (r *AtlasProjectReconciler) delete(ctx *workflow.Context, services *AtlasPr
 			if result := DeleteAllPrivateEndpoints(ctx, atlasProject); !result.IsOk() {
 				return r.terminate(ctx, workflow.ServerlessPrivateEndpointReady, errors.New(result.GetMessage()))
 			}
-			if result := DeleteAllNetworkPeers(ctx.Context, atlasProject.ID(), ctx.SdkClient.NetworkPeeringApi, ctx.Log); !result.IsOk() {
+			if result := DeleteOwnedNetworkPeers(ctx.Context, atlasProject, ctx.SdkClient.NetworkPeeringApi, ctx.Log); !result.IsOk() {
 				return r.terminate(ctx, workflow.ProjectNetworkPeerIsNotReadyInAtlas, errors.New(result.GetMessage()))
 			}
 

--- a/internal/controller/atlasproject/project_test.go
+++ b/internal/controller/atlasproject/project_test.go
@@ -2,6 +2,7 @@ package atlasproject
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"testing"
 
@@ -150,16 +151,8 @@ func TestHandleProject(t *testing.T) {
 					ListPrivateEndpointServicesExecute(admin.ListPrivateEndpointServicesApiRequest{ApiService: mockPrivateEndpointAPI}).
 					Return([]admin.EndpointService{}, nil, nil)
 
-				mockPeeringEndpointAPI := mockadmin.NewNetworkPeeringApi(t)
-				mockPeeringEndpointAPI.EXPECT().ListPeeringConnectionsWithParams(mock.Anything, mock.Anything).
-					Return(admin.ListPeeringConnectionsApiRequest{ApiService: mockPeeringEndpointAPI})
-				mockPeeringEndpointAPI.EXPECT().
-					ListPeeringConnectionsExecute(admin.ListPeeringConnectionsApiRequest{ApiService: mockPeeringEndpointAPI}.PageNum(1)).
-					Return(&admin.PaginatedContainerPeer{}, nil, nil)
-
 				return &admin.APIClient{
 					PrivateEndpointServicesApi: mockPrivateEndpointAPI,
-					NetworkPeeringApi:          mockPeeringEndpointAPI,
 				}
 			},
 			projectServiceMocker: func() project.ProjectService {
@@ -404,6 +397,15 @@ func TestHandleProject(t *testing.T) {
 					Name:       "my-project",
 					Namespace:  "default",
 					Finalizers: []string{customresource.FinalizerLabel},
+					Annotations: map[string]string{
+						// no skipped config, but some fake applied condig on network peerings
+						customresource.AnnotationLastAppliedConfiguration: func() string {
+							d, _ := json.Marshal(&akov2.AtlasProjectSpec{
+								NetworkPeers: []akov2.NetworkPeer{{}},
+							})
+							return string(d)
+						}(),
+					},
 				},
 				Spec: akov2.AtlasProjectSpec{
 					Name: "my-project",
@@ -510,6 +512,15 @@ func TestHandleProject(t *testing.T) {
 					Name:       "my-project",
 					Namespace:  "default",
 					Finalizers: []string{customresource.FinalizerLabel},
+					// no skipped config, but some fake applied condig on network peerings
+					Annotations: map[string]string{
+						customresource.AnnotationLastAppliedConfiguration: func() string {
+							d, _ := json.Marshal(&akov2.AtlasProjectSpec{
+								NetworkPeers: []akov2.NetworkPeer{{}},
+							})
+							return string(d)
+						}(),
+					},
 				},
 				Spec: akov2.AtlasProjectSpec{
 					Name: "my-project",
@@ -618,6 +629,15 @@ func TestHandleProject(t *testing.T) {
 					Name:       "my-project",
 					Namespace:  "default",
 					Finalizers: []string{customresource.FinalizerLabel},
+					// no skipped config, but some fake applied condig on network peerings
+					Annotations: map[string]string{
+						customresource.AnnotationLastAppliedConfiguration: func() string {
+							d, _ := json.Marshal(&akov2.AtlasProjectSpec{
+								NetworkPeers: []akov2.NetworkPeer{{}},
+							})
+							return string(d)
+						}(),
+					},
 				},
 				Spec: akov2.AtlasProjectSpec{
 					Name: "my-project",
@@ -1025,15 +1045,8 @@ func TestDelete(t *testing.T) {
 					ListPrivateEndpointServicesExecute(admin.ListPrivateEndpointServicesApiRequest{ApiService: mockPrivateEndpointAPI}).
 					Return([]admin.EndpointService{}, nil, nil)
 
-				mockPeeringEndpointAPI := mockadmin.NewNetworkPeeringApi(t)
-				mockPeeringEndpointAPI.EXPECT().ListPeeringConnectionsWithParams(mock.Anything, mock.Anything).
-					Return(admin.ListPeeringConnectionsApiRequest{ApiService: mockPeeringEndpointAPI}.PageNum(1))
-				mockPeeringEndpointAPI.EXPECT().
-					ListPeeringConnectionsExecute(admin.ListPeeringConnectionsApiRequest{ApiService: mockPeeringEndpointAPI}.PageNum(1)).
-					Return(&admin.PaginatedContainerPeer{}, nil, nil)
 				return &admin.APIClient{
 					PrivateEndpointServicesApi: mockPrivateEndpointAPI,
-					NetworkPeeringApi:          mockPeeringEndpointAPI,
 				}
 			},
 			projectServiceMocker: func() project.ProjectService {


### PR DESCRIPTION
- Do not delete containers when the last applied list is empty, meaning network peerings were not previously managed by the project controller.
- Skip reconciliation of network peerings when the last skipped list is empty, meaning network peerings had been migrated off the project using the skip reconciliation flag beforehand.
- Skip removal of network peerings when the reconciliation is deactivated (last skipped list is empty), otherwise remove only the owned network peers with IDs recorded in the status.

### All Submissions:

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
