### PR TITLE
CLOUDP-296922: test/int/project: fix conflicting kube updates

### DIFF
--- a/test/int/project_test.go
+++ b/test/int/project_test.go
@@ -397,6 +397,7 @@ var _ = Describe("AtlasProject", Label("int", "AtlasProject"), func() {
 			By("Breaking the Connection Secret", func() {
 				connectionSecret = buildConnectionSecret("my-atlas-key")
 				_, err := akoretry.RetryUpdateOnConflict(context.Background(), k8sClient, client.ObjectKeyFromObject(&connectionSecret), func(s *corev1.Secret) {
+					s.StringData = buildConnectionSecret("my-atlas-key").StringData
 					s.StringData["publicApiKey"] = "non-existing"
 				})
 				Expect(err).To(BeNil())


### PR DESCRIPTION
This fixes potential update conflicts in integration tests for projects. Most notably this fixes a flake like https://github.com/mongodb/mongodb-atlas-kubernetes/actions/runs/12990969241/job/36227793236?pr=2073:

```
2025-01-27T14:25:31.7198927Z   END STEP: Toggling auto-defer to false - /home/runner/work/mongodb-atlas-kubernetes/mongodb-atlas-kubernetes/test/int/project_test.go:610 @ 01/27/25 14:25:29.523 (3ms)
2025-01-27T14:25:31.7199729Z   [FAILED] Expected success, but got an error:
2025-01-27T14:25:31.7200041Z       <*errors.StatusError | 0xc000d3e140>: 
2025-01-27T14:25:31.7200740Z       Operation cannot be fulfilled on atlasprojects.atlas.mongodb.com "test-project": the object has been modified; please apply your changes to the latest version and try again
2025-01-27T14:25:31.7201400Z       {
2025-01-27T14:25:31.7201582Z           ErrStatus: {
2025-01-27T14:25:31.7201820Z               TypeMeta: {Kind: "", APIVersion: ""},
2025-01-27T14:25:31.7202224Z               ListMeta: {
2025-01-27T14:25:31.7202456Z                   SelfLink: "",
2025-01-27T14:25:31.7202699Z                   ResourceVersion: "",
2025-01-27T14:25:31.7202953Z                   Continue: "",
2025-01-27T14:25:31.7203194Z                   RemainingItemCount: nil,
2025-01-27T14:25:31.7203444Z               },
2025-01-27T14:25:31.7203738Z               Status: "Failure",
2025-01-27T14:25:31.7204435Z               Message: "Operation cannot be fulfilled on atlasprojects.atlas.mongodb.com \"test-project\": the object has been modified; please apply your changes to the latest version and try again",
2025-01-27T14:25:31.7205319Z               Reason: "Conflict",
2025-01-27T14:25:31.7205556Z               Details: {
2025-01-27T14:25:31.7205780Z                   Name: "test-project",
2025-01-27T14:25:31.7206052Z                   Group: "atlas.mongodb.com",
2025-01-27T14:25:31.7206324Z                   Kind: "atlasprojects",
2025-01-27T14:25:31.7206575Z                   UID: "",
2025-01-27T14:25:31.7206797Z                   Causes: nil,
2025-01-27T14:25:31.7207085Z                   RetryAfterSeconds: 0,
2025-01-27T14:25:31.7207405Z               },
2025-01-27T14:25:31.7207596Z               Code: 409,
2025-01-27T14:25:31.7207800Z           },
2025-01-27T14:25:31.7208019Z       }
2025-01-27T14:25:31.7208741Z   In [It] at: /home/runner/work/mongodb-atlas-kubernetes/mongodb-atlas-kubernetes/test/int/project_test.go:612 @ 01/27/25 14:25:29.523
```

### All Submissions:

* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if there is one).
* [ ] Update docs/release-notes/release-notes-template.md if your changes should be included in the release notes for the next release.
