### PR TITLE
CLOUDP-298827: move OWNERS to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*   @mongodb/atlas_kubernetes_team

--- a/OWNERS
+++ b/OWNERS
@@ -1,3 +1,0 @@
- #Github owners file. Docs: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-file-location
-
-* @igor-karpukhin @helderjs @roothorp @josvazg @s-urbaniak


### PR DESCRIPTION
This moves OWNERS to .github/CODEOWNERS as per https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-file-location and sets up our team for it.

### All Submissions:

* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if there is one).
* [ ] Update docs/release-notes/release-notes-template.md if your changes should be included in the release notes for the next release.
