### PR TITLE
CLOUDP-301799: bump kubernetes versions

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -20,9 +20,9 @@ jobs:
         name: Compute Test Matrix
         run: |
           # Note the use of external single quotes to allow for double quotes at inline YAML array
-          matrix='["v1.29.12-kind"]'
+          matrix='["v1.30.10-kind"]'
           if [ "${{ github.ref }}" == "refs/heads/main" ];then
-            matrix='["v1.29.12-kind", "v1.31.4-kind"]'
+            matrix='["v1.30.10-kind", "v1.32.2-kind"]'
           fi
           echo "matrix=${matrix}" >> "${GITHUB_OUTPUT}"
           cat "${GITHUB_OUTPUT}"

--- a/docs/dev/ci.md
+++ b/docs/dev/ci.md
@@ -108,7 +108,7 @@ Adjust the `matrix` variable in the above workflow to match the desired Kubernet
 
 Additionally, adjust the `ENVTEST_K8S_VERSION` variable in the `Makefile` as well.
 
-Finally, adjust the minimum Kubernetes version ("1.27.1" in the above example) in the [Atlas Kubernetes CLI repository](https://github.com/mongodb/atlas-cli-plugin-kubernetes] plugin) as well. Here, a Kubernetes cluster is being created for e2e tests programmatically. Bump and adjust the Kubernetes version in its `go.mod` file: https://github.com/mongodb/atlas-cli-plugin-kubernetes/blob/d34c4b18930b0cd77dc6013d52669161edb224d5/go.mod#L32.
+Finally, adjust the minimum Kubernetes version ("1.27.1" in the above example) in the [Atlas Kubernetes CLI repository](https://github.com/mongodb/atlas-cli-plugin-kubernetes] plugin) as well. Here, a Kubernetes cluster is being created for e2e tests programmatically. Bump and adjust the Kubernetes version in its `go.mod` file: https://github.com/mongodb/atlas-cli-plugin-kubernetes/blob/d34c4b18930b0cd77dc6013d52669161edb224d5/go.mod#L32 for the kind version and https://github.com/mongodb/atlas-cli-plugin-kubernetes/blob/d5b2610dd50e312e315b63d1bfd0d7dde244b262/test/e2e/operator_helper_test.go#L91-L98 for the actual Kubernetes version.
 
 ### Test Variants
 

--- a/docs/dev/ci.md
+++ b/docs/dev/ci.md
@@ -71,6 +71,8 @@ Note **Gov e2e tests** are never run on PRs.
 
 The [test-e2e.yml](../../.github/workflows/test-e2e.yml) workflow builds a test image and a bundle before running the tests. It also has to *compute* the version(s) of Kubernetes to test against. The Kubernetes version in PRs is set purposefully to the oldest kubernetes version. On scheduled nightly runs we test on both the latest and oldest supported versions.
 
+##### Kubernetes Version Matrix
+
 The version list selection is done by parameterising the kind image tag within the **strategy** **matrix** at the [test-e2e](../../.github/workflows/test-e2e.yml) workflow. Eg:
 
 ```yaml
@@ -101,6 +103,12 @@ The version list selection is done by parameterising the kind image tag within t
         k8s: ${{fromJson(needs.compute.outputs.test_matrix)}}
         ...
 ```
+
+Adjust the `matrix` variable in the above workflow to match the desired Kubernetes versions. It migh also be necessary to bump the `kind` version and the `kind-action` version in various workflows, see https://github.com/mongodb/mongodb-atlas-kubernetes/pull/2082 as an example.
+
+Additionally, adjust the `ENVTEST_K8S_VERSION` variable in the `Makefile` as well.
+
+Finally, adjust the minimum Kubernetes version ("1.27.1" in the above example) in the [Atlas Kubernetes CLI repository](https://github.com/mongodb/atlas-cli-plugin-kubernetes] plugin) as well. Here, a Kubernetes cluster is being created for e2e tests programmatically. Bump and adjust the Kubernetes version in its `go.mod` file: https://github.com/mongodb/atlas-cli-plugin-kubernetes/blob/d34c4b18930b0cd77dc6013d52669161edb224d5/go.mod#L32.
 
 ### Test Variants
 

--- a/docs/dev/release.md
+++ b/docs/dev/release.md
@@ -17,7 +17,13 @@ Most tools are automatically installed for you. Most of them are Go binaries and
 - [devbox](https://www.jetify.com/devbox) to be able to enter a sandbox development environment that includes necessary tools for the release process.
 - [Docker](https://www.docker.com/) to be able to deal with containers.
 
-## Before starting the Release
+## Release preparations (minimum n-1 weeks before the actual release)
+
+At least **one** (1) week before the release the Kubernetes Version testing matrix has to be updated both in this repository and the CLI repository https://github.com/mongodb/mongodb-atlas-cli.
+
+Please refer to the [CI documentation](ci.md) and submit a pull request, example: https://github.com/mongodb/mongodb-atlas-kubernetes/pull/2161 or https://github.com/mongodb/mongodb-atlas-kubernetes/pull/2082.
+
+## Release Notes
 
 - Create a draft of the release notes in a Google Document and share with Product and the Docs team.
 - Ensure as well that supporting documents for new features are in review.

--- a/docs/dev/release.md
+++ b/docs/dev/release.md
@@ -21,7 +21,7 @@ Most tools are automatically installed for you. Most of them are Go binaries and
 
 At least **one** (1) week before the release the Kubernetes Version testing matrix has to be updated both in this repository and the CLI repository https://github.com/mongodb/mongodb-atlas-cli.
 
-Please refer to the [CI documentation](ci.md) and submit a pull request, example: https://github.com/mongodb/mongodb-atlas-kubernetes/pull/2161 or https://github.com/mongodb/mongodb-atlas-kubernetes/pull/2082.
+Please refer to the [CI documentation](ci.md#kubernetes-version-matrix) and submit a pull request, example: https://github.com/mongodb/mongodb-atlas-kubernetes/pull/2161 or https://github.com/mongodb/mongodb-atlas-kubernetes/pull/2082.
 
 ## Release Notes
 


### PR DESCRIPTION
This bumps the Kubernetes version test matrix to 1.30-1.32.

### All Submissions:

* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if there is one).
* [ ] Update docs/release-notes/release-notes-template.md if your changes should be included in the release notes for the next release.
