### PR TITLE
CLOUDP-306112: Removed duplicate validation entry for Search Indexes

### DIFF
--- a/api/v1/atlassearchindex_types.go
+++ b/api/v1/atlassearchindex_types.go
@@ -48,7 +48,7 @@ type Synonym struct {
 	// +required
 	Name string `json:"name"`
 	// Specific pre-defined method chosen to apply to the synonyms to be searched
-	// +kubebuilder:validation:Enum:=lucene.standard;lucene.standard;lucene.simple;lucene.whitespace;lucene.keyword;lucene.arabic;lucene.armenian;lucene.basque;lucene.bengali;lucene.brazilian;lucene.bulgarian;lucene.catalan;lucene.chinese;lucene.cjk;lucene.czech;lucene.danish;lucene.dutch;lucene.english;lucene.finnish;lucene.french;lucene.galician;lucene.german;lucene.greek;lucene.hindi;lucene.hungarian;lucene.indonesian;lucene.irish;lucene.italian;lucene.japanese;lucene.korean;lucene.kuromoji;lucene.latvian;lucene.lithuanian;lucene.morfologik;lucene.nori;lucene.norwegian;lucene.persian;lucene.portuguese;lucene.romanian;lucene.russian;lucene.smartcn;lucene.sorani;lucene.spanish;lucene.swedish;lucene.thai;lucene.turkish;lucene.ukrainian
+	// +kubebuilder:validation:Enum:=lucene.standard;lucene.simple;lucene.whitespace;lucene.keyword;lucene.arabic;lucene.armenian;lucene.basque;lucene.bengali;lucene.brazilian;lucene.bulgarian;lucene.catalan;lucene.chinese;lucene.cjk;lucene.czech;lucene.danish;lucene.dutch;lucene.english;lucene.finnish;lucene.french;lucene.galician;lucene.german;lucene.greek;lucene.hindi;lucene.hungarian;lucene.indonesian;lucene.irish;lucene.italian;lucene.japanese;lucene.korean;lucene.kuromoji;lucene.latvian;lucene.lithuanian;lucene.morfologik;lucene.nori;lucene.norwegian;lucene.persian;lucene.portuguese;lucene.romanian;lucene.russian;lucene.smartcn;lucene.sorani;lucene.spanish;lucene.swedish;lucene.thai;lucene.turkish;lucene.ukrainian
 	// +required
 	Analyzer string `json:"analyzer"`
 	// Data set that stores the mapping one or more words map to one or more synonyms of those words

--- a/bundle/manifests/atlas.mongodb.com_atlasdeployments.yaml
+++ b/bundle/manifests/atlas.mongodb.com_atlasdeployments.yaml
@@ -457,7 +457,6 @@ spec:
                                       to apply to the synonyms to be searched
                                     enum:
                                     - lucene.standard
-                                    - lucene.standard
                                     - lucene.simple
                                     - lucene.whitespace
                                     - lucene.keyword

--- a/config/crd/bases/atlas.mongodb.com_atlasdeployments.yaml
+++ b/config/crd/bases/atlas.mongodb.com_atlasdeployments.yaml
@@ -453,7 +453,6 @@ spec:
                                       to apply to the synonyms to be searched
                                     enum:
                                     - lucene.standard
-                                    - lucene.standard
                                     - lucene.simple
                                     - lucene.whitespace
                                     - lucene.keyword

--- a/deploy/all-in-one.yaml
+++ b/deploy/all-in-one.yaml
@@ -1859,7 +1859,6 @@ spec:
                                       to apply to the synonyms to be searched
                                     enum:
                                     - lucene.standard
-                                    - lucene.standard
                                     - lucene.simple
                                     - lucene.whitespace
                                     - lucene.keyword

--- a/deploy/clusterwide/crds.yaml
+++ b/deploy/clusterwide/crds.yaml
@@ -1822,7 +1822,6 @@ spec:
                                       to apply to the synonyms to be searched
                                     enum:
                                     - lucene.standard
-                                    - lucene.standard
                                     - lucene.simple
                                     - lucene.whitespace
                                     - lucene.keyword

--- a/deploy/crds/atlas.mongodb.com_atlasdeployments.yaml
+++ b/deploy/crds/atlas.mongodb.com_atlasdeployments.yaml
@@ -453,7 +453,6 @@ spec:
                                       to apply to the synonyms to be searched
                                     enum:
                                     - lucene.standard
-                                    - lucene.standard
                                     - lucene.simple
                                     - lucene.whitespace
                                     - lucene.keyword

--- a/deploy/namespaced/crds.yaml
+++ b/deploy/namespaced/crds.yaml
@@ -1822,7 +1822,6 @@ spec:
                                       to apply to the synonyms to be searched
                                     enum:
                                     - lucene.standard
-                                    - lucene.standard
                                     - lucene.simple
                                     - lucene.whitespace
                                     - lucene.keyword

--- a/deploy/openshift/crds.yaml
+++ b/deploy/openshift/crds.yaml
@@ -1822,7 +1822,6 @@ spec:
                                       to apply to the synonyms to be searched
                                     enum:
                                     - lucene.standard
-                                    - lucene.standard
                                     - lucene.simple
                                     - lucene.whitespace
                                     - lucene.keyword


### PR DESCRIPTION
### All Submissions:

Note: original PR from @segui-mdb https://github.com/mongodb/mongodb-atlas-kubernetes/pull/2193.

Removed duplicate validation entry "lucene.standard" from the search index configuration

* [x] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if there is one).
* [ ] Update docs/release-notes/release-notes-template.md if your changes should be included in the release notes for the next release.
