### PR TITLE
CLOUDP-299771: helm: add flex support

### DIFF
--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -11,7 +11,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{github.event.pull_request.head.sha}}
-          
+          submodules: 'true'
+
       - name: Install devbox
         uses: jetify-com/devbox-install-action@v0.12.0
         with:

--- a/test/helm/flex_test.go
+++ b/test/helm/flex_test.go
@@ -1,0 +1,59 @@
+package helm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	akov2 "github.com/mongodb/mongodb-atlas-kubernetes/v2/api/v1"
+	"github.com/mongodb/mongodb-atlas-kubernetes/v2/api/v1/common"
+	"github.com/mongodb/mongodb-atlas-kubernetes/v2/test/helper/cmd"
+	"github.com/mongodb/mongodb-atlas-kubernetes/v2/test/helper/decoder"
+)
+
+func TestFlexSpec(t *testing.T) {
+	output := cmd.RunCommand(t, "helm", "template", "--values=flex_values.yaml", "../../helm-charts/charts/atlas-deployment")
+	objects := decoder.DecodeAll(t, output)
+
+	var gotDeployment *akov2.AtlasDeployment
+	for _, obj := range objects {
+		if d, ok := obj.(*akov2.AtlasDeployment); ok {
+			if gotDeployment != nil {
+				t.Errorf("Expect one deployment only but also got: %v", d)
+				continue
+			}
+			gotDeployment = d
+		}
+	}
+
+	// ignore
+	gotDeployment.Kind = ""
+	gotDeployment.APIVersion = ""
+	gotDeployment.Labels = nil
+
+	wantDeployment := &akov2.AtlasDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "flex-instance",
+			Namespace: "default",
+		},
+		Spec: akov2.AtlasDeploymentSpec{
+			FlexSpec: &akov2.FlexSpec{
+				Name: "flex-instance",
+				ProviderSettings: &akov2.FlexProviderSettings{
+					BackingProviderName: "AWS",
+					RegionName:          "US_EAST_1",
+				},
+			},
+			ProjectDualReference: akov2.ProjectDualReference{
+				ProjectRef: &common.ResourceRefNamespaced{
+					Name: "release-name-my-project",
+				},
+				ExternalProjectRef: nil,
+				ConnectionSecret:   nil,
+			},
+		},
+	}
+
+	require.Equal(t, wantDeployment, gotDeployment)
+}

--- a/test/helm/flex_values.yaml
+++ b/test/helm/flex_values.yaml
@@ -1,0 +1,6 @@
+deployments:
+  - flexSpec:
+     name: flex-instance
+     providerSettings:
+       backingProviderName: AWS
+       regionName: US_EAST_1

--- a/test/helper/cmd/cmd.go
+++ b/test/helper/cmd/cmd.go
@@ -1,0 +1,23 @@
+package cmd
+
+import (
+	"bytes"
+	"io"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// RunCommand executes the given command with the given arguments
+// and returns the resulting stdout and stderr as an io.Reader.
+//
+// If the command fails to run, the given test is being failed immediately.
+func RunCommand(t *testing.T, name string, args ...string) io.Reader {
+	var result bytes.Buffer
+	cmd := exec.Command(name, args...)
+	cmd.Stdout = &result
+	cmd.Stderr = &result
+	require.NoError(t, cmd.Run())
+	return &result
+}

--- a/test/helper/cmd/cmd.go
+++ b/test/helper/cmd/cmd.go
@@ -18,6 +18,10 @@ func RunCommand(t *testing.T, name string, args ...string) io.Reader {
 	cmd := exec.Command(name, args...)
 	cmd.Stdout = &result
 	cmd.Stderr = &result
-	require.NoError(t, cmd.Run())
+	err := cmd.Run()
+	if err != nil {
+		t.Log(result.String())
+	}
+	require.NoError(t, err)
 	return &result
 }

--- a/test/helper/decoder/decoder.go
+++ b/test/helper/decoder/decoder.go
@@ -2,6 +2,7 @@ package decoder
 
 import (
 	"bufio"
+	"errors"
 	"io"
 	"testing"
 
@@ -29,7 +30,7 @@ func DecodeAll(t *testing.T, from io.Reader) []runtime.Object {
 	var result []runtime.Object
 	for {
 		buf, err := reader.Read()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 		require.NoError(t, err)

--- a/test/helper/decoder/decoder.go
+++ b/test/helper/decoder/decoder.go
@@ -1,0 +1,42 @@
+package decoder
+
+import (
+	"bufio"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/client-go/kubernetes/scheme"
+
+	akov2 "github.com/mongodb/mongodb-atlas-kubernetes/v2/api/v1"
+)
+
+// DecodeAll decodes runtime objects using the core Kubernetes scheme
+// and the AKO scheme.
+//
+// If scheme registration or decoding fails, the given test fails immediately.
+func DecodeAll(t *testing.T, from io.Reader) []runtime.Object {
+	s := runtime.NewScheme()
+	require.NoError(t, scheme.AddToScheme(s))
+	require.NoError(t, akov2.AddToScheme(s))
+
+	decoder := serializer.NewCodecFactory(s).UniversalDeserializer()
+	reader := yaml.NewYAMLReader(bufio.NewReader(from))
+
+	var result []runtime.Object
+	for {
+		buf, err := reader.Read()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
+		obj, _, err := decoder.Decode(buf, nil, nil)
+		require.NoError(t, err)
+		result = append(result, obj)
+	}
+
+	return result
+}


### PR DESCRIPTION
Currently, flex deployments cannot be configured using our helm templates. This fixes it.

This references the changes in https://github.com/mongodb/helm-charts/pull/378.

### All Submissions:

* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if there is one).
* [ ] Update docs/release-notes/release-notes-template.md if your changes should be included in the release notes for the next release.
