### PR TITLE
CLOUDP-315738: Fixup devbox-update.yml

### DIFF
--- a/.github/workflows/devbox-update.yml
+++ b/.github/workflows/devbox-update.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   update-devbox:
     runs-on: ubuntu-latest
-
+    environment: release
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v4

--- a/.github/workflows/devbox-update.yml
+++ b/.github/workflows/devbox-update.yml
@@ -52,6 +52,7 @@ jobs:
         COMMIT_MESSAGE: 'Weekly devbox dependencies update'
         BRANCH: ${{ steps.generate_branch.outputs.BRANCH_NAME }}
       run: |
+        git checkout -b "${BRANCH}"
         git add .
         scripts/create-signed-commit.sh
 

--- a/scripts/create-signed-commit.sh
+++ b/scripts/create-signed-commit.sh
@@ -17,7 +17,7 @@
 # author and committer arguments. See:
 # https://github.com/peter-evans/create-pull-request/issues/1241#issuecomment-1232477512
 
-set -euo pipefail
+set -euxo pipefail
 
 # Configuration defaults
 github_token=${GITHUB_TOKEN:?}

--- a/scripts/create-signed-commit.sh
+++ b/scripts/create-signed-commit.sh
@@ -17,7 +17,7 @@
 # author and committer arguments. See:
 # https://github.com/peter-evans/create-pull-request/issues/1241#issuecomment-1232477512
 
-set -euxo pipefail
+set -euo pipefail
 
 # Configuration defaults
 github_token=${GITHUB_TOKEN:?}


### PR DESCRIPTION
# Summary

Some missing bits breaking the devbox automated updates:
- No **release** env was making secrets inaccesible for the workflow.
- Had to name the local branch properly for the sign commit and push to work properly.

## Proof of Work

✅ [Manual run worked](https://github.com/mongodb/mongodb-atlas-kubernetes/actions/runs/14693761761)

## Checklist
- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you checked for release_note changes?
- [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?

## Reminder (Please remove this when merging)
- Please try to Approve or Reject Changes the PR, keep PRs in review as short as possible
- Remember the following Communication Standards - use comment prefixes for clarity:
  * **blocking**: Must be addressed before approval.
  * **follow-up**: Can be addressed in a later PR or ticket.
  * **q**: Clarifying question.
  * **nit**: Non-blocking suggestions.
  * **note**: Side-note, non-actionable. Example: Praise 
  * --> no prefix is considered a question

