### PR TITLE
CLOUDP-314621: Use M20 instead of M10 in gov tests

### DIFF
--- a/test/e2e/atlas_gov_test.go
+++ b/test/e2e/atlas_gov_test.go
@@ -493,7 +493,7 @@ var _ = Describe("Atlas for Government", Label("atlas-gov"), func() {
 									{
 										ElectableSpecs: &akov2.Specs{
 											DiskIOPS:     pointer.MakePtr(int64(3000)),
-											InstanceSize: "M10",
+											InstanceSize: "M20",
 											NodeCount:    pointer.MakePtr(3),
 										},
 										AutoScaling: &akov2.AdvancedAutoScalingSpec{
@@ -503,7 +503,7 @@ var _ = Describe("Atlas for Government", Label("atlas-gov"), func() {
 											Compute: &akov2.ComputeSpec{
 												Enabled:          pointer.MakePtr(true),
 												ScaleDownEnabled: pointer.MakePtr(true),
-												MinInstanceSize:  "M10",
+												MinInstanceSize:  "M20",
 												MaxInstanceSize:  "M40",
 											},
 										},


### PR DESCRIPTION
# Summary

Replace M10 with M20 in gov tests, as the gov QA env does not support M10s anymore in AWS.

## Proof of Work

Tested locally, but will test CI as well.

## Checklist
- [X] Have you linked a jira ticket and/or is the ticket in the title?
- [X] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you checked for release_note changes?
- [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?

## Reminder (Please remove this when merging)
- Please try to Approve or Reject Changes the PR, keep PRs in review as short as possible
- Remember the following Communication Standards - use comment prefixes for clarity:
  * **blocking**: Must be addressed before approval.
  * **follow-up**: Can be addressed in a later PR or ticket.
  * **q**: Clarifying question.
  * **nit**: Non-blocking suggestions.
  * **note**: Side-note, non-actionable. Example: Praise 
  * --> no prefix is considered a question

