### PR TITLE
CLOUDP-294105: atlas/provider: remove SdkClient in favor of SdkClientSet

### DIFF
--- a/internal/controller/atlas/provider.go
+++ b/internal/controller/atlas/provider.go
@@ -32,7 +32,6 @@ const (
 
 type Provider interface {
 	Client(ctx context.Context, secretRef *client.ObjectKey, log *zap.SugaredLogger) (*mongodbatlas.Client, string, error)
-	SdkClient(ctx context.Context, secretRef *client.ObjectKey, log *zap.SugaredLogger) (*adminv20231115008.APIClient, string, error)
 	SdkClientSet(ctx context.Context, secretRef *client.ObjectKey, log *zap.SugaredLogger) (*ClientSet, string, error)
 	IsCloudGov() bool
 	IsResourceSupported(resource api.AtlasCustomResource) bool
@@ -123,16 +122,6 @@ func (p *ProductionProvider) Client(ctx context.Context, secretRef *client.Objec
 	c, err := mongodbatlas.New(httpClient, mongodbatlas.SetBaseURL(p.domain), mongodbatlas.SetUserAgent(operatorUserAgent()))
 
 	return c, secretData.OrgID, err
-}
-
-func (p *ProductionProvider) SdkClient(ctx context.Context, secretRef *client.ObjectKey, log *zap.SugaredLogger) (*adminv20231115008.APIClient, string, error) {
-	clientSet, orgID, err := p.SdkClientSet(ctx, secretRef, log)
-	if err != nil {
-		return nil, "", err
-	}
-
-	// Special case: SdkClient only returns the v20231115008 client.
-	return clientSet.SdkClient20231115008, orgID, nil
 }
 
 func (p *ProductionProvider) SdkClientSet(ctx context.Context, secretRef *client.ObjectKey, log *zap.SugaredLogger) (*ClientSet, string, error) {

--- a/internal/controller/atlascustomrole/atlascustomrole_controller.go
+++ b/internal/controller/atlascustomrole/atlascustomrole_controller.go
@@ -129,12 +129,12 @@ func (r *AtlasCustomRoleReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	if err != nil {
 		return r.fail(req, err), nil
 	}
-	atlasSdkClient, _, err := r.AtlasProvider.SdkClient(workflowCtx.Context, credentials, workflowCtx.Log)
+	atlasSdkClientSet, _, err := r.AtlasProvider.SdkClientSet(workflowCtx.Context, credentials, workflowCtx.Log)
 	if err != nil {
 		return r.terminate(workflowCtx, atlasCustomRole, api.ProjectCustomRolesReadyType, workflow.AtlasAPIAccessNotConfigured, true, err), nil
 	}
-	service := customroles.NewCustomRoles(atlasSdkClient.CustomDatabaseRolesApi)
-	project, err := r.ResolveProject(ctx, atlasSdkClient, atlasCustomRole)
+	service := customroles.NewCustomRoles(atlasSdkClientSet.SdkClient20231115008.CustomDatabaseRolesApi)
+	project, err := r.ResolveProject(ctx, atlasSdkClientSet.SdkClient20231115008, atlasCustomRole)
 	if err != nil {
 		return r.terminate(workflowCtx, atlasCustomRole, api.ProjectCustomRolesReadyType, workflow.AtlasAPIAccessNotConfigured, true, err), nil
 	}

--- a/internal/controller/atlascustomrole/atlascustomrole_controller_test.go
+++ b/internal/controller/atlascustomrole/atlascustomrole_controller_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/api"
 	akov2 "github.com/mongodb/mongodb-atlas-kubernetes/v2/api/v1"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/api/v1/status"
+	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/controller/atlas"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/controller/reconciler"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/controller/workflow"
 	atlasmocks "github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/mocks/atlas"
@@ -345,7 +346,7 @@ func TestAtlasCustomRoleReconciler_Reconcile(t *testing.T) {
 				Scheme:        testScheme,
 				EventRecorder: record.NewFakeRecorder(10),
 				AtlasProvider: &atlasmocks.TestProvider{
-					SdkClientFunc: func(secretRef *client.ObjectKey, log *zap.SugaredLogger) (*admin.APIClient, string, error) {
+					SdkSetClientFunc: func(secretRef *client.ObjectKey, log *zap.SugaredLogger) (*atlas.ClientSet, string, error) {
 						if tt.sdkShouldError {
 							return nil, "", fmt.Errorf("failed to create sdk")
 						}
@@ -371,10 +372,10 @@ func TestAtlasCustomRoleReconciler_Reconcile(t *testing.T) {
 							pAPI.EXPECT().GetProjectExecute(admin.GetProjectApiRequest{ApiService: pAPI}).
 								Return(grp, nil, nil)
 						}
-						return &admin.APIClient{
+						return &atlas.ClientSet{SdkClient20231115008: &admin.APIClient{
 							CustomDatabaseRolesApi: cdrAPI,
 							ProjectsApi:            pAPI,
-						}, "", nil
+						}}, "", nil
 					},
 					IsCloudGovFunc: func() bool {
 						return false

--- a/internal/controller/atlasdatabaseuser/databaseuser.go
+++ b/internal/controller/atlasdatabaseuser/databaseuser.go
@@ -48,17 +48,13 @@ func (r *AtlasDatabaseUserReconciler) handleDatabaseUser(ctx *workflow.Context, 
 	if err != nil {
 		return r.terminate(ctx, atlasDatabaseUser, api.DatabaseUserReadyType, workflow.AtlasAPIAccessNotConfigured, true, err)
 	}
-	sdkClient, _, err := r.AtlasProvider.SdkClient(ctx.Context, credentials, r.Log)
-	if err != nil {
-		return r.terminate(ctx, atlasDatabaseUser, api.DatabaseUserReadyType, workflow.AtlasAPIAccessNotConfigured, true, err)
-	}
 	sdkClientSet, _, err := r.AtlasProvider.SdkClientSet(ctx.Context, credentials, r.Log)
 	if err != nil {
 		return r.terminate(ctx, atlasDatabaseUser, api.DatabaseUserReadyType, workflow.AtlasAPIAccessNotConfigured, true, err)
 	}
-	dbUserService := dbuser.NewAtlasUsers(sdkClient.DatabaseUsersApi)
-	deploymentService := deployment.NewAtlasDeployments(sdkClient.ClustersApi, sdkClient.ServerlessInstancesApi, sdkClient.GlobalClustersApi, sdkClientSet.SdkClient20241113001.FlexClustersApi, r.AtlasProvider.IsCloudGov())
-	atlasProject, err := r.ResolveProject(ctx.Context, sdkClient, atlasDatabaseUser)
+	dbUserService := dbuser.NewAtlasUsers(sdkClientSet.SdkClient20231115008.DatabaseUsersApi)
+	deploymentService := deployment.NewAtlasDeployments(sdkClientSet.SdkClient20231115008.ClustersApi, sdkClientSet.SdkClient20231115008.ServerlessInstancesApi, sdkClientSet.SdkClient20231115008.GlobalClustersApi, sdkClientSet.SdkClient20241113001.FlexClustersApi, r.AtlasProvider.IsCloudGov())
+	atlasProject, err := r.ResolveProject(ctx.Context, sdkClientSet.SdkClient20231115008, atlasDatabaseUser)
 	if err != nil {
 		return r.terminate(ctx, atlasDatabaseUser, api.DatabaseUserReadyType, workflow.AtlasAPIAccessNotConfigured, true, err)
 	}

--- a/internal/controller/atlasdeployment/atlasdeployment_controller.go
+++ b/internal/controller/atlasdeployment/atlasdeployment_controller.go
@@ -136,23 +136,19 @@ func (r *AtlasDeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	if err != nil {
 		return r.terminate(workflowCtx, workflow.AtlasAPIAccessNotConfigured, err)
 	}
-	sdkClient, _, err := r.AtlasProvider.SdkClient(workflowCtx.Context, credentials, r.Log)
-	if err != nil {
-		return r.terminate(workflowCtx, workflow.AtlasAPIAccessNotConfigured, err)
-	}
-	workflowCtx.SdkClient = sdkClient
 	sdkClientSet, _, err := r.AtlasProvider.SdkClientSet(workflowCtx.Context, credentials, r.Log)
 	if err != nil {
 		return r.terminate(workflowCtx, workflow.AtlasAPIAccessNotConfigured, err)
 	}
+	workflowCtx.SdkClient = sdkClientSet.SdkClient20231115008
 	workflowCtx.SdkClientSet = sdkClientSet
 	workflowCtx.Client, _, err = r.AtlasProvider.Client(workflowCtx.Context, credentials, r.Log)
 	if err != nil {
 		return r.terminate(workflowCtx, workflow.AtlasAPIAccessNotConfigured, err)
 	}
-	projectService := project.NewProjectAPIService(sdkClient.ProjectsApi)
-	deploymentService := deployment.NewAtlasDeployments(sdkClient.ClustersApi, sdkClient.ServerlessInstancesApi, sdkClient.GlobalClustersApi, sdkClientSet.SdkClient20241113001.FlexClustersApi, r.AtlasProvider.IsCloudGov())
-	atlasProject, err := r.ResolveProject(workflowCtx.Context, sdkClient, atlasDeployment)
+	projectService := project.NewProjectAPIService(sdkClientSet.SdkClient20231115008.ProjectsApi)
+	deploymentService := deployment.NewAtlasDeployments(sdkClientSet.SdkClient20231115008.ClustersApi, sdkClientSet.SdkClient20231115008.ServerlessInstancesApi, sdkClientSet.SdkClient20231115008.GlobalClustersApi, sdkClientSet.SdkClient20241113001.FlexClustersApi, r.AtlasProvider.IsCloudGov())
+	atlasProject, err := r.ResolveProject(workflowCtx.Context, sdkClientSet.SdkClient20231115008, atlasDeployment)
 	if err != nil {
 		return r.terminate(workflowCtx, workflow.AtlasAPIAccessNotConfigured, err)
 	}

--- a/internal/controller/atlasdeployment/atlasdeployment_controller_test.go
+++ b/internal/controller/atlasdeployment/atlasdeployment_controller_test.go
@@ -1328,7 +1328,6 @@ func TestChangeDeploymentType(t *testing.T) {
 					return &mongodbatlas.Client{}, "org-id", nil
 				},
 				SdkSetClientFunc: func(secretRef *client.ObjectKey, log *zap.SugaredLogger) (*atlas.ClientSet, string, error) {
-
 					serverlessAPI := mockadmin.NewServerlessInstancesApi(t)
 					serverlessAPI.EXPECT().GetServerlessInstance(mock.Anything, "abc123", "cluster0").
 						Return(admin.GetServerlessInstanceApiRequest{ApiService: serverlessAPI})

--- a/internal/controller/atlasfederatedauth/atlasfederated_auth_controller.go
+++ b/internal/controller/atlasfederatedauth/atlasfederated_auth_controller.go
@@ -89,21 +89,14 @@ func (r *AtlasFederatedAuthReconciler) Reconcile(ctx context.Context, req ctrl.R
 		return result.ReconcileResult(), nil
 	}
 
-	atlasClient, orgID, err := r.AtlasProvider.SdkClient(workflowCtx.Context, fedauth.ConnectionSecretObjectKey(), log)
+	atlasClientSet, orgID, err := r.AtlasProvider.SdkClientSet(workflowCtx.Context, fedauth.ConnectionSecretObjectKey(), log)
 	if err != nil {
 		result := workflow.Terminate(workflow.AtlasAPIAccessNotConfigured, err)
 		setCondition(workflowCtx, api.FederatedAuthReadyType, result)
 		return result.ReconcileResult(), nil
 	}
 
-	atlasClientSet, _, err := r.AtlasProvider.SdkClientSet(workflowCtx.Context, fedauth.ConnectionSecretObjectKey(), log)
-	if err != nil {
-		result := workflow.Terminate(workflow.AtlasAPIAccessNotConfigured, err)
-		setCondition(workflowCtx, api.FederatedAuthReadyType, result)
-		return result.ReconcileResult(), nil
-	}
-
-	workflowCtx.SdkClient = atlasClient
+	workflowCtx.SdkClient = atlasClientSet.SdkClient20231115008
 	workflowCtx.SdkClientSet = atlasClientSet
 	workflowCtx.OrgID = orgID
 

--- a/internal/controller/atlasfederatedauth/atlasfederated_auth_controller_test.go
+++ b/internal/controller/atlasfederatedauth/atlasfederated_auth_controller_test.go
@@ -157,13 +157,13 @@ func TestReconcile(t *testing.T) {
 			)
 		atlasProvider := atlasmock.TestProvider{
 			SdkSetClientFunc: func(secretRef *client.ObjectKey, log *zap.SugaredLogger) (*atlas.ClientSet, string, error) {
-				return &atlas.ClientSet{SdkClient20241113001: &adminv20241113001.APIClient{
-					FederatedAuthenticationApi: fedAuthAPI,
-				}}, orgID, nil
-			},
-			SdkClientFunc: func(secretRef *client.ObjectKey, log *zap.SugaredLogger) (*admin.APIClient, string, error) {
-				return &admin.APIClient{
-					ProjectsApi: groupAPI,
+				return &atlas.ClientSet{
+					SdkClient20231115008: &admin.APIClient{
+						ProjectsApi: groupAPI,
+					},
+					SdkClient20241113001: &adminv20241113001.APIClient{
+						FederatedAuthenticationApi: fedAuthAPI,
+					},
 				}, orgID, nil
 			},
 			IsCloudGovFunc: func() bool {

--- a/internal/controller/atlasipaccesslist/atlasipaccesslist_controller_test.go
+++ b/internal/controller/atlasipaccesslist/atlasipaccesslist_controller_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/atlas-sdk/v20231115008/admin"
 	"go.mongodb.org/atlas-sdk/v20231115008/mockadmin"
+	adminv20241113001 "go.mongodb.org/atlas-sdk/v20241113001/admin"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -46,7 +47,7 @@ func TestReconcile(t *testing.T) {
 				IsSupportedFunc: func() bool {
 					return true
 				},
-				SdkClientFunc: func(secretRef *client.ObjectKey, log *zap.SugaredLogger) (*admin.APIClient, string, error) {
+				SdkSetClientFunc: func(secretRef *client.ObjectKey, log *zap.SugaredLogger) (*atlas.ClientSet, string, error) {
 					ialAPI := mockadmin.NewProjectIPAccessListApi(t)
 					ialAPI.EXPECT().ListProjectIpAccessLists(mock.Anything, "123").
 						Return(admin.ListProjectIpAccessListsApiRequest{ApiService: ialAPI})
@@ -77,9 +78,12 @@ func TestReconcile(t *testing.T) {
 					projectAPI.EXPECT().GetProjectByNameExecute(mock.Anything).
 						Return(&admin.Group{Id: pointer.MakePtr("123")}, nil, nil)
 
-					return &admin.APIClient{
-						ProjectIPAccessListApi: ialAPI,
-						ProjectsApi:            projectAPI,
+					return &atlas.ClientSet{
+						SdkClient20231115008: &admin.APIClient{
+							ProjectIPAccessListApi: ialAPI,
+							ProjectsApi:            projectAPI,
+						},
+						SdkClient20241113001: &adminv20241113001.APIClient{},
 					}, "", nil
 				},
 			},

--- a/internal/controller/atlasipaccesslist/state.go
+++ b/internal/controller/atlasipaccesslist/state.go
@@ -45,15 +45,15 @@ func (r *AtlasIPAccessListReconciler) handleCustomResource(ctx context.Context, 
 	if err != nil {
 		return r.terminate(workflowCtx, ipAccessList, api.ReadyType, workflow.AtlasAPIAccessNotConfigured, err)
 	}
-	sdkClient, _, err := r.AtlasProvider.SdkClient(ctx, credentials, r.Log)
+	sdkClientSet, _, err := r.AtlasProvider.SdkClientSet(ctx, credentials, r.Log)
 	if err != nil {
 		return r.terminate(workflowCtx, ipAccessList, api.ReadyType, workflow.AtlasAPIAccessNotConfigured, err)
 	}
-	atlasProject, err := r.ResolveProject(ctx, sdkClient, ipAccessList)
+	atlasProject, err := r.ResolveProject(ctx, sdkClientSet.SdkClient20231115008, ipAccessList)
 	if err != nil {
 		return r.terminate(workflowCtx, ipAccessList, api.ReadyType, workflow.AtlasAPIAccessNotConfigured, err)
 	}
-	ipAccessListService := ipaccesslist.NewIPAccessList(sdkClient.ProjectIPAccessListApi)
+	ipAccessListService := ipaccesslist.NewIPAccessList(sdkClientSet.SdkClient20231115008.ProjectIPAccessListApi)
 
 	return r.handleIPAccessList(workflowCtx, ipAccessListService, atlasProject.ID, ipAccessList)
 }

--- a/internal/controller/atlasipaccesslist/state_test.go
+++ b/internal/controller/atlasipaccesslist/state_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/atlas-sdk/v20231115008/admin"
 	"go.mongodb.org/atlas-sdk/v20231115008/mockadmin"
+	adminv20241113001 "go.mongodb.org/atlas-sdk/v20241113001/admin"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -179,7 +180,7 @@ func TestHandleCustomResource(t *testing.T) {
 				IsSupportedFunc: func() bool {
 					return true
 				},
-				SdkClientFunc: func(secretRef *client.ObjectKey, log *zap.SugaredLogger) (*admin.APIClient, string, error) {
+				SdkSetClientFunc: func(secretRef *client.ObjectKey, log *zap.SugaredLogger) (*atlas.ClientSet, string, error) {
 					return nil, "", errors.New("failed to create sdk")
 				},
 			},
@@ -217,8 +218,10 @@ func TestHandleCustomResource(t *testing.T) {
 				IsSupportedFunc: func() bool {
 					return true
 				},
-				SdkClientFunc: func(secretRef *client.ObjectKey, log *zap.SugaredLogger) (*admin.APIClient, string, error) {
-					return &admin.APIClient{}, "", nil
+				SdkSetClientFunc: func(secretRef *client.ObjectKey, log *zap.SugaredLogger) (*atlas.ClientSet, string, error) {
+					return &atlas.ClientSet{
+						SdkClient20231115008: &admin.APIClient{},
+					}, "", nil
 				},
 			},
 			expectedResult: ctrl.Result{RequeueAfter: workflow.DefaultRetry},
@@ -256,7 +259,7 @@ func TestHandleCustomResource(t *testing.T) {
 				IsSupportedFunc: func() bool {
 					return true
 				},
-				SdkClientFunc: func(secretRef *client.ObjectKey, log *zap.SugaredLogger) (*admin.APIClient, string, error) {
+				SdkSetClientFunc: func(secretRef *client.ObjectKey, log *zap.SugaredLogger) (*atlas.ClientSet, string, error) {
 					ialAPI := mockadmin.NewProjectIPAccessListApi(t)
 					ialAPI.EXPECT().ListProjectIpAccessLists(mock.Anything, "123").
 						Return(admin.ListProjectIpAccessListsApiRequest{ApiService: ialAPI})
@@ -287,9 +290,12 @@ func TestHandleCustomResource(t *testing.T) {
 					projectAPI.EXPECT().GetProjectByNameExecute(mock.Anything).
 						Return(&admin.Group{Id: pointer.MakePtr("123")}, nil, nil)
 
-					return &admin.APIClient{
-						ProjectIPAccessListApi: ialAPI,
-						ProjectsApi:            projectAPI,
+					return &atlas.ClientSet{
+						SdkClient20231115008: &admin.APIClient{
+							ProjectIPAccessListApi: ialAPI,
+							ProjectsApi:            projectAPI,
+						},
+						SdkClient20241113001: &adminv20241113001.APIClient{},
 					}, "", nil
 				},
 			},

--- a/internal/controller/atlasprivateendpoint/atlasprivateendpoint_controller.go
+++ b/internal/controller/atlasprivateendpoint/atlasprivateendpoint_controller.go
@@ -102,15 +102,15 @@ func (r *AtlasPrivateEndpointReconciler) ensureCustomResource(ctx context.Contex
 	if err != nil {
 		return r.terminate(workflowCtx, akoPrivateEndpoint, nil, api.ReadyType, workflow.AtlasAPIAccessNotConfigured, err)
 	}
-	sdkClient, _, err := r.AtlasProvider.SdkClient(ctx, credentials, r.Log)
+	sdkClientSet, _, err := r.AtlasProvider.SdkClientSet(ctx, credentials, r.Log)
 	if err != nil {
 		return r.terminate(workflowCtx, akoPrivateEndpoint, nil, api.ReadyType, workflow.AtlasAPIAccessNotConfigured, err)
 	}
-	atlasProject, err := r.ResolveProject(ctx, sdkClient, akoPrivateEndpoint)
+	atlasProject, err := r.ResolveProject(ctx, sdkClientSet.SdkClient20231115008, akoPrivateEndpoint)
 	if err != nil {
 		return r.terminate(workflowCtx, akoPrivateEndpoint, nil, api.ReadyType, workflow.AtlasAPIAccessNotConfigured, err)
 	}
-	privateEndpointService := privateendpoint.NewPrivateEndpointAPI(sdkClient.PrivateEndpointServicesApi)
+	privateEndpointService := privateendpoint.NewPrivateEndpointAPI(sdkClientSet.SdkClient20231115008.PrivateEndpointServicesApi)
 
 	return r.handlePrivateEndpointService(workflowCtx, privateEndpointService, atlasProject.ID, akoPrivateEndpoint)
 }

--- a/internal/controller/atlasproject/atlasproject_controller.go
+++ b/internal/controller/atlasproject/atlasproject_controller.go
@@ -146,18 +146,18 @@ func (r *AtlasProjectReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return result.ReconcileResult(), nil
 	}
 
-	atlasSdkClient, orgID, err := r.AtlasProvider.SdkClient(workflowCtx.Context, atlasProject.ConnectionSecretObjectKey(), log)
+	atlasSdkClient, orgID, err := r.AtlasProvider.SdkClientSet(workflowCtx.Context, atlasProject.ConnectionSecretObjectKey(), log)
 	if err != nil {
 		result := workflow.Terminate(workflow.AtlasAPIAccessNotConfigured, err)
 		setCondition(workflowCtx, api.ProjectReadyType, result)
 		return result.ReconcileResult(), nil
 	}
-	workflowCtx.SdkClient = atlasSdkClient
+	workflowCtx.SdkClient = atlasSdkClient.SdkClient20231115008
 	services := AtlasProjectServices{}
-	services.projectService = project.NewProjectAPIService(atlasSdkClient.ProjectsApi)
-	services.teamsService = teams.NewTeamsAPIService(atlasSdkClient.TeamsApi, atlasSdkClient.MongoDBCloudUsersApi)
-	services.maintenanceService = maintenancewindow.NewMaintenanceWindowAPIService(atlasSdkClient.MaintenanceWindowsApi)
-	services.encryptionAtRestService = encryptionatrest.NewEncryptionAtRestAPI(atlasSdkClient.EncryptionAtRestUsingCustomerKeyManagementApi)
+	services.projectService = project.NewProjectAPIService(atlasSdkClient.SdkClient20231115008.ProjectsApi)
+	services.teamsService = teams.NewTeamsAPIService(atlasSdkClient.SdkClient20231115008.TeamsApi, atlasSdkClient.SdkClient20231115008.MongoDBCloudUsersApi)
+	services.maintenanceService = maintenancewindow.NewMaintenanceWindowAPIService(atlasSdkClient.SdkClient20231115008.MaintenanceWindowsApi)
+	services.encryptionAtRestService = encryptionatrest.NewEncryptionAtRestAPI(atlasSdkClient.SdkClient20231115008.EncryptionAtRestUsingCustomerKeyManagementApi)
 
 	atlasClient, _, err := r.AtlasProvider.Client(workflowCtx.Context, atlasProject.ConnectionSecretObjectKey(), log)
 	if err != nil {

--- a/internal/controller/atlasproject/atlasproject_controller_test.go
+++ b/internal/controller/atlasproject/atlasproject_controller_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/atlas-sdk/v20231115008/admin"
 	"go.mongodb.org/atlas-sdk/v20231115008/mockadmin"
+	adminv20241113001 "go.mongodb.org/atlas-sdk/v20241113001/admin"
 	"go.mongodb.org/atlas/mongodbatlas"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
@@ -29,6 +30,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/api"
 	akov2 "github.com/mongodb/mongodb-atlas-kubernetes/v2/api/v1"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/api/v1/common"
+	atlas_controllers "github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/controller/atlas"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/controller/customresource"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/controller/workflow"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/indexer"
@@ -142,8 +144,11 @@ func TestRenconcile(t *testing.T) {
 					ClientFunc: func(secretRef *client.ObjectKey, log *zap.SugaredLogger) (*mongodbatlas.Client, string, error) {
 						return tt.atlasClientMocker(), "", nil
 					},
-					SdkClientFunc: func(secretRef *client.ObjectKey, log *zap.SugaredLogger) (*admin.APIClient, string, error) {
-						return tt.atlasSDKMocker(), "", nil
+					SdkSetClientFunc: func(secretRef *client.ObjectKey, log *zap.SugaredLogger) (*atlas_controllers.ClientSet, string, error) {
+						return &atlas_controllers.ClientSet{
+							SdkClient20231115008: tt.atlasSDKMocker(),
+							SdkClient20241113001: &adminv20241113001.APIClient{},
+						}, "", nil
 					},
 				},
 			}

--- a/internal/controller/atlasproject/team_reconciler.go
+++ b/internal/controller/atlasproject/team_reconciler.go
@@ -58,14 +58,14 @@ func (r *AtlasProjectReconciler) teamReconcile(
 			return result.ReconcileResult(), nil
 		}
 
-		atlasClient, orgID, err := r.AtlasProvider.SdkClient(teamCtx.Context, connectionSecretKey, log)
+		atlasClient, orgID, err := r.AtlasProvider.SdkClientSet(teamCtx.Context, connectionSecretKey, log)
 		if err != nil {
 			result := workflow.Terminate(workflow.AtlasAPIAccessNotConfigured, err)
 			setCondition(teamCtx, api.ReadyType, result)
 			return result.ReconcileResult(), nil
 		}
 		teamCtx.OrgID = orgID
-		teamCtx.SdkClient = atlasClient
+		teamCtx.SdkClient = atlasClient.SdkClient20231115008
 
 		teamID, result := r.ensureTeamState(teamCtx, teamsService, team)
 		if !result.IsOk() {

--- a/internal/controller/atlasstream/atlasstream_instance_controller.go
+++ b/internal/controller/atlasstream/atlasstream_instance_controller.go
@@ -93,11 +93,11 @@ func (r *AtlasStreamsInstanceReconciler) ensureAtlasStreamsInstance(ctx context.
 		return r.terminate(workflowCtx, workflow.Internal, err)
 	}
 
-	atlasClient, orgID, err := r.AtlasProvider.SdkClient(workflowCtx.Context, project.ConnectionSecretObjectKey(), log)
+	atlasClient, orgID, err := r.AtlasProvider.SdkClientSet(workflowCtx.Context, project.ConnectionSecretObjectKey(), log)
 	if err != nil {
 		return r.terminate(workflowCtx, workflow.AtlasAPIAccessNotConfigured, err)
 	}
-	workflowCtx.SdkClient = atlasClient
+	workflowCtx.SdkClient = atlasClient.SdkClient20231115008
 	workflowCtx.OrgID = orgID
 
 	atlasStreamInstance, _, err := workflowCtx.SdkClient.StreamsApi.

--- a/internal/controller/atlasstream/atlasstream_instance_controller_test.go
+++ b/internal/controller/atlasstream/atlasstream_instance_controller_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"go.mongodb.org/atlas-sdk/v20231115008/admin"
 	"go.mongodb.org/atlas-sdk/v20231115008/mockadmin"
+	adminv20241113001 "go.mongodb.org/atlas-sdk/v20241113001/admin"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 	"go.uber.org/zap/zaptest/observer"
@@ -27,6 +28,7 @@ import (
 	akov2 "github.com/mongodb/mongodb-atlas-kubernetes/v2/api/v1"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/api/v1/common"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/api/v1/status"
+	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/controller/atlas"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/controller/customresource"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/controller/workflow"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/indexer"
@@ -375,7 +377,7 @@ func TestEnsureAtlasStreamsInstance(t *testing.T) {
 				IsSupportedFunc: func() bool {
 					return true
 				},
-				SdkClientFunc: func(secretRef *client.ObjectKey, log *zap.SugaredLogger) (*admin.APIClient, string, error) {
+				SdkSetClientFunc: func(secretRef *client.ObjectKey, log *zap.SugaredLogger) (*atlas.ClientSet, string, error) {
 					return nil, "", errors.New("failed to configure sdk client")
 				},
 			},
@@ -471,8 +473,11 @@ func TestEnsureAtlasStreamsInstance(t *testing.T) {
 				IsSupportedFunc: func() bool {
 					return true
 				},
-				SdkClientFunc: func(secretRef *client.ObjectKey, log *zap.SugaredLogger) (*admin.APIClient, string, error) {
-					return &admin.APIClient{StreamsApi: streamsAPI}, "org-id", nil
+				SdkSetClientFunc: func(secretRef *client.ObjectKey, log *zap.SugaredLogger) (*atlas.ClientSet, string, error) {
+					return &atlas.ClientSet{
+						SdkClient20231115008: &admin.APIClient{StreamsApi: streamsAPI},
+						SdkClient20241113001: &adminv20241113001.APIClient{},
+					}, "", nil
 				},
 			},
 		}
@@ -594,8 +599,11 @@ func TestEnsureAtlasStreamsInstance(t *testing.T) {
 				IsSupportedFunc: func() bool {
 					return true
 				},
-				SdkClientFunc: func(secretRef *client.ObjectKey, log *zap.SugaredLogger) (*admin.APIClient, string, error) {
-					return &admin.APIClient{StreamsApi: streamsAPI}, "org-id", nil
+				SdkSetClientFunc: func(secretRef *client.ObjectKey, log *zap.SugaredLogger) (*atlas.ClientSet, string, error) {
+					return &atlas.ClientSet{
+						SdkClient20231115008: &admin.APIClient{StreamsApi: streamsAPI},
+						SdkClient20241113001: &adminv20241113001.APIClient{},
+					}, "", nil
 				},
 			},
 		}
@@ -707,8 +715,11 @@ func TestEnsureAtlasStreamsInstance(t *testing.T) {
 				IsSupportedFunc: func() bool {
 					return true
 				},
-				SdkClientFunc: func(secretRef *client.ObjectKey, log *zap.SugaredLogger) (*admin.APIClient, string, error) {
-					return &admin.APIClient{StreamsApi: streamsAPI}, "org-id", nil
+				SdkSetClientFunc: func(secretRef *client.ObjectKey, log *zap.SugaredLogger) (*atlas.ClientSet, string, error) {
+					return &atlas.ClientSet{
+						SdkClient20231115008: &admin.APIClient{StreamsApi: streamsAPI},
+						SdkClient20241113001: &adminv20241113001.APIClient{},
+					}, "", nil
 				},
 			},
 		}
@@ -823,8 +834,11 @@ func TestEnsureAtlasStreamsInstance(t *testing.T) {
 				IsSupportedFunc: func() bool {
 					return true
 				},
-				SdkClientFunc: func(secretRef *client.ObjectKey, log *zap.SugaredLogger) (*admin.APIClient, string, error) {
-					return &admin.APIClient{StreamsApi: streamsAPI}, "org-id", nil
+				SdkSetClientFunc: func(secretRef *client.ObjectKey, log *zap.SugaredLogger) (*atlas.ClientSet, string, error) {
+					return &atlas.ClientSet{
+						SdkClient20231115008: &admin.APIClient{StreamsApi: streamsAPI},
+						SdkClient20241113001: &adminv20241113001.APIClient{},
+					}, "org-id", nil
 				},
 			},
 		}
@@ -937,8 +951,11 @@ func TestEnsureAtlasStreamsInstance(t *testing.T) {
 				IsSupportedFunc: func() bool {
 					return true
 				},
-				SdkClientFunc: func(secretRef *client.ObjectKey, log *zap.SugaredLogger) (*admin.APIClient, string, error) {
-					return &admin.APIClient{StreamsApi: streamsAPI}, "org-id", nil
+				SdkSetClientFunc: func(secretRef *client.ObjectKey, log *zap.SugaredLogger) (*atlas.ClientSet, string, error) {
+					return &atlas.ClientSet{
+						SdkClient20231115008: &admin.APIClient{StreamsApi: streamsAPI},
+						SdkClient20241113001: &adminv20241113001.APIClient{},
+					}, "org-id", nil
 				},
 			},
 		}

--- a/internal/mocks/atlas/provider.go
+++ b/internal/mocks/atlas/provider.go
@@ -3,7 +3,6 @@ package atlas
 import (
 	"context"
 
-	"go.mongodb.org/atlas-sdk/v20231115008/admin"
 	"go.mongodb.org/atlas/mongodbatlas"
 	"go.uber.org/zap"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -14,7 +13,6 @@ import (
 
 type TestProvider struct {
 	ClientFunc       func(secretRef *client.ObjectKey, log *zap.SugaredLogger) (*mongodbatlas.Client, string, error)
-	SdkClientFunc    func(secretRef *client.ObjectKey, log *zap.SugaredLogger) (*admin.APIClient, string, error)
 	SdkSetClientFunc func(secretRef *client.ObjectKey, log *zap.SugaredLogger) (*atlas.ClientSet, string, error)
 	IsCloudGovFunc   func() bool
 	IsSupportedFunc  func() bool
@@ -22,10 +20,6 @@ type TestProvider struct {
 
 func (f *TestProvider) Client(_ context.Context, secretRef *client.ObjectKey, log *zap.SugaredLogger) (*mongodbatlas.Client, string, error) {
 	return f.ClientFunc(secretRef, log)
-}
-
-func (f *TestProvider) SdkClient(_ context.Context, secretRef *client.ObjectKey, log *zap.SugaredLogger) (*admin.APIClient, string, error) {
-	return f.SdkClientFunc(secretRef, log)
 }
 
 func (f *TestProvider) IsCloudGov() bool {

--- a/internal/translation/client.go
+++ b/internal/translation/client.go
@@ -12,9 +12,9 @@ import (
 )
 
 func NewVersionedClient(ctx context.Context, provider atlas.Provider, secretRef *types.NamespacedName, log *zap.SugaredLogger) (*admin.APIClient, error) {
-	apiClient, _, err := provider.SdkClient(ctx, secretRef, log)
+	apiClientSet, _, err := provider.SdkClientSet(ctx, secretRef, log)
 	if err != nil {
 		return nil, fmt.Errorf("failed to instantiate Versioned Atlas client: %w", err)
 	}
-	return apiClient, nil
+	return apiClientSet.SdkClient20231115008, nil
 }

--- a/internal/translation/datafederation/datafederation_test.go
+++ b/internal/translation/datafederation/datafederation_test.go
@@ -6,10 +6,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"k8s.io/apimachinery/pkg/types"
-
 	"go.mongodb.org/atlas-sdk/v20231115008/admin"
+	adminv20241113001 "go.mongodb.org/atlas-sdk/v20241113001/admin"
 	"go.uber.org/zap"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/controller/atlas"
@@ -25,15 +25,18 @@ func TestNewDatafederationService(t *testing.T) {
 		{
 			name: "success",
 			provider: &atlasmocks.TestProvider{
-				SdkClientFunc: func(_ *client.ObjectKey, _ *zap.SugaredLogger) (*admin.APIClient, string, error) {
-					return &admin.APIClient{}, "", nil
+				SdkSetClientFunc: func(secretRef *client.ObjectKey, log *zap.SugaredLogger) (*atlas.ClientSet, string, error) {
+					return &atlas.ClientSet{
+						SdkClient20231115008: &admin.APIClient{},
+						SdkClient20241113001: &adminv20241113001.APIClient{},
+					}, "", nil
 				},
 			},
 		},
 		{
 			name: "failure",
 			provider: &atlasmocks.TestProvider{
-				SdkClientFunc: func(_ *client.ObjectKey, _ *zap.SugaredLogger) (*admin.APIClient, string, error) {
+				SdkSetClientFunc: func(secretRef *client.ObjectKey, log *zap.SugaredLogger) (*atlas.ClientSet, string, error) {
 					return nil, "", errors.New("fake error")
 				},
 			},

--- a/internal/translation/dbuser/dbuser_test.go
+++ b/internal/translation/dbuser/dbuser_test.go
@@ -11,11 +11,13 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/atlas-sdk/v20231115008/admin"
 	"go.mongodb.org/atlas-sdk/v20231115008/mockadmin"
+	adminv20241113001 "go.mongodb.org/atlas-sdk/v20241113001/admin"
 	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	akov2 "github.com/mongodb/mongodb-atlas-kubernetes/v2/api/v1"
+	atlas_controller "github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/controller/atlas"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/mocks/atlas"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/pointer"
 )
@@ -23,8 +25,11 @@ import (
 func TestNewAtlasDatabaseUsersService(t *testing.T) {
 	ctx := context.Background()
 	provider := &atlas.TestProvider{
-		SdkClientFunc: func(_ *client.ObjectKey, _ *zap.SugaredLogger) (*admin.APIClient, string, error) {
-			return &admin.APIClient{}, "", nil
+		SdkSetClientFunc: func(secretRef *client.ObjectKey, log *zap.SugaredLogger) (*atlas_controller.ClientSet, string, error) {
+			return &atlas_controller.ClientSet{
+				SdkClient20231115008: &admin.APIClient{},
+				SdkClient20241113001: &adminv20241113001.APIClient{},
+			}, "", nil
 		},
 	}
 	secretRef := &types.NamespacedName{}
@@ -38,7 +43,7 @@ func TestFailedNewAtlasDatabaseUsersService(t *testing.T) {
 	expectedErr := errors.New("fake error")
 	ctx := context.Background()
 	provider := &atlas.TestProvider{
-		SdkClientFunc: func(_ *client.ObjectKey, _ *zap.SugaredLogger) (*admin.APIClient, string, error) {
+		SdkSetClientFunc: func(secretRef *client.ObjectKey, log *zap.SugaredLogger) (*atlas_controller.ClientSet, string, error) {
 			return nil, "", expectedErr
 		},
 	}


### PR DESCRIPTION
This is the first cleanup PR that addresses the refactoring of the SDK clientset in favor of better semantics. This first change removes the `SdkClient` function in favor of `SdkClientSet` as we want to push using client sets in the code only.

### All Submissions:

* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if there is one).
* [ ] Update docs/release-notes/release-notes-template.md if your changes should be included in the release notes for the next release.
