### PR TITLE
Remove duplicated entry "lucene.standard".

### DIFF
--- a/bundle/manifests/atlas.mongodb.com_atlasdeployments.yaml
+++ b/bundle/manifests/atlas.mongodb.com_atlasdeployments.yaml
@@ -457,7 +457,6 @@ spec:
                                       to apply to the synonyms to be searched
                                     enum:
                                     - lucene.standard
-                                    - lucene.standard
                                     - lucene.simple
                                     - lucene.whitespace
                                     - lucene.keyword

--- a/config/crd/bases/atlas.mongodb.com_atlasdeployments.yaml
+++ b/config/crd/bases/atlas.mongodb.com_atlasdeployments.yaml
@@ -453,7 +453,6 @@ spec:
                                       to apply to the synonyms to be searched
                                     enum:
                                     - lucene.standard
-                                    - lucene.standard
                                     - lucene.simple
                                     - lucene.whitespace
                                     - lucene.keyword

--- a/deploy/crds/atlas.mongodb.com_atlasdeployments.yaml
+++ b/deploy/crds/atlas.mongodb.com_atlasdeployments.yaml
@@ -453,7 +453,6 @@ spec:
                                       to apply to the synonyms to be searched
                                     enum:
                                     - lucene.standard
-                                    - lucene.standard
                                     - lucene.simple
                                     - lucene.whitespace
                                     - lucene.keyword


### PR DESCRIPTION
When converting to json schema this duplicated entry is not removed which causes the schema to fail to parse with kubeconform.

### All Submissions:

* [ X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if there is one).
* [ ] Update docs/release-notes/release-notes-template.md if your changes should be included in the release notes for the next release.
