### PR TITLE
CLOUDP-299772: Remove last skipped config

### DIFF
--- a/internal/controller/atlasproject/atlasproject_controller.go
+++ b/internal/controller/atlasproject/atlasproject_controller.go
@@ -378,7 +378,7 @@ func lastAppliedSpecFrom(atlasProject *akov2.AtlasProject) (*akov2.AtlasProjectS
 }
 
 func (r *AtlasProjectReconciler) clearLastAppliedMigratedResources(ctx context.Context, atlasProject *akov2.AtlasProject) error {
-	lastCfg, err := customresource.ParseLastConfigApplied(&akov2.AtlasProjectSpec{}, atlasProject)
+	lastCfg, err := customresource.ParseLastConfigApplied[akov2.AtlasProjectSpec](atlasProject)
 	if err != nil {
 		return fmt.Errorf("failed to parse last applied config annotation: %w", err)
 	}

--- a/internal/controller/atlasproject/atlasproject_controller.go
+++ b/internal/controller/atlasproject/atlasproject_controller.go
@@ -388,7 +388,12 @@ func (r *AtlasProjectReconciler) clearLastAppliedMigratedResources(ctx context.C
 	lastCfg.PrivateEndpoints = nil
 	lastCfg.ProjectIPAccessList = nil
 	lastCfg.NetworkPeers = nil
-	if err := customresource.ApplyLastConfigApplied(ctx, &akov2.AtlasProject{Spec: *lastCfg}, r.Client); err != nil {
+	shallowCopy := akov2.AtlasProject{
+		TypeMeta:   atlasProject.TypeMeta,
+		ObjectMeta: atlasProject.ObjectMeta,
+		Spec:       *lastCfg,
+	}
+	if err := customresource.ApplyLastConfigApplied(ctx, &shallowCopy, r.Client); err != nil {
 		return fmt.Errorf("failed to apply last applied config annotation: %w", err)
 	}
 	return nil

--- a/internal/controller/atlasproject/atlasproject_controller.go
+++ b/internal/controller/atlasproject/atlasproject_controller.go
@@ -382,6 +382,9 @@ func (r *AtlasProjectReconciler) clearLastAppliedMigratedResources(ctx context.C
 	if err != nil {
 		return fmt.Errorf("failed to parse last applied config annotation: %w", err)
 	}
+	if clearedCfg == nil { // nothing to patch
+		return nil
+	}
 	// clear all resources migrated as independent CRDs to avoid eager
 	// reconciliation that might conflict with independent CRs and apply
 	clearedCfg.CustomRoles = nil

--- a/internal/controller/atlasproject/atlasproject_controller.go
+++ b/internal/controller/atlasproject/atlasproject_controller.go
@@ -110,11 +110,7 @@ func (r *AtlasProjectReconciler) Reconcile(ctx context.Context, req ctrl.Request
 			}
 		}
 
-		err := customresource.ApplyLastConfigSkipped(ctx, atlasProject, r.Client)
-		if err != nil {
-			log.Errorw("Failed to apply last skipped config", "error", err)
-			return workflow.Terminate(workflow.Internal, err).ReconcileResult(), nil
-		}
+		// TODO: clear last applied for type
 
 		return workflow.OK().ReconcileResult(), nil
 	}

--- a/internal/controller/atlasproject/atlasproject_controller_test.go
+++ b/internal/controller/atlasproject/atlasproject_controller_test.go
@@ -420,9 +420,8 @@ func TestLastSpecFrom(t *testing.T) {
 
 		"should return nil when there is no last spec": {},
 		"should return error when last spec annotation is wrong": {
-			annotations: map[string]string{"mongodb.com/last-applied-configuration": "{wrong}"},
-			expectedError: "error parsing JSON annotation value [{wrong}] into a v1.AtlasProjectSpec:" +
-				" invalid character 'w' looking for beginning of object key string",
+			annotations:   map[string]string{"mongodb.com/last-applied-configuration": "{wrong}"},
+			expectedError: "invalid character 'w' looking for beginning of object key string",
 		},
 		"should return last spec": {
 			annotations: map[string]string{"mongodb.com/last-applied-configuration": "{\"name\": \"my-project\"}"},

--- a/internal/controller/atlasproject/atlasproject_controller_test.go
+++ b/internal/controller/atlasproject/atlasproject_controller_test.go
@@ -504,7 +504,7 @@ func TestSkipClearsMigratedResourcesLastConfig(t *testing.T) {
 	require.Equal(t, reconcile.Result{}, result)
 	require.NoError(t, err)
 	require.NoError(t, k8sClient.Get(ctx, client.ObjectKeyFromObject(&prj), &prj))
-	lastApplied, err := customresource.ParseLastConfigApplied(&akov2.AtlasProjectSpec{}, &prj)
+	lastApplied, err := customresource.ParseLastConfigApplied[akov2.AtlasProjectSpec](&prj)
 	require.NoError(t, err)
 	wantLastApplied := &akov2.AtlasProjectSpec{
 		Name:                      "test-project",

--- a/internal/controller/atlasproject/atlasproject_controller_test.go
+++ b/internal/controller/atlasproject/atlasproject_controller_test.go
@@ -419,7 +419,7 @@ func TestLastSpecFrom(t *testing.T) {
 		"should return nil when there is no last spec": {},
 		"should return error when last spec annotation is wrong": {
 			annotations: map[string]string{"mongodb.com/last-applied-configuration": "{wrong}"},
-			expectedError: "error reading AtlasProject Spec from annotation [mongodb.com/last-applied-configuration]:" +
+			expectedError: "error parsing JSON annotation value [{wrong}] into a v1.AtlasProjectSpec:" +
 				" invalid character 'w' looking for beginning of object key string",
 		},
 		"should return last spec": {

--- a/internal/controller/atlasproject/atlasproject_controller_test.go
+++ b/internal/controller/atlasproject/atlasproject_controller_test.go
@@ -499,7 +499,9 @@ func TestSkipClearsMigratedResourcesLastConfig(t *testing.T) {
 			},
 		},
 	}
+
 	result, err := r.Reconcile(ctx, req)
+
 	require.Equal(t, reconcile.Result{}, result)
 	require.NoError(t, err)
 	require.NoError(t, k8sClient.Get(ctx, client.ObjectKeyFromObject(&prj), &prj))

--- a/internal/controller/atlasproject/custom_roles_test.go
+++ b/internal/controller/atlasproject/custom_roles_test.go
@@ -21,57 +21,6 @@ import (
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/pointer"
 )
 
-func TestShouldCustomRolesSkipReconciling(t *testing.T) {
-	tests := []struct {
-		name        string
-		annotations map[string]string
-		expected    bool
-		shouldFail  bool
-	}{
-		{
-			name:        "No annotations present",
-			annotations: map[string]string{},
-			expected:    false,
-			shouldFail:  false,
-		},
-		{
-			name:        "Annotation present but invalid JSON",
-			annotations: map[string]string{customresource.AnnotationLastSkippedConfiguration: "invalid"},
-			expected:    false,
-			shouldFail:  true,
-		},
-		{
-			name:        "Annotation present with empty CustomRoles",
-			annotations: map[string]string{customresource.AnnotationLastSkippedConfiguration: "{\"CustomRoles\": []}"},
-			expected:    true,
-			shouldFail:  false,
-		},
-		{
-			name:        "Annotation present with non-empty CustomRoles",
-			annotations: map[string]string{customresource.AnnotationLastSkippedConfiguration: "{\"CustomRoles\": [{\"Name\": \"role1\"}]}"},
-			expected:    false,
-			shouldFail:  false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			atlasProject := &akov2.AtlasProject{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: tt.annotations,
-				},
-			}
-			result, err := shouldCustomRolesSkipReconciling(atlasProject)
-			if tt.shouldFail {
-				assert.Error(t, err)
-			} else {
-				assert.NoError(t, err)
-			}
-			assert.Equal(t, tt.expected, result)
-		})
-	}
-}
-
 func TestEnsureCustomRoles(t *testing.T) {
 	testRole := []akov2.CustomRole{
 		{

--- a/internal/controller/atlasproject/ipaccess_list.go
+++ b/internal/controller/atlasproject/ipaccess_list.go
@@ -1,7 +1,6 @@
 package atlasproject
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"reflect"
@@ -9,7 +8,6 @@ import (
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/api"
 	akov2 "github.com/mongodb/mongodb-atlas-kubernetes/v2/api/v1"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/api/v1/status"
-	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/controller/customresource"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/controller/workflow"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/translation/ipaccesslist"
 )
@@ -130,18 +128,6 @@ func handleIPAccessList(ctx *workflow.Context, project *akov2.AtlasProject) work
 	ctx.Log.Debug("starting ip access list processing")
 	defer ctx.Log.Debug("finished ip access list processing")
 
-	skipped, err := shouldIPAccessListSkipReconciliation(project)
-	if err != nil {
-		return workflow.Terminate(workflow.Internal, err)
-	}
-
-	if skipped {
-		ctx.EnsureStatusOption(status.AtlasProjectExpiredIPAccessOption(nil))
-		ctx.UnsetCondition(api.IPAccessListReadyType)
-
-		return workflow.OK()
-	}
-
 	lastApplied, err := mapLastAppliedIPAccessList(project)
 	if err != nil {
 		return workflow.Terminate(workflow.Internal, fmt.Errorf("failed to get last applied configuration: %w", err))
@@ -155,20 +141,6 @@ func handleIPAccessList(ctx *workflow.Context, project *akov2.AtlasProject) work
 	}
 
 	return c.reconcile()
-}
-
-func shouldIPAccessListSkipReconciliation(atlasProject *akov2.AtlasProject) (bool, error) {
-	lastSkippedSpec := akov2.AtlasProjectSpec{}
-	lastSkippedSpecString, ok := atlasProject.Annotations[customresource.AnnotationLastSkippedConfiguration]
-	if ok {
-		if err := json.Unmarshal([]byte(lastSkippedSpecString), &lastSkippedSpec); err != nil {
-			return false, fmt.Errorf("failed to parse last skipped configuration: %w", err)
-		}
-
-		return len(lastSkippedSpec.ProjectIPAccessList) == 0, nil
-	}
-
-	return false, nil
 }
 
 func mapLastAppliedIPAccessList(atlasProject *akov2.AtlasProject) (ipaccesslist.IPAccessEntries, error) {

--- a/internal/controller/atlasproject/ipaccess_list_test.go
+++ b/internal/controller/atlasproject/ipaccess_list_test.go
@@ -379,7 +379,7 @@ func TestHandleIPAccessList(t *testing.T) {
 			expectedCalls: func(apiMock *mockadmin.ProjectIPAccessListApi) admin.ProjectIPAccessListApi {
 				return apiMock
 			},
-			expectedResult: workflow.Terminate(workflow.Internal, errors.New("failed to get last applied configuration: error parsing JSON annotation value [{wrong}] into a v1.AtlasProjectSpec: invalid character 'w' looking for beginning of object key string")),
+			expectedResult: workflow.Terminate(workflow.Internal, errors.New("failed to get last applied configuration: error reading AtlasProject Spec from annotation [mongodb.com/last-applied-configuration]: invalid character 'w' looking for beginning of object key string")),
 		},
 		"should successfully handle ip access list reconciliation": {
 			expectedCalls: func(apiMock *mockadmin.ProjectIPAccessListApi) admin.ProjectIPAccessListApi {
@@ -495,9 +495,8 @@ func TestMapLastAppliedIPAccessList(t *testing.T) {
 		expectedError       string
 	}{
 		"should return error when last spec annotation is wrong": {
-			annotations: map[string]string{customresource.AnnotationLastAppliedConfiguration: "{wrong}"},
-			expectedError: "error parsing JSON annotation value [{wrong}] into a v1.AtlasProjectSpec:" +
-				" invalid character 'w' looking for beginning of object key string",
+			annotations:   map[string]string{customresource.AnnotationLastAppliedConfiguration: "{wrong}"},
+			expectedError: "invalid character 'w' looking for beginning of object key string",
 		},
 		"should return nil when there is no last spec": {},
 		"should return map of last ip access list": {

--- a/internal/controller/atlasproject/ipaccess_list_test.go
+++ b/internal/controller/atlasproject/ipaccess_list_test.go
@@ -379,7 +379,7 @@ func TestHandleIPAccessList(t *testing.T) {
 			expectedCalls: func(apiMock *mockadmin.ProjectIPAccessListApi) admin.ProjectIPAccessListApi {
 				return apiMock
 			},
-			expectedResult: workflow.Terminate(workflow.Internal, errors.New("failed to get last applied configuration: error reading AtlasProject Spec from annotation [mongodb.com/last-applied-configuration]: invalid character 'w' looking for beginning of object key string")),
+			expectedResult: workflow.Terminate(workflow.Internal, errors.New("failed to get last applied configuration: error parsing JSON annotation value [{wrong}] into a v1.AtlasProjectSpec: invalid character 'w' looking for beginning of object key string")),
 		},
 		"should successfully handle ip access list reconciliation": {
 			expectedCalls: func(apiMock *mockadmin.ProjectIPAccessListApi) admin.ProjectIPAccessListApi {
@@ -496,7 +496,7 @@ func TestMapLastAppliedIPAccessList(t *testing.T) {
 	}{
 		"should return error when last spec annotation is wrong": {
 			annotations: map[string]string{customresource.AnnotationLastAppliedConfiguration: "{wrong}"},
-			expectedError: "error reading AtlasProject Spec from annotation [mongodb.com/last-applied-configuration]:" +
+			expectedError: "error parsing JSON annotation value [{wrong}] into a v1.AtlasProjectSpec:" +
 				" invalid character 'w' looking for beginning of object key string",
 		},
 		"should return nil when there is no last spec": {},

--- a/internal/controller/atlasproject/ipaccess_list_test.go
+++ b/internal/controller/atlasproject/ipaccess_list_test.go
@@ -374,21 +374,6 @@ func TestHandleIPAccessList(t *testing.T) {
 		expectedResult     workflow.Result
 		expectedConditions []api.Condition
 	}{
-		"should fail resolving last skipped flag": {
-			annotations: map[string]string{customresource.AnnotationLastSkippedConfiguration: "{wrong}"},
-			expectedCalls: func(apiMock *mockadmin.ProjectIPAccessListApi) admin.ProjectIPAccessListApi {
-				return apiMock
-			},
-			expectedResult: workflow.Terminate(workflow.Internal, errors.New("failed to parse last skipped configuration: invalid character 'w' looking for beginning of object key string")),
-		},
-		"should skip reconciliation": {
-			annotations: map[string]string{customresource.AnnotationLastSkippedConfiguration: "{\"projectIpAccessList\": []}"},
-			expectedCalls: func(apiMock *mockadmin.ProjectIPAccessListApi) admin.ProjectIPAccessListApi {
-				return apiMock
-			},
-			expectedResult:     workflow.OK(),
-			expectedConditions: []api.Condition{},
-		},
 		"should fail getting last applied configuration": {
 			annotations: map[string]string{customresource.AnnotationLastAppliedConfiguration: "{wrong}"},
 			expectedCalls: func(apiMock *mockadmin.ProjectIPAccessListApi) admin.ProjectIPAccessListApi {
@@ -539,42 +524,6 @@ func TestMapLastAppliedIPAccessList(t *testing.T) {
 				assert.ErrorContains(t, err, tt.expectedError)
 			}
 			assert.Equal(t, tt.expectedIPAccessLst, result)
-		})
-	}
-}
-
-func TestHasSkippedIPAccessListConfiguration(t *testing.T) {
-	tests := map[string]struct {
-		annotations   map[string]string
-		expected      bool
-		expectedError string
-	}{
-		"should return error when last spec annotation is wrong": {
-			annotations: map[string]string{customresource.AnnotationLastSkippedConfiguration: "{wrong}"},
-			expectedError: "failed to parse last skipped configuration:" +
-				" invalid character 'w' looking for beginning of object key string",
-		},
-		"should return false when there is no annotation": {},
-		"should return false where there are last ip access list": {
-			annotations: map[string]string{
-				customresource.AnnotationLastSkippedConfiguration: "{\"projectIpAccessList\": [{\"ipAddress\":\"192.168.0.100\"},{\"awsSecurityGroup\":\"sg-123456\",\"comment\":\"My AWS SG\"}]}"},
-		},
-		"should return true where last ip access list is empty": {
-			annotations: map[string]string{
-				customresource.AnnotationLastSkippedConfiguration: "{\"projectIpAccessList\": []}"},
-			expected: true,
-		},
-	}
-	for name, tt := range tests {
-		t.Run(name, func(t *testing.T) {
-			p := &akov2.AtlasProject{}
-			p.WithAnnotations(tt.annotations)
-
-			result, err := shouldIPAccessListSkipReconciliation(p)
-			if err != nil {
-				assert.ErrorContains(t, err, tt.expectedError)
-			}
-			assert.Equal(t, tt.expected, result)
 		})
 	}
 }

--- a/internal/controller/atlasproject/private_endpoint.go
+++ b/internal/controller/atlasproject/private_endpoint.go
@@ -2,9 +2,7 @@ package atlasproject
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
-	"fmt"
 	"net/http"
 
 	"go.mongodb.org/atlas-sdk/v20231115008/admin"
@@ -14,26 +12,12 @@ import (
 	akov2 "github.com/mongodb/mongodb-atlas-kubernetes/v2/api/v1"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/api/v1/provider"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/api/v1/status"
-	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/controller/customresource"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/controller/workflow"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/set"
 )
 
 func ensurePrivateEndpoint(workflowCtx *workflow.Context, project *akov2.AtlasProject) workflow.Result {
-	skipped, err := hasSkippedPrivateEndpointConfiguration(project)
-	if err != nil {
-		return workflow.Terminate(workflow.Internal, err)
-	}
-
-	if skipped {
-		workflowCtx.EnsureStatusOption(status.AtlasProjectAddPrivateEndpointsOption(nil))
-		workflowCtx.UnsetCondition(api.PrivateEndpointServiceReadyType)
-		workflowCtx.UnsetCondition(api.PrivateEndpointReadyType)
-
-		return workflow.OK()
-	}
-
 	specPEs := project.Spec.DeepCopy().PrivateEndpoints
 
 	lastAppliedPEs, err := mapLastAppliedPrivateEndpoint(project)
@@ -584,20 +568,6 @@ func getEndpointsIntersection(specPEs []akov2.PrivateEndpoint, atlasPEs []atlasP
 type intersectionPair struct {
 	spec  akov2.PrivateEndpoint
 	atlas atlasPE
-}
-
-func hasSkippedPrivateEndpointConfiguration(atlasProject *akov2.AtlasProject) (bool, error) {
-	lastSkippedSpec := akov2.AtlasProjectSpec{}
-	lastSkippedSpecString, ok := atlasProject.Annotations[customresource.AnnotationLastSkippedConfiguration]
-	if ok {
-		if err := json.Unmarshal([]byte(lastSkippedSpecString), &lastSkippedSpec); err != nil {
-			return false, fmt.Errorf("failed to parse last skipped configuration: %w", err)
-		}
-
-		return len(lastSkippedSpec.PrivateEndpoints) == 0, nil
-	}
-
-	return false, nil
 }
 
 func mapLastAppliedPrivateEndpoint(atlasProject *akov2.AtlasProject) (map[string]akov2.PrivateEndpoint, error) {

--- a/internal/controller/atlasproject/private_endpoint_test.go
+++ b/internal/controller/atlasproject/private_endpoint_test.go
@@ -175,7 +175,7 @@ func TestMapLastAppliedPrivateEndpoint(t *testing.T) {
 	}{
 		"should return error when last spec annotation is wrong": {
 			annotations: map[string]string{customresource.AnnotationLastAppliedConfiguration: "{wrong}"},
-			expectedError: "error reading AtlasProject Spec from annotation [mongodb.com/last-applied-configuration]:" +
+			expectedError: "error parsing JSON annotation value [{wrong}] into a v1.AtlasProjectSpec:" +
 				" invalid character 'w' looking for beginning of object key string",
 		},
 		"should return nil when there is no last spec": {},

--- a/internal/controller/atlasproject/private_endpoint_test.go
+++ b/internal/controller/atlasproject/private_endpoint_test.go
@@ -174,9 +174,8 @@ func TestMapLastAppliedPrivateEndpoint(t *testing.T) {
 		expectedError string
 	}{
 		"should return error when last spec annotation is wrong": {
-			annotations: map[string]string{customresource.AnnotationLastAppliedConfiguration: "{wrong}"},
-			expectedError: "error parsing JSON annotation value [{wrong}] into a v1.AtlasProjectSpec:" +
-				" invalid character 'w' looking for beginning of object key string",
+			annotations:   map[string]string{customresource.AnnotationLastAppliedConfiguration: "{wrong}"},
+			expectedError: "invalid character 'w' looking for beginning of object key string",
 		},
 		"should return nil when there is no last spec": {},
 		"should return map of last private endpoints": {

--- a/internal/controller/customresource/protection.go
+++ b/internal/controller/customresource/protection.go
@@ -71,7 +71,8 @@ func ApplyLastConfigApplied(ctx context.Context, resource api.AtlasCustomResourc
 	return nil
 }
 
-func ParseLastConfigApplied[S any](spec *S, resource api.AtlasCustomResource) (*S, error) {
+func ParseLastConfigApplied[S any](resource api.AtlasCustomResource) (*S, error) {
+	var spec S
 	lastAppliedJSON, ok := resource.GetAnnotations()[AnnotationLastAppliedConfiguration]
 	if !ok {
 		return nil, nil
@@ -79,9 +80,9 @@ func ParseLastConfigApplied[S any](spec *S, resource api.AtlasCustomResource) (*
 
 	err := json.Unmarshal([]byte(lastAppliedJSON), &spec)
 	if err != nil {
-		return nil, fmt.Errorf("error parsing JSON annotation value [%s] into a %T: %w", lastAppliedJSON, *spec, err)
+		return nil, fmt.Errorf("error parsing JSON annotation value [%s] into a %T: %w", lastAppliedJSON, spec, err)
 	}
-	return spec, nil
+	return &spec, nil
 }
 
 func IsResourceManagedByOperator(resource api.AtlasCustomResource) (bool, error) {

--- a/internal/controller/customresource/protection.go
+++ b/internal/controller/customresource/protection.go
@@ -72,35 +72,28 @@ func ApplyLastConfigApplied(ctx context.Context, resource api.AtlasCustomResourc
 }
 
 func PatchLastConfigApplied[S any](ctx context.Context, k8sClient client.Client, resource api.AtlasCustomResource, spec *S) error {
-	copy, err := setLastAppliedConfigAnnotation(resource, spec)
-	if err != nil {
-		return fmt.Errorf("failed to set the last applied config annotation: %w", err)
+	if spec == nil {
+		return fmt.Errorf("spec is nil")
 	}
 
-	err = k8sClient.Patch(ctx, copy, client.MergeFrom(resource))
+	js, err := json.Marshal(spec)
 	if err != nil {
-		return fmt.Errorf("failed to patch resource: %w", err)
+		return fmt.Errorf("failed to marshal %v: %w", spec, err)
 	}
-	return nil
-}
 
-func setLastAppliedConfigAnnotation[S any](resource api.AtlasCustomResource, spec *S) (api.AtlasCustomResource, error) {
-	uObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(spec)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get unstructured object from spec %v: %w", spec, err)
-	}
-	js, err := json.Marshal(uObj)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal %v: %w", uObj, err)
-	}
-	copy := resource.DeepCopyObject().(api.AtlasCustomResource)
-	annotations := copy.GetAnnotations()
+	resourceCopy := resource.DeepCopyObject().(api.AtlasCustomResource)
+	annotations := resourceCopy.GetAnnotations()
 	if annotations == nil {
 		annotations = map[string]string{}
 	}
 	annotations[AnnotationLastAppliedConfiguration] = string(js)
-	copy.SetAnnotations(annotations)
-	return copy, nil
+	resourceCopy.SetAnnotations(annotations)
+
+	err = k8sClient.Patch(ctx, resourceCopy, client.MergeFrom(resource))
+	if err != nil {
+		return fmt.Errorf("failed to patch resource: %w", err)
+	}
+	return nil
 }
 
 func ParseLastConfigApplied[S any](resource api.AtlasCustomResource) (*S, error) {

--- a/internal/controller/customresource/protection.go
+++ b/internal/controller/customresource/protection.go
@@ -12,7 +12,6 @@ import (
 
 const (
 	AnnotationLastAppliedConfiguration = "mongodb.com/last-applied-configuration"
-	AnnotationLastSkippedConfiguration = "mongodb.com/last-skipped-configuration"
 )
 
 type OperatorChecker func(resource api.AtlasCustomResource) (bool, error)
@@ -42,10 +41,6 @@ func IsOwner(resource api.AtlasCustomResource, protectionFlag bool, operatorChec
 
 func ApplyLastConfigApplied(ctx context.Context, resource api.AtlasCustomResource, k8sClient client.Client) error {
 	return applyLastSpec(ctx, resource, k8sClient, AnnotationLastAppliedConfiguration)
-}
-
-func ApplyLastConfigSkipped(ctx context.Context, resource api.AtlasCustomResource, k8sClient client.Client) error {
-	return applyLastSpec(ctx, resource, k8sClient, AnnotationLastSkippedConfiguration)
 }
 
 func applyLastSpec(ctx context.Context, resource api.AtlasCustomResource, k8sClient client.Client, annotationKey string) error {

--- a/internal/controller/customresource/protection.go
+++ b/internal/controller/customresource/protection.go
@@ -112,7 +112,7 @@ func ParseLastConfigApplied[S any](resource api.AtlasCustomResource) (*S, error)
 
 	err := json.Unmarshal([]byte(lastAppliedJSON), &spec)
 	if err != nil {
-		return nil, fmt.Errorf("error parsing JSON annotation value [%s] into a %T: %w", lastAppliedJSON, spec, err)
+		return nil, fmt.Errorf("error parsing JSON annotation value into a %T: %w", spec, err)
 	}
 	return &spec, nil
 }

--- a/internal/controller/customresource/protection_test.go
+++ b/internal/controller/customresource/protection_test.go
@@ -286,10 +286,10 @@ func TestPatchLastConfigAppliedErrors(t *testing.T) {
 		wantErrorMsg string
 	}{
 		{
-			title:        "nil spec cannot get unstructured",
+			title:        "nil spec fails",
 			object:       &akov2.AtlasProject{},
 			spec:         nil,
-			wantErrorMsg: "ToUnstructured requires a non-nil pointer to an object",
+			wantErrorMsg: "spec is nil",
 		},
 		{
 			title:        "empty struct cannot be patched",
@@ -327,7 +327,7 @@ func TestParseLastConfigApplied(t *testing.T) {
 					},
 				},
 			},
-			wantErrorMsg: "error parsing JSON annotation value [bad-json]",
+			wantErrorMsg: "error parsing JSON annotation value into a v1.AtlasProjectSpec",
 		},
 		{
 			title: "proper but empty JSON renders empty spec",

--- a/internal/controller/customresource/protection_test.go
+++ b/internal/controller/customresource/protection_test.go
@@ -153,22 +153,6 @@ func TestApplyLastConfigApplied(t *testing.T) {
 	assert.Equal(t, expectedConfig, annot[customresource.AnnotationLastAppliedConfiguration])
 }
 
-func TestApplyLastConfigSkipped(t *testing.T) {
-	resource := sampleResource()
-	resource.Name = "foo"
-	resource.Spec.Username = "test-user"
-
-	scheme := runtime.NewScheme()
-	utilruntime.Must(akov2.AddToScheme(scheme))
-	c := fake.NewClientBuilder().WithObjects(resource).WithScheme(scheme).Build()
-	assert.NoError(t, customresource.ApplyLastConfigSkipped(context.Background(), resource, c))
-
-	annot := resource.GetAnnotations()
-	assert.NotEmpty(t, annot)
-	expectedConfig := `{"roles":null,"username":"test-user"}`
-	assert.Equal(t, expectedConfig, annot[customresource.AnnotationLastSkippedConfiguration])
-}
-
 func TestIsResourceManagedByOperator(t *testing.T) {
 	testCases := []struct {
 		title         string

--- a/internal/controller/customresource/protection_test.go
+++ b/internal/controller/customresource/protection_test.go
@@ -2,17 +2,23 @@ package customresource_test
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/api"
 	akov2 "github.com/mongodb/mongodb-atlas-kubernetes/v2/api/v1"
+	"github.com/mongodb/mongodb-atlas-kubernetes/v2/api/v1/common"
+	"github.com/mongodb/mongodb-atlas-kubernetes/v2/api/v1/project"
+	"github.com/mongodb/mongodb-atlas-kubernetes/v2/api/v1/status"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/controller/customresource"
 )
 
@@ -182,4 +188,201 @@ func TestIsResourceManagedByOperator(t *testing.T) {
 			assert.Equal(t, tc.expectManaged, managed)
 		})
 	}
+}
+
+func TestPatchLastConfigApplied(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	utilruntime.Must(akov2.AddToScheme(scheme))
+	for _, tc := range []struct {
+		title  string
+		object *akov2.AtlasProject
+		spec   *akov2.AtlasProjectSpec
+	}{
+		{
+			title: "spec without changes is a noop",
+			object: &akov2.AtlasProject{
+				TypeMeta:   metav1.TypeMeta{Kind: "AtlasProject", APIVersion: "atlas.mongodb.com"},
+				ObjectMeta: metav1.ObjectMeta{Name: "test-project", Namespace: "ns", Annotations: map[string]string{}},
+				Spec: akov2.AtlasProjectSpec{
+					Name:                "atlas-project-name",
+					ConnectionSecret:    &common.ResourceRefNamespaced{Name: "secret-name"},
+					CustomRoles:         []akov2.CustomRole{{}},
+					ProjectIPAccessList: []project.IPAccessList{{}},
+					PrivateEndpoints:    []akov2.PrivateEndpoint{{}},
+					NetworkPeers:        []akov2.NetworkPeer{{}},
+					Teams:               []akov2.Team{{}},
+				},
+				Status: status.AtlasProjectStatus{ID: "some-id"},
+			},
+			spec: &akov2.AtlasProjectSpec{ // same as object's spec, no changes
+				Name:                "atlas-project-name",
+				ConnectionSecret:    &common.ResourceRefNamespaced{Name: "secret-name"},
+				CustomRoles:         []akov2.CustomRole{{}},
+				ProjectIPAccessList: []project.IPAccessList{{}},
+				PrivateEndpoints:    []akov2.PrivateEndpoint{{}},
+				NetworkPeers:        []akov2.NetworkPeer{{}},
+				Teams:               []akov2.Team{{}},
+			},
+		},
+
+		{
+			title: "cleared spec is applied with no other changes",
+			object: &akov2.AtlasProject{
+				TypeMeta:   metav1.TypeMeta{Kind: "AtlasProject", APIVersion: "atlas.mongodb.com"},
+				ObjectMeta: metav1.ObjectMeta{Name: "test-project", Namespace: "ns", Annotations: map[string]string{}},
+				Spec: akov2.AtlasProjectSpec{
+					Name:                "atlas-project-name",
+					ConnectionSecret:    &common.ResourceRefNamespaced{Name: "secret-name"},
+					CustomRoles:         []akov2.CustomRole{{}},
+					ProjectIPAccessList: []project.IPAccessList{{}},
+					PrivateEndpoints:    []akov2.PrivateEndpoint{{}},
+					NetworkPeers:        []akov2.NetworkPeer{{}},
+					Teams:               []akov2.Team{{}},
+				},
+				Status: status.AtlasProjectStatus{ID: "some-id"},
+			},
+			spec: &akov2.AtlasProjectSpec{ // clear applied
+				Name:             "atlas-project-name",
+				ConnectionSecret: &common.ResourceRefNamespaced{Name: "secret-name"},
+				Teams:            []akov2.Team{{}},
+			},
+		},
+	} {
+		t.Run(tc.title, func(t *testing.T) {
+			k8sClient := fake.NewClientBuilder().WithObjects(tc.object).WithScheme(scheme).Build()
+
+			require.NoError(t, customresource.PatchLastConfigApplied(ctx, k8sClient, tc.object, tc.spec))
+
+			result := akov2.AtlasProject{}
+			require.NoError(t, k8sClient.Get(ctx, client.ObjectKeyFromObject(tc.object), &result))
+
+			resultSpec, err := customresource.ParseLastConfigApplied[akov2.AtlasProjectSpec](&result)
+			require.NoError(t, err)
+			assert.Equal(t, tc.spec, resultSpec)
+
+			want := tc.object
+			assert.Equal(t, clearProjectToCompare(want), clearProjectToCompare(&result))
+		})
+	}
+}
+
+func clearProjectToCompare(prj *akov2.AtlasProject) *akov2.AtlasProject {
+	copy := prj.DeepCopy()
+	// ignore the resourceVersion and the last applied config, compared separately
+	delete(copy.Annotations, customresource.AnnotationLastAppliedConfiguration)
+	copy.ResourceVersion = ""
+	return copy
+}
+
+func TestPatchLastConfigAppliedErrors(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	utilruntime.Must(akov2.AddToScheme(scheme))
+	for _, tc := range []struct {
+		title        string
+		object       *akov2.AtlasProject
+		spec         *struct{}
+		wantErrorMsg string
+	}{
+		{
+			title:        "nil spec cannot get unstructured",
+			object:       &akov2.AtlasProject{},
+			spec:         nil,
+			wantErrorMsg: "ToUnstructured requires a non-nil pointer to an object",
+		},
+		{
+			title:        "empty struct cannot be patched",
+			object:       &akov2.AtlasProject{},
+			spec:         &struct{}{},
+			wantErrorMsg: "failed to patch resource:  \"\" is invalid: metadata.name: Required value: name is required",
+		},
+	} {
+		t.Run(tc.title, func(t *testing.T) {
+			k8sClient := fake.NewClientBuilder().WithObjects(tc.object).WithScheme(scheme).Build()
+
+			err := customresource.PatchLastConfigApplied(ctx, k8sClient, tc.object, tc.spec)
+			assert.ErrorContains(t, err, tc.wantErrorMsg)
+		})
+	}
+}
+
+func TestParseLastConfigApplied(t *testing.T) {
+	for _, tc := range []struct {
+		title        string
+		object       *akov2.AtlasProject
+		want         *akov2.AtlasProjectSpec
+		wantErrorMsg string
+	}{
+		{
+			title:  "empty project without annotations renders nothing",
+			object: &akov2.AtlasProject{},
+		},
+		{
+			title: "broken JSON in annotation renders error",
+			object: &akov2.AtlasProject{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						customresource.AnnotationLastAppliedConfiguration: "bad-json",
+					},
+				},
+			},
+			wantErrorMsg: "error parsing JSON annotation value [bad-json]",
+		},
+		{
+			title: "proper but empty JSON renders empty spec",
+			object: &akov2.AtlasProject{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						customresource.AnnotationLastAppliedConfiguration: "{}",
+					},
+				},
+			},
+			want: &akov2.AtlasProjectSpec{},
+		},
+		{
+			title: "sample JSON spec renders original",
+			object: &akov2.AtlasProject{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						customresource.AnnotationLastAppliedConfiguration: jsonize(
+							akov2.AtlasProjectSpec{
+								Name:                "atlas-project-name",
+								ConnectionSecret:    &common.ResourceRefNamespaced{Name: "secret-name"},
+								CustomRoles:         []akov2.CustomRole{{}},
+								ProjectIPAccessList: []project.IPAccessList{{}},
+								PrivateEndpoints:    []akov2.PrivateEndpoint{{}},
+								NetworkPeers:        []akov2.NetworkPeer{{}},
+								Teams:               []akov2.Team{{}},
+							}),
+					},
+				},
+			},
+			want: &akov2.AtlasProjectSpec{
+				Name:                "atlas-project-name",
+				ConnectionSecret:    &common.ResourceRefNamespaced{Name: "secret-name"},
+				CustomRoles:         []akov2.CustomRole{{}},
+				ProjectIPAccessList: []project.IPAccessList{{}},
+				PrivateEndpoints:    []akov2.PrivateEndpoint{{}},
+				NetworkPeers:        []akov2.NetworkPeer{{}},
+				Teams:               []akov2.Team{{}},
+			},
+		},
+	} {
+		t.Run(tc.title, func(t *testing.T) {
+			spec, err := customresource.ParseLastConfigApplied[akov2.AtlasProjectSpec](tc.object)
+			if tc.wantErrorMsg != "" {
+				assert.ErrorContains(t, err, tc.wantErrorMsg)
+			}
+			assert.Equal(t, tc.want, spec)
+		})
+	}
+}
+
+func jsonize(obj any) string {
+	js, err := json.Marshal(obj)
+	if err != nil {
+		return err.Error()
+	}
+	return string(js)
 }

--- a/test/e2e/ipaccesslist_test.go
+++ b/test/e2e/ipaccesslist_test.go
@@ -84,7 +84,6 @@ var _ = Describe("Migrate ip access list from sub-resources to separate custom r
 			Expect(testData.K8SClient.Update(testData.Context, testData.Project)).To(Succeed())
 			Eventually(func(g Gomega) {
 				g.Expect(testData.K8SClient.Get(testData.Context, client.ObjectKeyFromObject(testData.Project), testData.Project)).To(Succeed())
-				g.Expect(customresource.AnnotationLastSkippedConfiguration).To(BeKeyOf(testData.Project.GetAnnotations()))
 				g.Expect(testData.Project.Status.Conditions).To(ContainElement(conditions.MatchCondition(api.TrueCondition(api.ReadyType))))
 			}).WithTimeout(5 * time.Minute).WithPolling(10 * time.Second).Should(Succeed())
 		})

--- a/test/e2e/privateendpoint_test.go
+++ b/test/e2e/privateendpoint_test.go
@@ -412,7 +412,6 @@ var _ = Describe("Migrate private endpoints from sub-resources to separate custo
 			Eventually(func(g Gomega) {
 				g.Expect(testData.K8SClient.Get(testData.Context, client.ObjectKeyFromObject(testData.Project), testData.Project)).To(Succeed())
 				g.Expect(testData.Project.Generation).ToNot(Equal(testData.Project.Status.ObservedGeneration))
-				g.Expect(customresource.AnnotationLastSkippedConfiguration).To(BeKeyOf(testData.Project.GetAnnotations()))
 				g.Expect(testData.Project.Status.Conditions).To(ContainElement(conditions.MatchCondition(api.TrueCondition(api.ReadyType))))
 			}).WithTimeout(15 * time.Minute).WithPolling(10 * time.Second).Should(Succeed())
 		})


### PR DESCRIPTION
Replace it by:
- Clearing the resource lists for migrated independent CRDs at skip time. So that they will not eagerly try to take over  the full resource list when skip is removed and potentially conflict with existing independent CRs.
- Without last applied config, non greediness behaviour kicks in and the legacy embedded resource controller will not delete resources from Atlas that does not know about.

Testing: Added one test verifying that migrated resource lists get cleared when the project reconcile is skipped, and several tests cases per migrated resource to verify non greedy behaviour conforms to expectations.

### All Submissions:

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
