### PR TITLE
CLOUDP-303005: Allow Serverless Alerts to specify decimal thresholds by @tvdw-mongodb

### DIFF
--- a/api/v1/alert_configurations.go
+++ b/api/v1/alert_configurations.go
@@ -360,9 +360,16 @@ func (in *MetricThreshold) IsEqual(threshold *admin.ServerlessMetricThreshold) b
 	if threshold == nil {
 		return false
 	}
+	thresholdFloat, err := strconv.ParseFloat(in.Threshold, 64)
+	if err != nil {
+		// A parsing error means we're not equal, because the other object has a valid
+		// value. The actual error will be returned when calling ToAtlas.
+		return false
+	}
+
 	return in.MetricName == threshold.GetMetricName() &&
 		in.Operator == threshold.GetOperator() &&
-		in.Threshold == strconv.FormatInt(int64(threshold.GetThreshold()), 10) &&
+		thresholdFloat == threshold.GetThreshold() &&
 		in.Units == threshold.GetUnits() &&
 		in.Mode == threshold.GetMode()
 }

--- a/api/v1/alert_configurations_test.go
+++ b/api/v1/alert_configurations_test.go
@@ -1,0 +1,128 @@
+package v1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/atlas-sdk/v20231115008/admin"
+
+	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/pointer"
+)
+
+func TestServerlessMetricThreshold(t *testing.T) {
+	tests := []struct {
+		name      string
+		akoData   *MetricThreshold
+		atlasData *admin.ServerlessMetricThreshold
+		equal     bool
+	}{
+		{
+			name: "Should be able to parse float Theshold",
+			atlasData: &admin.ServerlessMetricThreshold{
+				MetricName: "test",
+				Mode:       pointer.MakePtr("test"),
+				Operator:   pointer.MakePtr("IN"),
+				Threshold:  pointer.MakePtr(3.14),
+				Units:      pointer.MakePtr("test"),
+			},
+			akoData: &MetricThreshold{
+				MetricName: "test",
+				Operator:   "IN",
+				Threshold:  "3.14",
+				Units:      "test",
+				Mode:       "test",
+			},
+			equal: true,
+		},
+		{
+			name: "Should be able to parse int Theshold",
+			atlasData: &admin.ServerlessMetricThreshold{
+				MetricName: "test",
+				Mode:       pointer.MakePtr("test"),
+				Operator:   pointer.MakePtr("IN"),
+				Threshold:  pointer.MakePtr[float64](3),
+				Units:      pointer.MakePtr("test"),
+			},
+			akoData: &MetricThreshold{
+				MetricName: "test",
+				Operator:   "IN",
+				Threshold:  "3",
+				Units:      "test",
+				Mode:       "test",
+			},
+			equal: true,
+		},
+		{
+			name: "Should be false if Theshold is not a number",
+			atlasData: &admin.ServerlessMetricThreshold{
+				MetricName: "test",
+				Mode:       pointer.MakePtr("test"),
+				Operator:   pointer.MakePtr("IN"),
+				Threshold:  pointer.MakePtr(3.14),
+				Units:      pointer.MakePtr("test"),
+			},
+			akoData: &MetricThreshold{
+				MetricName: "test",
+				Operator:   "IN",
+				Threshold:  "13InvalidFloat",
+				Units:      "test",
+				Mode:       "test",
+			},
+			equal: false,
+		},
+		{
+			name:      "Should be false input is nil",
+			atlasData: nil,
+			akoData: &MetricThreshold{
+				MetricName: "test",
+				Operator:   "IN",
+				Threshold:  "3.14",
+				Units:      "test",
+				Mode:       "test",
+			},
+			equal: false,
+		},
+		{
+			name: "Should be false if operator mismatched",
+			atlasData: &admin.ServerlessMetricThreshold{
+				MetricName: "test",
+				Mode:       pointer.MakePtr("test"),
+				Operator:   pointer.MakePtr("IN"),
+				Threshold:  pointer.MakePtr(3.14),
+				Units:      pointer.MakePtr("test"),
+			},
+			akoData: &MetricThreshold{
+				MetricName: "test",
+				Operator:   "LOWER",
+				Threshold:  "3.14",
+				Units:      "test",
+				Mode:       "test",
+			},
+			equal: false,
+		},
+		{
+			name: "Should fail if Threshold mismatched",
+			atlasData: &admin.ServerlessMetricThreshold{
+				MetricName: "test",
+				Mode:       pointer.MakePtr("test"),
+				Operator:   pointer.MakePtr("IN"),
+				Threshold:  pointer.MakePtr(3.14),
+				Units:      pointer.MakePtr("test"),
+			},
+			akoData: &MetricThreshold{
+				MetricName: "test",
+				Operator:   "IN",
+				Threshold:  "2.718",
+				Units:      "test",
+				Mode:       "test",
+			},
+			equal: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.equal, tt.akoData.IsEqual(tt.atlasData))
+		})
+	}
+}


### PR DESCRIPTION
### All Submissions:

Allow Serverless Alerts to specify decimal thresholds by @tvdw-mongodb

* [x] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if there is one).
* [ ] Update docs/release-notes/release-notes-template.md if your changes should be included in the release notes for the next release.
