### PR TITLE
CLOUDP-313350: Fix ako-releaser email

### DIFF
--- a/.github/workflows/devbox-update.yml
+++ b/.github/workflows/devbox-update.yml
@@ -49,7 +49,7 @@ jobs:
       if: steps.check_changes.outputs.CHANGES == 'true'
       run: |
         git config user.name "ako-releaser"
-        git config user.email "285350+your-app[bot]@users.noreply.github.com"
+        git config user.email "285350+ako-releaser[bot]@users.noreply.github.com"
         git checkout -b ${{ steps.generate_branch.outputs.BRANCH_NAME }}  # New branch
         git add .
         git commit -m "Weekly devbox dependencies update"

--- a/.github/workflows/sync-helm-charts.yaml
+++ b/.github/workflows/sync-helm-charts.yaml
@@ -100,7 +100,7 @@ jobs:
             echo "Changes detected. Creating PR"
 
             git config user.name "ako-releaser"
-            git config user.email "285350+your-app[bot]@users.noreply.github.com"
+            git config user.email "285350+ako-releaser[bot]@users.noreply.github.com"
 
             git checkout -b "${BRANCH_NAME}"
             git add .

--- a/.github/workflows/update-helm.yaml
+++ b/.github/workflows/update-helm.yaml
@@ -82,7 +82,7 @@ jobs:
             echo "Changes detected. Creating PR"
 
             git config user.name "ako-releaser"
-            git config user.email "285350+your-app[bot]@users.noreply.github.com"
+            git config user.email "285350+ako-releaser[bot]@users.noreply.github.com"
 
             git checkout -b "${BRANCH_NAME}"
             git add .

--- a/.github/workflows/update-licenses.yml
+++ b/.github/workflows/update-licenses.yml
@@ -51,7 +51,7 @@ jobs:
           if [[ $(git diff --stat) != '' ]]; then
             echo 'Committing changes'
             git config user.name "ako-releaser"
-            git config user.email "285350+your-app[bot]@users.noreply.github.com"
+            git config user.email "285350+ako-releaser[bot]@users.noreply.github.com"
             git add .
             git commit -m "Fix licenses after dependabot changes" -m "[dependabot skip]"
             git push


### PR DESCRIPTION
# Summary

Fix ako-releaser email on workflows

## Checklist
- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you checked for release_note changes?
- [x] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?

## Reminder (Please remove this when merging)
- Please try to Approve or Reject Changes the PR, keep PRs in review as short as possible
- Remember the following Communication Standards - use comment prefixes for clarity:
  * **blocking**: Must be addressed before approval.
  * **follow-up**: Can be addressed in a later PR or ticket.
  * **q**: Clarifying question.
  * **nit**: Non-blocking suggestions.
  * **note**: Side-note, non-actionable. Example: Praise 
  * --> no prefix is considered a question

