### PR TITLE
CLOUDP-315762: Fix workflow path to create-signed-commit.sh

### DIFF
--- a/.github/workflows/sync-helm-charts.yaml
+++ b/.github/workflows/sync-helm-charts.yaml
@@ -101,7 +101,7 @@ jobs:
 
             export GITHUB_TOKEN="${GH_TOKEN}"
             git add .
-            scripts/create-signed-commit.sh
+            ../scripts/create-signed-commit.sh
 
             gh pr create --base main --head "${BRANCH}" --title "${COMMIT_MSG}" --body "${COMMIT_MSG}"
           fi


### PR DESCRIPTION
# Summary

Fix the path to reach the `create-signed-commit.sh` script properly. The workflow script working directory is not at the root directory of the repo, instead it is at `./helm-charts-cloned` at that point.

## Proof of Work

TBD

## Checklist
- [X] Have you linked a jira ticket and/or is the ticket in the title?
- [X] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you checked for release_note changes?
- [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?

## Reminder (Please remove this when merging)
- Please try to Approve or Reject Changes the PR, keep PRs in review as short as possible
- Remember the following Communication Standards - use comment prefixes for clarity:
  * **blocking**: Must be addressed before approval.
  * **follow-up**: Can be addressed in a later PR or ticket.
  * **q**: Clarifying question.
  * **nit**: Non-blocking suggestions.
  * **note**: Side-note, non-actionable. Example: Praise 
  * --> no prefix is considered a question

