### PR TITLE
CLOUDP-309306: Project reconciler incorrectly sets PE status for unmanaged resources

### DIFF
--- a/internal/controller/atlasproject/private_endpoint.go
+++ b/internal/controller/atlasproject/private_endpoint.go
@@ -596,7 +596,6 @@ func hasManagedPrivateEndpoints(specPEs []akov2.PrivateEndpoint, atlasPEs []atla
 		}
 	}
 
-	//b := set.DeprecatedDifference(atlasPEs, specPEs)
 	// if any of the PE in atlas is specified in the spec, return true
 	a := set.DeprecatedIntersection(specPEs, atlasPEs)
 	if len(specPEs) > 0 && len(a) > 0 {

--- a/internal/controller/atlasproject/private_endpoint.go
+++ b/internal/controller/atlasproject/private_endpoint.go
@@ -590,10 +590,19 @@ func mapLastAppliedPrivateEndpoint(atlasProject *akov2.AtlasProject) (map[string
 
 func hasManagedPrivateEndpoints(specPEs []akov2.PrivateEndpoint, atlasPEs []atlasPE, lastAppliedPEs map[string]akov2.PrivateEndpoint) bool {
 	for _, pe := range atlasPEs {
+		// if any of the PE in atlas was previously managed, return true
 		if _, ok := lastAppliedPEs[pe.Identifier().(string)]; ok {
 			return true
 		}
 	}
 
-	return len(set.DeprecatedDifference(specPEs, atlasPEs)) == 0
+	//b := set.DeprecatedDifference(atlasPEs, specPEs)
+	// if any of the PE in atlas is specified in the spec, return true
+	a := set.DeprecatedIntersection(specPEs, atlasPEs)
+	if len(specPEs) > 0 && len(a) > 0 {
+		return true
+	}
+
+	// if there are not managed or previously managed entries, return false
+	return false
 }


### PR DESCRIPTION
# Summary

The project reconciler sets a status condition for a resource it does not manage. Without the corresponding configuration, the reconciler is unable to track the resource properly, preventing the project from reaching a ready state.

## Proof of Work

Incremented unit test covering more greedy behavior cases

## Checklist
- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you checked for release_note changes?
- [x] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?

## Reminder (Please remove this when merging)
- Please try to Approve or Reject Changes the PR, keep PRs in review as short as possible
- Remember the following Communication Standards - use comment prefixes for clarity:
  * **blocking**: Must be addressed before approval.
  * **follow-up**: Can be addressed in a later PR or ticket.
  * **q**: Clarifying question.
  * **nit**: Non-blocking suggestions.
  * **note**: Side-note, non-actionable. Example: Praise 
  * --> no prefix is considered a question

