### PR TITLE
internal/dryrun: prevent panics during conversion

### DIFF
--- a/internal/dryrun/manager.go
+++ b/internal/dryrun/manager.go
@@ -168,17 +168,13 @@ func (m *Manager) dryRunReconcilers(ctx context.Context) error {
 
 			for _, item := range list.Items {
 				req := reconcile.Request{NamespacedName: client.ObjectKeyFromObject(&item)}
-				if err := m.Cluster.GetScheme().Convert(&item, resource, nil); err != nil {
-					return fmt.Errorf("unable to convert item %T: %w", item, err)
-				}
-
 				_, err := reconciler.Reconcile(ctx, req)
 				if err != nil {
-					if err := m.reportError(ctx, resource, err); err != nil {
+					if err := m.reportError(ctx, &item, err); err != nil {
 						return err
 					}
 				}
-				if err := m.eventf(ctx, resource, corev1.EventTypeNormal, DryRunReason, "done"); err != nil {
+				if err := m.eventf(ctx, &item, corev1.EventTypeNormal, DryRunReason, "done"); err != nil {
 					return err
 				}
 			}

--- a/internal/dryrun/manager_test.go
+++ b/internal/dryrun/manager_test.go
@@ -330,6 +330,44 @@ func TestManager_dryRunReconcilers(t *testing.T) {
 			},
 		},
 		{
+			name: "Should be able to dry-run nested struct fields with unexported fields",
+			reconcilers: []reconciler{
+				&mockReconciler{
+					Resource: &akov2.AtlasProject{},
+					ErrFail:  fmt.Errorf("failed to reconcile"),
+				},
+			},
+			objects: []client.Object{
+				&akov2.AtlasProject{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test",
+						Namespace: "test",
+					},
+					Spec: akov2.AtlasProjectSpec{
+						AlertConfigurations: []akov2.AlertConfiguration{
+							{
+								Notifications: []akov2.Notification{
+									{
+										ChannelName: "foo",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantEvents: []*corev1.Event{
+				{
+					InvolvedObject: corev1.ObjectReference{Kind: "AtlasProject", APIVersion: "atlas.mongodb.com/v1", Namespace: "test", Name: "test"},
+					Message:        "failed to reconcile",
+				},
+				{
+					InvolvedObject: corev1.ObjectReference{Kind: "AtlasProject", APIVersion: "atlas.mongodb.com/v1", Namespace: "test", Name: "test"},
+					Message:        "done",
+				},
+			},
+		},
+		{
 			name: "Should ignore objects from a different namespace",
 			reconcilers: []reconciler{
 				&mockReconciler{


### PR DESCRIPTION
Given the following AtlasProject definition:

```
apiVersion: atlas.mongodb.com/v1
kind: AtlasProject
metadata:
  name: ia-project-growth-db
spec:
  alertConfigurations:
  - notifications:
    - apiTokenRef:
        name: ia-slack-api-token
        namespace: mongodb-atlas-system-dev
      channelName: atlas-growth-platforms-alerts
      typeName: SLACK
```

We are getting a panic from converting to a runtime object because of this upstream issue: https://github.com/kubernetes/kubernetes/issues/124154

However, we can work around this as we don't need to convert at all. The unstructured object already implements the runtime.Object interfaces which can be passed the dry-run reporting functions.

panic: reflect: reflect.Value.Set using value obtained using unexported field

```
goroutine 1 [running]:
reflect.flag.mustBeAssignableSlow(0x1b8)
        /Users/s.urbaniak/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.6.darwin-arm64/src/reflect/value.go:254 +0xf0
reflect.flag.mustBeAssignable(0x1b8)
        /Users/s.urbaniak/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.6.darwin-arm64/src/reflect/value.go:244 +0x60
reflect.Value.Set({0x103177a60, 0x1400068cb48, 0x1b8}, {0x103177a60, 0x1048d10a0, 0x98})
        /Users/s.urbaniak/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.6.darwin-arm64/src/reflect/value.go:2307 +0x38
k8s.io/apimachinery/pkg/runtime.structFromUnstructured({0x10328a840, 0x14000b0f800, 0x15}, {0x1035f6500, 0x1400068cb48, 0x199}, 0x140004a2c90)
        /Users/s.urbaniak/go/pkg/mod/k8s.io/apimachinery@v0.32.2/pkg/runtime/converter.go:556 +0x4f0
k8s.io/apimachinery/pkg/runtime.fromUnstructured({0x10328a840, 0x14000b0f800, 0x15}, {0x1035f6500, 0x1400068cb48, 0x199}, 0x140004a2c90)
        /Users/s.urbaniak/go/pkg/mod/k8s.io/apimachinery@v0.32.2/pkg/runtime/converter.go:359 +0x9ac
k8s.io/apimachinery/pkg/runtime.sliceFromUnstructured({0x103141500, 0x140005dd170, 0x97}, {0x10313f900, 0x140005d8840, 0x197}, 0x140004a2c90)
        /Users/s.urbaniak/go/pkg/mod/k8s.io/apimachinery@v0.32.2/pkg/runtime/converter.go:488 +0x87c
k8s.io/apimachinery/pkg/runtime.fromUnstructured({0x103141500, 0x140005dd170, 0x97}, {0x10313f900, 0x140005d8840, 0x197}, 0x140004a2c90)
        /Users/s.urbaniak/go/pkg/mod/k8s.io/apimachinery@v0.32.2/pkg/runtime/converter.go:355 +0x960
k8s.io/apimachinery/pkg/runtime.structFromUnstructured({0x10328a840, 0x14000b0f7d0, 0x15}, {0x1034c3100, 0x140005d8808, 0x199}, 0x140004a2c90)
        /Users/s.urbaniak/go/pkg/mod/k8s.io/apimachinery@v0.32.2/pkg/runtime/converter.go:550 +0x424
k8s.io/apimachinery/pkg/runtime.fromUnstructured({0x10328a840, 0x14000b0f7d0, 0x15}, {0x1034c3100, 0x140005d8808, 0x199}, 0x140004a2c90)
        /Users/s.urbaniak/go/pkg/mod/k8s.io/apimachinery@v0.32.2/pkg/runtime/converter.go:359 +0x9ac
k8s.io/apimachinery/pkg/runtime.sliceFromUnstructured({0x103141500, 0x140005dd758, 0x97}, {0x10313f940, 0x14000567330, 0x197}, 0x140004a2c90)
        /Users/s.urbaniak/go/pkg/mod/k8s.io/apimachinery@v0.32.2/pkg/runtime/converter.go:488 +0x87c
k8s.io/apimachinery/pkg/runtime.fromUnstructured({0x103141500, 0x140005dd758, 0x97}, {0x10313f940, 0x14000567330, 0x197}, 0x140004a2c90)
        /Users/s.urbaniak/go/pkg/mod/k8s.io/apimachinery@v0.32.2/pkg/runtime/converter.go:355 +
```

This fixes it.

### All Submissions:

* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if there is one).
* [ ] Update docs/release-notes/release-notes-template.md if your changes should be included in the release notes for the next release.
