### PR TITLE
CLOUDP-315676: Upgrade golang-jwt to v5

### DIFF
--- a/tools/makejwt/go.mod
+++ b/tools/makejwt/go.mod
@@ -2,4 +2,4 @@ module tools/makejwt
 
 go 1.24
 
-require github.com/golang-jwt/jwt v3.2.2+incompatible
+require github.com/golang-jwt/jwt/v5 v5.2.2

--- a/tools/makejwt/go.sum
+++ b/tools/makejwt/go.sum
@@ -1,2 +1,2 @@
-github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
-github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
+github.com/golang-jwt/jwt/v5 v5.2.2 h1:Rl4B7itRWVtYIHFrSNd7vhTiz9UpLdi6gZhZ3wEeDy8=
+github.com/golang-jwt/jwt/v5 v5.2.2/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=

--- a/tools/makejwt/main.go
+++ b/tools/makejwt/main.go
@@ -29,7 +29,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/golang-jwt/jwt"
+	"github.com/golang-jwt/jwt/v5"
 )
 
 var (

--- a/tools/makejwt/main_test.go
+++ b/tools/makejwt/main_test.go
@@ -27,7 +27,7 @@ import (
 	"encoding/base64"
 	"testing"
 
-	"github.com/golang-jwt/jwt"
+	"github.com/golang-jwt/jwt/v5"
 )
 
 func generateRandomRSAKey() (*rsa.PrivateKey, error) {


### PR DESCRIPTION
# Summary

Upgrade golang-jwt to v5.

This is expected to fix Security Alert [#51 jwt-go allows excessive memory allocation during header parsing](https://github.com/mongodb/mongodb-atlas-kubernetes/security/dependabot/51)

## Proof of Work

CI should pass

## Checklist
- [X] Have you linked a jira ticket and/or is the ticket in the title?
- [X] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you checked for release_note changes?
- [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?

## Reminder (Please remove this when merging)
- Please try to Approve or Reject Changes the PR, keep PRs in review as short as possible
- Remember the following Communication Standards - use comment prefixes for clarity:
  * **blocking**: Must be addressed before approval.
  * **follow-up**: Can be addressed in a later PR or ticket.
  * **q**: Clarifying question.
  * **nit**: Non-blocking suggestions.
  * **note**: Side-note, non-actionable. Example: Praise 
  * --> no prefix is considered a question

