### PR TITLE
CLOUDP-286238: Fix autoscale reconcile loop on disabled scale down

### DIFF
--- a/internal/translation/deployment/compare.go
+++ b/internal/translation/deployment/compare.go
@@ -314,7 +314,8 @@ func computeAutoscalingConfigAreEqual(desired, current *akov2.ComputeSpec) bool 
 		return false
 	}
 
-	if desired.MinInstanceSize != current.MinInstanceSize {
+	scaleDown := current.ScaleDownEnabled != nil && *current.ScaleDownEnabled
+	if scaleDown && (desired.MinInstanceSize != current.MinInstanceSize) {
 		return false
 	}
 

--- a/internal/translation/deployment/compare_test.go
+++ b/internal/translation/deployment/compare_test.go
@@ -1779,13 +1779,26 @@ func TestComputeAutoscalingConfigAreEqual(t *testing.T) {
 				ScaleDownEnabled: pointer.MakePtr(false),
 			},
 		},
-		"should return false when min instance has changed": {
+		"should return false when min instance has changed and scale down is enabled": {
 			akoAutoscaling: &akov2.ComputeSpec{
-				MinInstanceSize: "M20",
+				ScaleDownEnabled: pointer.MakePtr(true),
+				MinInstanceSize:  "M20",
 			},
 			atlasAutoscaling: &akov2.ComputeSpec{
-				MinInstanceSize: "M10",
+				ScaleDownEnabled: pointer.MakePtr(true),
+				MinInstanceSize:  "M10",
 			},
+		},
+		"should return true when min instance has changed and scale down is disabled": {
+			akoAutoscaling: &akov2.ComputeSpec{
+				ScaleDownEnabled: pointer.MakePtr(false),
+				MinInstanceSize:  "M20",
+			},
+			atlasAutoscaling: &akov2.ComputeSpec{
+				ScaleDownEnabled: pointer.MakePtr(false),
+				MinInstanceSize:  "M10",
+			},
+			expected: true,
 		},
 		"should return false when max instance has changed": {
 			akoAutoscaling: &akov2.ComputeSpec{


### PR DESCRIPTION
When Scale Down is disabled `ScaleDownEnabled=false`, the Atlas API replies with an empty setting for `MinInstanceSize`, which is an ilegal value to set in the Spec. This means the comparison between the Atlas state and the Kubernetes Spec will always fail and hence the reconciliation loop.

This fix just ignores the value of `MinInstanceSize` for the comparison when `ScaleDownEnabled=false`, so that the reconcile loop is avoided.

Closes #2106 

### All Submissions:

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [X] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if there is one).
