### PR TITLE
CLOUDP-313568: Adjust cluster instances to bypass Atlas slowness

### DIFF
--- a/test/e2e/atlas_gov_test.go
+++ b/test/e2e/atlas_gov_test.go
@@ -493,7 +493,7 @@ var _ = Describe("Atlas for Government", Label("atlas-gov"), func() {
 									{
 										ElectableSpecs: &akov2.Specs{
 											DiskIOPS:     pointer.MakePtr(int64(3000)),
-											InstanceSize: "M20",
+											InstanceSize: "M10",
 											NodeCount:    pointer.MakePtr(3),
 										},
 										AutoScaling: &akov2.AdvancedAutoScalingSpec{
@@ -503,7 +503,7 @@ var _ = Describe("Atlas for Government", Label("atlas-gov"), func() {
 											Compute: &akov2.ComputeSpec{
 												Enabled:          pointer.MakePtr(true),
 												ScaleDownEnabled: pointer.MakePtr(true),
-												MinInstanceSize:  "M20",
+												MinInstanceSize:  "M10",
 												MaxInstanceSize:  "M40",
 											},
 										},

--- a/test/int/deployment_test.go
+++ b/test/int/deployment_test.go
@@ -314,7 +314,8 @@ var _ = Describe("AtlasDeployment", Label("int", "AtlasDeployment", "deployment-
 
 	Describe("Create deployment & change ReplicationSpecs", Label("AtlasDeploymentSharding"), func() {
 		It("Should Succeed", func(ctx context.Context) {
-			createdDeployment = akov2.DefaultAWSDeployment(namespace.Name, createdProject.Name)
+			createdDeployment = akov2.DefaultAWSDeployment(namespace.Name, createdProject.Name).
+				WithInstanceSize("M30")
 
 			// Atlas will add some defaults in case the Atlas Operator doesn't set them
 			replicationSpecsCheck := func(deployment *admin.AdvancedClusterDescription) {


### PR DESCRIPTION
# Summary

Atlas QA has been slower than usual for the past weeks and this is causing out tests to timeout and the CI pipeline to fail. This tweaks some instance sizes of timing out tests suggests by SREs

## Proof of Work

CI Should be green.

## Checklist
- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you checked for release_note changes?
- [x] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?

## Reminder (Please remove this when merging)
- Please try to Approve or Reject Changes the PR, keep PRs in review as short as possible
- Remember the following Communication Standards - use comment prefixes for clarity:
  * **blocking**: Must be addressed before approval.
  * **follow-up**: Can be addressed in a later PR or ticket.
  * **q**: Clarifying question.
  * **nit**: Non-blocking suggestions.
  * **note**: Side-note, non-actionable. Example: Praise 
  * --> no prefix is considered a question

