### PR TITLE
CLOUDP-304211: Only accept pull_request_target with safe-to-test label

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,24 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  trace:
+    name: Traces
+    runs-on: ubuntu-latest
+    steps:
+    - name: Show
+      id: show
+      env:
+        SAFE_TO_TEST_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'safe-to-test') }}
+        SAFE_TO_TEST_LABEL_TARGET: ${{ contains(github.event.pull_request_target.labels.*.name, 'safe-to-test') }}
+        EVENT: ${{ github.event_name }}
+      run: |
+        echo SAFE_TO_TEST_LABEL="${SAFE_TO_TEST_LABEL}"
+        echo SAFE_TO_TEST_LABEL_TARGET="${SAFE_TO_TEST_LABEL_TARGET}"
+        echo EVENT="${EVENT}"
+
   run-tests:
+    needs:
+      - trace
     name: Run Tests
     runs-on: ubuntu-latest
     # Contributions do NOT run any testing by default, a label is needed to allow testing

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,73 +8,28 @@ on:
       - 'main'
     paths-ignore:
       - 'docs/**'
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review, converted_to_draft, labeled, unlabeled]
-    branches:
-      - '**'
-    paths-ignore:
-      - 'docs/**'
-  pull_request_target:
-    types: [labeled]
   merge_group:
   workflow_dispatch:
+  workflow_call:
 
 concurrency:
   group: test-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 jobs:
-  run-tests:
-    name: Run Tests
-    runs-on: ubuntu-latest
-    steps:
-    - name: Show
-      env:
-        SAFE_TO_TEST_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'safe-to-test') }}
-        SAFE_TO_TEST_LABEL_TARGET: ${{ contains(github.event.pull_request_target.labels.*.name, 'safe-to-test') }}
-        EVENT: ${{ github.event_name }}
-        ACTION: ${{ github.event.action }}
-        ALLOWED: ${{ (!contains(github.event.pull_request.labels.*.name, 'safe-to-test') && github.event_name == 'pull_request') ||   (contains(github.event.pull_request_target.labels.*.name, 'safe-to-test') && github.event_name == 'pull_request_target')}}
-      run: |
-        echo SAFE_TO_TEST_LABEL="${SAFE_TO_TEST_LABEL}"
-        echo SAFE_TO_TEST_LABEL_TARGET="${SAFE_TO_TEST_LABEL_TARGET}"
-        echo EVENT="${EVENT}"
-        echo ACTION="${ACTION}"
-        echo ALLOWED="${ALLOWED}"
-    - name: allowed message
-      # Contributions do NOT run any testing by default, a label is needed to allow testing
-      # Only accept either code owner's PRs from the same repo 
-      # or pull_request_target events with the safe-to-test allow flag
-      if: |
-        (!contains(github.event.pull_request.labels.*.name, 'safe-to-test') &&
-        github.event_name == 'pull_request') || 
-        (contains(github.event.pull_request_target.labels.*.name, 'safe-to-test') &&
-        github.event_name == 'pull_request_target')
-      run: echo "Allowed to run tests"
-
   lint:
-    needs:
-      - run-tests
     uses: ./.github/workflows/lint.yaml
 
   validate-manifests:
-    needs:
-      - run-tests
     uses: ./.github/workflows/validate-manifests.yml
   
   unit-tests:
-    needs:
-      - run-tests
     uses: ./.github/workflows/test-unit.yml
 
   check-licenses:
-    needs:
-      - run-tests
     uses: ./.github/workflows/check-licenses.yml
   
   cloud-tests-filter:
-    needs:
-      - run-tests
     uses: ./.github/workflows/cloud-tests-filter.yml
 
   cloud-tests:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,9 @@ on:
       - '**'
     paths-ignore:
       - 'docs/**'
+  pull_request_target:
+    types: [labeled]
+    branches: [main]
   merge_group:
   workflow_dispatch:
 
@@ -26,11 +29,13 @@ jobs:
     name: Run Tests
     runs-on: ubuntu-latest
     # Contributions do NOT run any testing by default, a label is needed to allow testing
+    # Only accept either code owner's PRs from the same repo 
+    # or pull_request_target events with the safe-to-test allow flag
     if: |
-      github.event.pull_request.base.repo.full_name == github.event.pull_request.head.repo.full_name ||
-      contains(github.event.pull_request.labels.*.name, 'safe-to-test') ||
-      contains(github.event.pull_request.labels.*.name, 'cloud-tests') ||
-      contains(github.event.pull_request.labels.*.name, 'retest')
+      (!contains(github.event.pull_request.labels.*.name, 'safe-to-test') &&
+      github.event_name == 'pull_request') || 
+      (contains(github.event.pull_request_target.labels.*.name, 'safe-to-test') &&
+      github.event_name == 'pull_request_target')
     steps:
       - name: allowed message
         run: echo "Allowed to run tests"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,10 +33,14 @@ jobs:
         SAFE_TO_TEST_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'safe-to-test') }}
         SAFE_TO_TEST_LABEL_TARGET: ${{ contains(github.event.pull_request_target.labels.*.name, 'safe-to-test') }}
         EVENT: ${{ github.event_name }}
+        ACTION: ${{ github.event.action }}
+        ALLOWED: ${{ (!contains(github.event.pull_request.labels.*.name, 'safe-to-test') && github.event_name == 'pull_request') ||   (contains(github.event.pull_request_target.labels.*.name, 'safe-to-test') && github.event_name == 'pull_request_target')}}
       run: |
         echo SAFE_TO_TEST_LABEL="${SAFE_TO_TEST_LABEL}"
         echo SAFE_TO_TEST_LABEL_TARGET="${SAFE_TO_TEST_LABEL_TARGET}"
         echo EVENT="${EVENT}"
+        echo ACTION="${ACTION}"
+        echo ALLOWED="${ALLOWED}"
     - name: allowed message
       # Contributions do NOT run any testing by default, a label is needed to allow testing
       # Only accept either code owner's PRs from the same repo 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,6 @@ on:
       - 'docs/**'
   pull_request_target:
     types: [labeled]
-    branches: [main]
   merge_group:
   workflow_dispatch:
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,12 +25,11 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  trace:
-    name: Traces
+  run-tests:
+    name: Run Tests
     runs-on: ubuntu-latest
     steps:
     - name: Show
-      id: show
       env:
         SAFE_TO_TEST_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'safe-to-test') }}
         SAFE_TO_TEST_LABEL_TARGET: ${{ contains(github.event.pull_request_target.labels.*.name, 'safe-to-test') }}
@@ -39,23 +38,16 @@ jobs:
         echo SAFE_TO_TEST_LABEL="${SAFE_TO_TEST_LABEL}"
         echo SAFE_TO_TEST_LABEL_TARGET="${SAFE_TO_TEST_LABEL_TARGET}"
         echo EVENT="${EVENT}"
-
-  run-tests:
-    needs:
-      - trace
-    name: Run Tests
-    runs-on: ubuntu-latest
-    # Contributions do NOT run any testing by default, a label is needed to allow testing
-    # Only accept either code owner's PRs from the same repo 
-    # or pull_request_target events with the safe-to-test allow flag
-    if: |
-      (!contains(github.event.pull_request.labels.*.name, 'safe-to-test') &&
-      github.event_name == 'pull_request') || 
-      (contains(github.event.pull_request_target.labels.*.name, 'safe-to-test') &&
-      github.event_name == 'pull_request_target')
-    steps:
-      - name: allowed message
-        run: echo "Allowed to run tests"
+    - name: allowed message
+      # Contributions do NOT run any testing by default, a label is needed to allow testing
+      # Only accept either code owner's PRs from the same repo 
+      # or pull_request_target events with the safe-to-test allow flag
+      if: |
+        (!contains(github.event.pull_request.labels.*.name, 'safe-to-test') &&
+        github.event_name == 'pull_request') || 
+        (contains(github.event.pull_request_target.labels.*.name, 'safe-to-test') &&
+        github.event_name == 'pull_request_target')
+      run: echo "Allowed to run tests"
 
   lint:
     needs:

--- a/.github/workflows/trigger.yml
+++ b/.github/workflows/trigger.yml
@@ -1,0 +1,24 @@
+name: Trigger
+
+on:
+  pull_request_target:
+    types: [labeled]
+    paths-ignore:
+      - 'docs/**'
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, converted_to_draft, labeled, unlabeled]
+    branches:
+      - '**'
+    paths-ignore:
+      - 'docs/**'
+
+jobs:
+  run-tests:
+    name: Run Tests
+    # Contributions do NOT run any testing by default, a label is needed to allow testing
+    # Only accept either code owner's PRs from the same repo
+    # or pull_request_target events with the safe-to-test allow flag
+    if: |
+      (!contains(github.event.pull_request.labels.*.name, 'safe-to-test') && github.event_name == 'pull_request') || 
+      (contains(github.event.pull_request_target.labels.*.name, 'safe-to-test') && github.event_name == 'pull_request_target')
+    uses: ./.github/workflows/test.yml


### PR DESCRIPTION
This PR uses a new small `trigger.yml` workflow to handle the logic for both `pull_request` & `pull_request_target` separately of other ways to trigger the `test.yml` workflow. There are only 2 scenarios allowed:

1. The `pull_request` events without the `safe-to-test` label, intended for code owner contributions. Uses the incoming change repo creds, which is the same, as the PR comes from a branch in the same repo.
2. The `pull_request_target` events with `safe-to-test` label that a code owner have just set. Uses the target repo creds, that is the AKO repo creds, and is intended to allow contributions to be tested once a code owner decides it is safe to do so.

### All Submissions:

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
