### PR TITLE
CLOUDP-301800: dryrun: add support for namespace filtering

### DIFF
--- a/internal/operator/builder.go
+++ b/internal/operator/builder.go
@@ -226,7 +226,7 @@ func (b *Builder) Build(ctx context.Context) (cluster.Cluster, error) {
 			return nil, fmt.Errorf("failed to initialize event client: %w", err)
 		}
 
-		mgr, err := dryrun.NewManager(c, corev1Client, b.logger)
+		mgr, err := dryrun.NewManager(c, corev1Client, b.logger, b.namespaces)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create dry-run manager: %w", err)
 		}


### PR DESCRIPTION
Currently, Atlas Operator respects the “WATCH_NAMESPACE” environment variable which lets you filter namespaces the operator is watching.

We need to retain this behavior for the dry-run as well as the current code base is wiring cache setup with namespace bindings so we have to respect that in the dry-run manager implementation as well, otherwise behavior will cause errors during the dry-run.

### All Submissions:

* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if there is one).
* [ ] Update docs/release-notes/release-notes-template.md if your changes should be included in the release notes for the next release.
