### PR TITLE
CLOUDP-305569: Fix autoscaling compute comparison.

### DIFF
--- a/internal/translation/deployment/compare.go
+++ b/internal/translation/deployment/compare.go
@@ -298,16 +298,21 @@ func diskAutoscalingConfigAreEqual(desired, current *akov2.DiskGB) bool {
 }
 
 func computeAutoscalingConfigAreEqual(desired, current *akov2.ComputeSpec) bool {
-	if desired == nil && current == nil {
-		return true
+	if desired == nil {
+		desired = &akov2.ComputeSpec{}
 	}
 
-	if (desired != nil && current == nil) || (desired == nil && current != nil) {
-		return false
+	if current == nil {
+		current = &akov2.ComputeSpec{}
 	}
 
 	if desired.Enabled != nil && !areEqual(desired.Enabled, current.Enabled) {
 		return false
+	}
+
+	// If autoscaling is disabled rest of fields don't matter.
+	if desired.Enabled == nil || !*desired.Enabled {
+		return true
 	}
 
 	if desired.ScaleDownEnabled != nil && !areEqual(desired.ScaleDownEnabled, current.ScaleDownEnabled) {


### PR DESCRIPTION
Fixes the autoscaling compute comparison:

* A nil compute spec is equivalent to a compute spec with Enabled set to false.
* A disabled compute spec is equivalent to any other disabled compute spec regardless of the rest of fields.

### All Submissions:

* [ X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if there is one).
* [ ] Update docs/release-notes/release-notes-template.md if your changes should be included in the release notes for the next release.
