### PR TITLE
CLOUDP-313350: Fix the commit sign base64 encoding

### DIFF
--- a/scripts/create-signed-commit.sh
+++ b/scripts/create-signed-commit.sh
@@ -18,7 +18,7 @@
 # https://github.com/peter-evans/create-pull-request/issues/1241#issuecomment-1232477512
 
 set -euo pipefail
-  
+
 # Configuration defaults
 github_token=${GITHUB_TOKEN:?}
 repo_owner="${REPO_OWNER:-mongodb}"
@@ -26,59 +26,59 @@ repo_name="${REPO_NAME:-mongodb-atlas-kubernetes}"
 branch="${BRANCH:?}"
 commit_message="${COMMIT_MESSAGE:?}"
 
-# Fetch the latest commit SHA  
+# Fetch the latest commit SHA
 LATEST_COMMIT_SHA=$(curl -s -H "Authorization: token $github_token" \
-  "https://api.github.com/repos/$repo_owner/$repo_name/git/ref/heads/$branch" | jq -r '.object.sha')  
-  
+  "https://api.github.com/repos/$repo_owner/$repo_name/git/ref/heads/$branch" | jq -r '.object.sha')
+
 LATEST_TREE_SHA=$(curl -s -H "Authorization: token $github_token" \
-  "https://api.github.com/repos/$repo_owner/$repo_name/git/commits/$LATEST_COMMIT_SHA" | jq -r '.tree.sha')  
-  
+  "https://api.github.com/repos/$repo_owner/$repo_name/git/commits/$LATEST_COMMIT_SHA" | jq -r '.tree.sha')
+
+echo "Creating a signed commit in GitHub."
 echo "Latest commit SHA: $LATEST_COMMIT_SHA"  
-echo "Latest tree SHA: $LATEST_TREE_SHA"  
-  
+echo "Latest tree SHA: $LATEST_TREE_SHA"
+
 # Collect all modified files  
 MODIFIED_FILES=$(git diff --name-only --cached)  
 echo "Modified files: $MODIFIED_FILES"  
-  
+
 # Create blob and tree  
 NEW_TREE_ARRAY="["  
 for FILE_PATH in $MODIFIED_FILES; do  
   # Read file content encoded to base64  
-  ENCODED_CONTENT=$(base64 < "${FILE_PATH}")  
-  
+  ENCODED_CONTENT=$(base64 -w0 < "${FILE_PATH}")
+
   # Create blob  
-  BLOB_SHA=$(curl -s -X POST -H "Authorization: token $github_token" \
+  BLOB_JSON=$(curl -s -X POST -H "Authorization: token $github_token" \
     -H "Accept: application/vnd.github.v3+json" \
     -d "{\"content\": \"$ENCODED_CONTENT\", \"encoding\": \"base64\"}" \
-    "https://api.github.com/repos/$repo_owner/$repo_name/git/blobs" | jq -r '.sha')  
-  
+    "https://api.github.com/repos/$repo_owner/$repo_name/git/blobs")
+  BLOB_SHA=$(echo "${BLOB_JSON}" | jq -r '.sha')
+
   # Append file info to tree JSON  
   NEW_TREE_ARRAY="${NEW_TREE_ARRAY}{\"path\": \"$FILE_PATH\", \"mode\": \"100644\", \"type\": \"blob\", \"sha\": \"$BLOB_SHA\"},"  
-done  
-  
+done
+
 # Remove trailing comma and close the array  
-NEW_TREE_ARRAY="${NEW_TREE_ARRAY%,}]"  
-  
+NEW_TREE_ARRAY="${NEW_TREE_ARRAY%,}]"
+
 # Create new tree  
 NEW_TREE_SHA=$(curl -s -X POST -H "Authorization: token $github_token" \
   -H "Accept: application/vnd.github.v3+json" \
   -d "{\"base_tree\": \"$LATEST_TREE_SHA\", \"tree\": $NEW_TREE_ARRAY}" \
   "https://api.github.com/repos/$repo_owner/$repo_name/git/trees" | jq -r '.sha')  
-  
+
 echo "New tree SHA: $NEW_TREE_SHA"  
-  
+
 # Create a new commit
-set -x
 NEW_COMMIT_SHA=$(curl -s -X POST -H "Authorization: token $github_token" \
   -H "Accept: application/vnd.github.v3+json" \
   -d "{\"message\": \"$commit_message\", \"tree\": \"$NEW_TREE_SHA\", \"parents\": [\"$LATEST_COMMIT_SHA\"]}" \
-  "https://api.github.com/repos/$repo_owner/$repo_name/git/commits" | jq -r '.sha')  
-set +x
+  "https://api.github.com/repos/$repo_owner/$repo_name/git/commits" | jq -r '.sha')
 echo "New commit SHA: $NEW_COMMIT_SHA"  
-  
+
 # Update the reference of the branch to point to the new commit  
 curl -s -X PATCH -H "Authorization: token $github_token" \
   -H "Accept: application/vnd.github.v3+json" -d "{\"sha\": \"$NEW_COMMIT_SHA\"}" \
   "https://api.github.com/repos/$repo_owner/$repo_name/git/refs/heads/$branch"  
-  
+
 echo "Branch ${branch} updated to new commit ${NEW_COMMIT_SHA}."  


### PR DESCRIPTION
# Summary

Must use `base64 -w0` to avoid new lines in commits with long changes. before that, the base64 encoding adding EOLs to the encoded output was breaking requests sent to GitHub.

Also fixed some formatting whitespacing and EOLs.

## Proof of Work

✅ [Test commit generated in test repo](https://github.com/josvazg/mongodb-atlas-kubernetes/pull/193/commits/82cb78f2ce09850cf20537a580d41abdfd83da54) [Commit generating test job](https://github.com/josvazg/mongodb-atlas-kubernetes/actions/runs/14599365034/job/40953382020)

## Checklist
- [X] Have you linked a jira ticket and/or is the ticket in the title?
- [X] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you checked for release_note changes?
- [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?

## Reminder (Please remove this when merging)
- Please try to Approve or Reject Changes the PR, keep PRs in review as short as possible
- Remember the following Communication Standards - use comment prefixes for clarity:
  * **blocking**: Must be addressed before approval.
  * **follow-up**: Can be addressed in a later PR or ticket.
  * **q**: Clarifying question.
  * **nit**: Non-blocking suggestions.
  * **note**: Side-note, non-actionable. Example: Praise 
  * --> no prefix is considered a question

