### PR TITLE
CLOUDP-304797: Fix configuration to assess RH warnings

### DIFF
--- a/.github/actions/gen-install-scripts/Dockerfile
+++ b/.github/actions/gen-install-scripts/Dockerfile
@@ -15,7 +15,7 @@ RUN cd /usr/local/bin &&\
 RUN CONTROLLER_GEN_TMP_DIR=$(mktemp -d) && \
     cd $CONTROLLER_GEN_TMP_DIR && \
     go mod init tmp && \
-    go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.16.1 && \
+    go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.17.2 && \
     rm -rf $CONTROLLER_GEN_TMP_DIR && \
     CONTROLLER_GEN=${GOBIN}/controller-gen
 

--- a/PROJECT
+++ b/PROJECT
@@ -143,4 +143,12 @@ resources:
   kind: AtlasNetworkPeering
   path: github.com/mongodb/mongodb-atlas-kubernetes/v2/api/v1
   version: v1
+- api:
+    crdVersion: v1
+    namespaced: true
+  domain: mongodb.com
+  group: atlas
+  kind: AtlasBackupCompliancePolicy
+  path: github.com/mongodb/mongodb-atlas-kubernetes/v2/api/v1
+  version: v1
 version: "3"

--- a/api/v1/atlasbackupcompliancepolicy_types.go
+++ b/api/v1/atlasbackupcompliancepolicy_types.go
@@ -36,6 +36,8 @@ func init() {
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:categories=atlas,shortName=abcp
 // +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
+
+// The AtlasBackupCompliancePolicy is a configuration that enforces specific backup and retention requirements
 type AtlasBackupCompliancePolicy struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -44,6 +46,7 @@ type AtlasBackupCompliancePolicy struct {
 	Status status.BackupCompliancePolicyStatus `json:"status,omitempty"`
 }
 
+// AtlasBackupCompliancePolicySpec is the specification of the desired configuration of backup compliance policy
 type AtlasBackupCompliancePolicySpec struct {
 	// Email address of the user who authorized to update the Backup Compliance Policy settings.
 	// +kubebuilder:validation:Required

--- a/config/crd/bases/atlas.mongodb.com_atlasbackupcompliancepolicies.yaml
+++ b/config/crd/bases/atlas.mongodb.com_atlasbackupcompliancepolicies.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.17.2
   name: atlasbackupcompliancepolicies.atlas.mongodb.com
 spec:
   group: atlas.mongodb.com
@@ -25,8 +25,8 @@ spec:
     name: v1
     schema:
       openAPIV3Schema:
-        description: AtlasBackupCompliancePolicy defines the desired state of a compliance
-          policy in Atlas.
+        description: The AtlasBackupCompliancePolicy is a configuration that enforces
+          specific backup and retention requirements
         properties:
           apiVersion:
             description: |-
@@ -46,6 +46,8 @@ spec:
           metadata:
             type: object
           spec:
+            description: AtlasBackupCompliancePolicySpec is the specification of the
+              desired configuration of backup compliance policy
             properties:
               authorizedEmail:
                 description: Email address of the user who authorized to update the

--- a/config/crd/bases/atlas.mongodb.com_atlasbackuppolicies.yaml
+++ b/config/crd/bases/atlas.mongodb.com_atlasbackuppolicies.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.17.2
   name: atlasbackuppolicies.atlas.mongodb.com
 spec:
   group: atlas.mongodb.com

--- a/config/crd/bases/atlas.mongodb.com_atlasbackupschedules.yaml
+++ b/config/crd/bases/atlas.mongodb.com_atlasbackupschedules.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.17.2
   name: atlasbackupschedules.atlas.mongodb.com
 spec:
   group: atlas.mongodb.com

--- a/config/crd/bases/atlas.mongodb.com_atlascustomroles.yaml
+++ b/config/crd/bases/atlas.mongodb.com_atlascustomroles.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.17.2
   name: atlascustomroles.atlas.mongodb.com
 spec:
   group: atlas.mongodb.com

--- a/config/crd/bases/atlas.mongodb.com_atlasdatabaseusers.yaml
+++ b/config/crd/bases/atlas.mongodb.com_atlasdatabaseusers.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.17.2
   name: atlasdatabaseusers.atlas.mongodb.com
 spec:
   group: atlas.mongodb.com

--- a/config/crd/bases/atlas.mongodb.com_atlasdatafederations.yaml
+++ b/config/crd/bases/atlas.mongodb.com_atlasdatafederations.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.17.2
   name: atlasdatafederations.atlas.mongodb.com
 spec:
   group: atlas.mongodb.com

--- a/config/crd/bases/atlas.mongodb.com_atlasdeployments.yaml
+++ b/config/crd/bases/atlas.mongodb.com_atlasdeployments.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.17.2
   name: atlasdeployments.atlas.mongodb.com
 spec:
   group: atlas.mongodb.com

--- a/config/crd/bases/atlas.mongodb.com_atlasfederatedauths.yaml
+++ b/config/crd/bases/atlas.mongodb.com_atlasfederatedauths.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.17.2
   name: atlasfederatedauths.atlas.mongodb.com
 spec:
   group: atlas.mongodb.com

--- a/config/crd/bases/atlas.mongodb.com_atlasipaccesslists.yaml
+++ b/config/crd/bases/atlas.mongodb.com_atlasipaccesslists.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.17.2
   name: atlasipaccesslists.atlas.mongodb.com
 spec:
   group: atlas.mongodb.com

--- a/config/crd/bases/atlas.mongodb.com_atlasnetworkcontainers.yaml
+++ b/config/crd/bases/atlas.mongodb.com_atlasnetworkcontainers.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.17.2
   name: atlasnetworkcontainers.atlas.mongodb.com
 spec:
   group: atlas.mongodb.com

--- a/config/crd/bases/atlas.mongodb.com_atlasnetworkpeerings.yaml
+++ b/config/crd/bases/atlas.mongodb.com_atlasnetworkpeerings.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.17.2
   name: atlasnetworkpeerings.atlas.mongodb.com
 spec:
   group: atlas.mongodb.com

--- a/config/crd/bases/atlas.mongodb.com_atlasprivateendpoints.yaml
+++ b/config/crd/bases/atlas.mongodb.com_atlasprivateendpoints.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.17.2
   name: atlasprivateendpoints.atlas.mongodb.com
 spec:
   group: atlas.mongodb.com

--- a/config/crd/bases/atlas.mongodb.com_atlasprojects.yaml
+++ b/config/crd/bases/atlas.mongodb.com_atlasprojects.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.17.2
   name: atlasprojects.atlas.mongodb.com
 spec:
   group: atlas.mongodb.com

--- a/config/crd/bases/atlas.mongodb.com_atlassearchindexconfigs.yaml
+++ b/config/crd/bases/atlas.mongodb.com_atlassearchindexconfigs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.17.2
   name: atlassearchindexconfigs.atlas.mongodb.com
 spec:
   group: atlas.mongodb.com

--- a/config/crd/bases/atlas.mongodb.com_atlasstreamconnections.yaml
+++ b/config/crd/bases/atlas.mongodb.com_atlasstreamconnections.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.17.2
   name: atlasstreamconnections.atlas.mongodb.com
 spec:
   group: atlas.mongodb.com

--- a/config/crd/bases/atlas.mongodb.com_atlasstreaminstances.yaml
+++ b/config/crd/bases/atlas.mongodb.com_atlasstreaminstances.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.17.2
   name: atlasstreaminstances.atlas.mongodb.com
 spec:
   group: atlas.mongodb.com

--- a/config/crd/bases/atlas.mongodb.com_atlasteams.yaml
+++ b/config/crd/bases/atlas.mongodb.com_atlasteams.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.17.2
   name: atlasteams.atlas.mongodb.com
 spec:
   group: atlas.mongodb.com

--- a/config/manifests/bases/mongodb-atlas-kubernetes.clusterserviceversion.yaml
+++ b/config/manifests/bases/mongodb-atlas-kubernetes.clusterserviceversion.yaml
@@ -14,6 +14,8 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
+    repository: https://github.com/mongodb/mongodb-atlas-kubernetes
+    support: support@mongodb.com
   labels:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.arm64: supported
@@ -34,6 +36,12 @@ spec:
       kind: AtlasSearchIndexConfig
       name: atlassearchindexconfigs.atlas.mongodb.com
       version: v1
+    - description: The AtlasBackupCompliancePolicy is a configuration that enforces
+        specific backup and retention requirements
+      displayName: Atlas Backup Compliance Policy
+      kind: AtlasBackupCompliancePolicy
+      name: atlasbackupcompliancepolicies.atlas.mongodb.com
+      version: v1
     - description: AtlasBackupPolicy is the Schema for the atlasbackuppolicies API
       displayName: Atlas Backup Policy
       kind: AtlasBackupPolicy
@@ -44,6 +52,11 @@ spec:
       displayName: Atlas Backup Schedule
       kind: AtlasBackupSchedule
       name: atlasbackupschedules.atlas.mongodb.com
+      version: v1
+    - description: AtlasCustomRole is the Schema for the AtlasCustomRole API
+      displayName: Atlas Custom Role
+      kind: AtlasCustomRole
+      name: atlascustomroles.atlas.mongodb.com
       version: v1
     - description: AtlasDatabaseUser is the Schema for the Atlas Database User API
       displayName: Atlas Database User
@@ -60,6 +73,31 @@ spec:
       displayName: Atlas Deployment
       kind: AtlasDeployment
       name: atlasdeployments.atlas.mongodb.com
+      version: v1
+    - description: AtlasIPAccessList is the Schema for the atlasipaccesslists API.
+      displayName: Atlas IPAccess List
+      kind: AtlasIPAccessList
+      name: atlasipaccesslists.atlas.mongodb.com
+      version: v1
+    - description: AtlasNetworkContainer is the Schema for the AtlasNetworkContainer
+        API
+      displayName: Atlas Network Container
+      kind: AtlasNetworkContainer
+      name: atlasnetworkcontainers.atlas.mongodb.com
+      version: v1
+    - description: AtlasNetworkPeering is the Schema for the AtlasNetworkPeering API
+      displayName: Atlas Network Peering
+      kind: AtlasNetworkPeering
+      name: atlasnetworkpeerings.atlas.mongodb.com
+      version: v1
+    - description: |-
+        The AtlasPrivateEndpoint custom resource definition (CRD) defines a desired [Private Endpoint](https://www.mongodb.com/docs/atlas/security-private-endpoint/#std-label-private-endpoint-overview) configuration for an Atlas project.
+        It allows a private connection between your cloud provider and Atlas that doesn't send information through a public network.
+
+        You can use private endpoints to create a unidirectional connection to Atlas clusters from your virtual network.
+      displayName: Atlas Private Endpoint
+      kind: AtlasPrivateEndpoint
+      name: atlasprivateendpoints.atlas.mongodb.com
       version: v1
     - description: AtlasProject is the Schema for the atlasprojects API
       displayName: Atlas Project

--- a/config/samples/atlas_v1_atlasbackupcompliancepolicy.yaml
+++ b/config/samples/atlas_v1_atlasbackupcompliancepolicy.yaml
@@ -1,0 +1,21 @@
+apiVersion: atlas.mongodb.com/v1
+kind: AtlasBackupCompliancePolicy
+metadata:
+  name: my-backup-compliance-policy
+spec:
+  authorizedEmail: john.doe@example.com
+  authorizedUserFirstName: John
+  authorizedUserLastName: Doe
+  copyProtectionEnabled: false
+  encryptionAtRestEnabled: false
+  onDemandPolicy:
+    retentionUnit: weeks
+    retentionValue: 3
+  overwriteBackupPolicies: false
+  pointInTimeEnabled: true
+  restoreWindowDays: 42
+  scheduledPolicyItems:
+    - frequencyInterval: 2
+      frequencyType: daily
+      retentionUnit: days
+      retentionValue: 7

--- a/config/samples/atlas_v1_atlascustomrole.yaml
+++ b/config/samples/atlas_v1_atlascustomrole.yaml
@@ -1,0 +1,25 @@
+apiVersion: atlas.mongodb.com/v1
+kind: AtlasCustomRole
+metadata:
+  name: shard-operator-role
+spec:
+  projectRef:
+    name: my-project
+  role:
+    name: my-role
+    actions:
+      - name: getShardMap
+        resources:
+          - cluster: true
+      - name: shardingState
+        resources:
+           - cluster: true
+      - name: connPoolStats
+        resources:
+           - cluster: true
+      - name: getLog
+        resources:
+           - cluster: true
+    inheritedRoles:
+      - name: operator-role-1
+        database: admin

--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -11,4 +11,12 @@ resources:
   - atlas_v1_atlasipaccesslist.yaml
   - atlas_v1_atlasnetworkcontainer.yaml
   - atlas_v1_atlasnetworkpeering.yaml
+  - atlas_v1_atlasstreaminstance.yaml
+  - atlas_v1_atlasstreamconnection.yaml
+  - atlas_v1_atlasdatafederation.yaml
+  - atlas_v1_atlasfederatedauth.yaml
+  - atlas_v1_atlasprivateendpoint.yaml
+  - atlas_v1_atlassearchindexconfigs.yaml
+  - atlas_v1_atlasbackupcompliancepolicy.yaml
+  - atlas_v1_atlascustomrole.yaml
 # +kubebuilder:scaffold:manifestskustomizesamples

--- a/devbox.json
+++ b/devbox.json
@@ -20,7 +20,7 @@
     "operator-sdk@1.36.1",
     "shellcheck@latest",
     "golangci-lint@2.0.0",
-    "kubernetes-controller-tools@0.16.1",
+    "kubernetes-controller-tools@0.17.2",
     "setup-envtest@0.18.2",
     "awscli2@latest",
     "go-mockery@latest",

--- a/devbox.lock
+++ b/devbox.lock
@@ -478,8 +478,8 @@
       }
     },
     "github:NixOS/nixpkgs/nixpkgs-unstable": {
-      "last_modified": "2025-04-12T07:19:22Z",
-      "resolved": "github:NixOS/nixpkgs/2349f9de17183971db12ae9e0123dab132023bd7?lastModified=1744442362&narHash=sha256-i47t4DRIZgwBZw2Osbrp1OJhhO1k%2Fn%2BQzRx%2BTrmfE9Y%3D"
+      "last_modified": "2025-04-17T05:47:26Z",
+      "resolved": "github:NixOS/nixpkgs/ebe4301cbd8f81c4f8d3244b3632338bbeb6d49c?lastModified=1744868846&narHash=sha256-5RJTdUHDmj12Qsv7XOhuospjAjATNiTMElplWnJE9Hs%3D"
     },
     "go-mockery@latest": {
       "last_modified": "2025-03-27T11:50:31Z",
@@ -969,51 +969,51 @@
         }
       }
     },
-    "kubernetes-controller-tools@0.16.1": {
-      "last_modified": "2024-09-10T15:01:03Z",
-      "resolved": "github:NixOS/nixpkgs/5ed627539ac84809c78b2dd6d26a5cebeb5ae269#kubernetes-controller-tools",
+    "kubernetes-controller-tools@0.17.2": {
+      "last_modified": "2025-03-23T05:31:05Z",
+      "resolved": "github:NixOS/nixpkgs/dd613136ee91f67e5dba3f3f41ac99ae89c5406b#kubernetes-controller-tools",
       "source": "devbox-search",
-      "version": "0.16.1",
+      "version": "0.17.2",
       "systems": {
         "aarch64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/81ynvd61f8jha78p44r6ya7rsf5292qb-controller-tools-0.16.1",
+              "path": "/nix/store/x2g121jdk7fdxb7vx964rrhbiwd0g0rm-controller-tools-0.17.2",
               "default": true
             }
           ],
-          "store_path": "/nix/store/81ynvd61f8jha78p44r6ya7rsf5292qb-controller-tools-0.16.1"
+          "store_path": "/nix/store/x2g121jdk7fdxb7vx964rrhbiwd0g0rm-controller-tools-0.17.2"
         },
         "aarch64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/c2aaf01sisq5ai2zjgnqaxbykxghqy1h-controller-tools-0.16.1",
+              "path": "/nix/store/jaz48mw3pinfdw9gd8fng63gn7wwzmxy-controller-tools-0.17.2",
               "default": true
             }
           ],
-          "store_path": "/nix/store/c2aaf01sisq5ai2zjgnqaxbykxghqy1h-controller-tools-0.16.1"
+          "store_path": "/nix/store/jaz48mw3pinfdw9gd8fng63gn7wwzmxy-controller-tools-0.17.2"
         },
         "x86_64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/42ar5zfn1ycr6pg13q74r4bcrg89pwc5-controller-tools-0.16.1",
+              "path": "/nix/store/3wdf34xlpff7m01ggzr7pb9f3w3cl95f-controller-tools-0.17.2",
               "default": true
             }
           ],
-          "store_path": "/nix/store/42ar5zfn1ycr6pg13q74r4bcrg89pwc5-controller-tools-0.16.1"
+          "store_path": "/nix/store/3wdf34xlpff7m01ggzr7pb9f3w3cl95f-controller-tools-0.17.2"
         },
         "x86_64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/a28n08d6knfjdirnnn1n7ynn5dijccml-controller-tools-0.16.1",
+              "path": "/nix/store/xgppkdij5f73igwfp5as058fmh21wn9p-controller-tools-0.17.2",
               "default": true
             }
           ],
-          "store_path": "/nix/store/a28n08d6knfjdirnnn1n7ynn5dijccml-controller-tools-0.16.1"
+          "store_path": "/nix/store/xgppkdij5f73igwfp5as058fmh21wn9p-controller-tools-0.17.2"
         }
       }
     },


### PR DESCRIPTION
# Summary

Red Hat CI raises a couple of warning when evaluating our operator bundle. This PR adjust the project config to address the following warnings:

check_osdk_bundle_validate_operator_framework
check_osdk_bundle_validate_operatorhub
check_required_fields

The warning check_using_fbc was not addressed once it require change the way we package the bundle.

## Proof of Work

operator-sdk bundle validate ./bundle --select-optional suite=operatorframework

operator-sdk bundle validate ./bundle --select-optional name=operatorhub

operator-sdk bundle validate ./bundle --select-optional name=operatorhubv2

Errors should not be listed by the validation commands above

## Checklist
- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you checked for release_note changes?
- [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?

## Reminder (Please remove this when merging)
- Please try to Approve or Reject Changes the PR, keep PRs in review as short as possible
- Remember the following Communication Standards - use comment prefixes for clarity:
  * **blocking**: Must be addressed before approval.
  * **follow-up**: Can be addressed in a later PR or ticket.
  * **q**: Clarifying question.
  * **nit**: Non-blocking suggestions.
  * **note**: Side-note, non-actionable. Example: Praise 
  * --> no prefix is considered a question

