### PR TITLE
CLOUDP-301141: test/int/databaseuser_unprotected_test.go: fix concurrent updates

### DIFF
--- a/test/int/databaseuser_unprotected_test.go
+++ b/test/int/databaseuser_unprotected_test.go
@@ -556,7 +556,6 @@ var _ = Describe("Atlas Database User", Label("int", "AtlasDatabaseUser", "prote
 			By("Fixing the user date expiration", func() {
 				after := time.Now().UTC().Add(time.Hour * 10).Format("2006-01-02T15:04:05")
 
-				Expect(k8sClient.Update(context.Background(), testDBUser1)).To(Succeed())
 				retry.RetryUpdateOnConflict(context.Background(), k8sClient, client.ObjectKeyFromObject(testDBUser1), func(user *akov2.AtlasDatabaseUser) {
 					user.Spec.DeleteAfterDate = after
 				})
@@ -571,7 +570,6 @@ var _ = Describe("Atlas Database User", Label("int", "AtlasDatabaseUser", "prote
 			By("Expiring the User", func() {
 				before := time.Now().UTC().Add(time.Minute * -5).Format("2006-01-02T15:04:05")
 
-				Expect(k8sClient.Update(context.Background(), testDBUser1)).To(Succeed())
 				retry.RetryUpdateOnConflict(context.Background(), k8sClient, client.ObjectKeyFromObject(testDBUser1), func(user *akov2.AtlasDatabaseUser) {
 					user.Spec.DeleteAfterDate = before
 				})

--- a/test/int/databaseuser_unprotected_test.go
+++ b/test/int/databaseuser_unprotected_test.go
@@ -556,9 +556,10 @@ var _ = Describe("Atlas Database User", Label("int", "AtlasDatabaseUser", "prote
 			By("Fixing the user date expiration", func() {
 				after := time.Now().UTC().Add(time.Hour * 10).Format("2006-01-02T15:04:05")
 
-				retry.RetryUpdateOnConflict(context.Background(), k8sClient, client.ObjectKeyFromObject(testDBUser1), func(user *akov2.AtlasDatabaseUser) {
+				_, err := retry.RetryUpdateOnConflict(context.Background(), k8sClient, client.ObjectKeyFromObject(testDBUser1), func(user *akov2.AtlasDatabaseUser) {
 					user.Spec.DeleteAfterDate = after
 				})
+				Expect(err).NotTo(HaveOccurred())
 				Eventually(func() bool {
 					return resources.CheckCondition(k8sClient, testDBUser1, api.TrueCondition(api.ReadyType))
 				}).WithTimeout(databaseUserTimeout).WithPolling(PollingInterval).Should(BeTrue())
@@ -570,9 +571,10 @@ var _ = Describe("Atlas Database User", Label("int", "AtlasDatabaseUser", "prote
 			By("Expiring the User", func() {
 				before := time.Now().UTC().Add(time.Minute * -5).Format("2006-01-02T15:04:05")
 
-				retry.RetryUpdateOnConflict(context.Background(), k8sClient, client.ObjectKeyFromObject(testDBUser1), func(user *akov2.AtlasDatabaseUser) {
+				_, err := retry.RetryUpdateOnConflict(context.Background(), k8sClient, client.ObjectKeyFromObject(testDBUser1), func(user *akov2.AtlasDatabaseUser) {
 					user.Spec.DeleteAfterDate = before
 				})
+				Expect(err).NotTo(HaveOccurred())
 				Eventually(func() bool {
 					return resources.CheckCondition(k8sClient, testDBUser1, api.FalseCondition(api.DatabaseUserReadyType).WithReason(string(workflow.DatabaseUserExpired)))
 				}).WithTimeout(databaseUserTimeout).WithPolling(PollingInterval).Should(BeTrue())


### PR DESCRIPTION
Currently, we try to do an update of users in the AtlasDatabaseUser integration test before we start retrying. The first update though can fail with a conflict 409 so it becomes a flake.

This fixes it by removing the update and deferring to `RetryUpdateOnConflict` which is one line below.

### All Submissions:

* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if there is one).
* [ ] Update docs/release-notes/release-notes-template.md if your changes should be included in the release notes for the next release.
