### PR TITLE
CLOUDP-303935: cloud-test.yml: remove dependency from codecov

### DIFF
--- a/.github/workflows/cloud-tests.yml
+++ b/.github/workflows/cloud-tests.yml
@@ -25,27 +25,6 @@ jobs:
     steps:
       - name: allowed message
         run: echo "Allowed to run"
-      - name: check Github action bot comment
-        if: github.event_name == 'pull_request'
-        uses: peter-evans/find-comment@v3
-        id: find-bot-comment
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          comment-author: github-actions[bot]
-          body-includes: 'https://app.codecov.io/github/mongodb/mongodb-atlas-kubernetes/commit'
-      - name: edit comment if exists
-        if:  github.event_name == 'pull_request' && steps.find-bot-comment.outputs.comment-id != ''
-        uses: peter-evans/create-or-update-comment@v4
-        with:
-          edit-mode: replace
-          comment-id: ${{ steps.find-bot-comment.outputs.comment-id }}
-          body: https://app.codecov.io/github/mongodb/mongodb-atlas-kubernetes/commit/${{ github.event.pull_request.head.sha }}
-      - name: comment PR
-        if: github.event_name == 'pull_request' && steps.find-bot-comment.outputs.comment-id == ''
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh pr comment ${{ github.event.pull_request.number }} -R mongodb/mongodb-atlas-kubernetes -b "https://app.codecov.io/github/mongodb/mongodb-atlas-kubernetes/commit/${{ github.event.pull_request.head.sha }}"
 
   int-tests:
     needs: allowed


### PR DESCRIPTION
Today, running cloud-tests depends on certain labels but also on the availability to assert codecov comments: https://github.com/mongodb/mongodb-atlas-kubernetes/blob/ca781f006c4ed3367b6e860a9156c26111875705/.github/workflows/cloud-tests.yml#L28-L48

This fails for contributions from forked repositories, i.e. https://github.com/mongodb/mongodb-atlas-kubernetes/pull/2162.

This fixes it.

### All Submissions:

* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if there is one).
* [ ] Update docs/release-notes/release-notes-template.md if your changes should be included in the release notes for the next release.
