### PR TITLE
CLOUDP-312253: Configure codecov

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -2,3 +2,43 @@ comment: false
 
 github_checks:
   annotations: false
+
+coverage:
+  status:
+    project:
+      default: false
+      operator:
+        paths:
+          - "!tests/"
+          - "!tools/"
+      tests:
+        paths: "test/"
+      tools:
+        paths: "tools/"
+
+component_management:
+  default_rules: # default rules that will be inherited by all components
+    statuses:
+      - type: project
+        target: auto
+        informational: true
+  individual_components:
+    - component_id: operator
+      name: operator
+      paths:
+        - "!tests/"
+        - "!tools/"
+    - component_id: test-helpers
+      name: test-helpers
+      paths:
+        - test/**
+    - component_id: tools
+      name: tools
+      paths:
+        - tools/**
+      statuses:
+        - type: project
+          target: auto
+          threshold: 5
+          informational: true
+        - type: patch

--- a/.github/workflows/test-e2e-gov.yml
+++ b/.github/workflows/test-e2e-gov.yml
@@ -46,11 +46,3 @@ jobs:
         with:
           name: logs
           path: output/**
-      - name: Upload test results to codecov.io
-        if: ${{ success() }}
-        uses: codecov/codecov-action@v5
-        with:
-          name: ${{ matrix.test }}
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: test/e2e/coverprofile.out
-          verbose: true

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -276,12 +276,3 @@ jobs:
         with:
           name: logs
           path: output/**
-      - name: Upload test results to codecov.io
-        if: ${{ success() }}
-        uses: codecov/codecov-action@v5
-        with:
-          name: e2e-${{ matrix.test }}
-          flags: e2e,${{ matrix.test }}
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: test/e2e/coverprofile.out
-          verbose: true

--- a/.github/workflows/test-int.yml
+++ b/.github/workflows/test-int.yml
@@ -53,12 +53,3 @@ jobs:
           GINKGO_EDITOR_INTEGRATION: "true"
         run: |
           devbox run -- 'make ${{ matrix.target }}'
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
-        with:
-          name: int-${{ matrix.test }}
-          flags: integration,${{ matrix.test }}
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: coverprofile.out
-          verbose: true
-


### PR DESCRIPTION
# Summary

Codecov is assessing all repository paths and tests types, generating confusing reports and blocking PR to be merged.
This configuration exclude E2E and integration tests from coverage, and make it informational (non-blocking merge). 
## Proof of Work

We should see a realistic number for unit-test coverage. PRs shouldn't be blocked from being merged for wrong reduced coverage.

## Checklist
- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you checked for release_note changes?
- [x] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?

## Reminder (Please remove this when merging)
- Please try to Approve or Reject Changes the PR, keep PRs in review as short as possible
- Remember the following Communication Standards - use comment prefixes for clarity:
  * **blocking**: Must be addressed before approval.
  * **follow-up**: Can be addressed in a later PR or ticket.
  * **q**: Clarifying question.
  * **nit**: Non-blocking suggestions.
  * **note**: Side-note, non-actionable. Example: Praise 
  * --> no prefix is considered a question

