### PR TITLE
CLOUDP-317676: Revert not to bump deployment chart with AKO releases

### DIFF
--- a/helm-charts/atlas-deployment/Chart.yaml
+++ b/helm-charts/atlas-deployment/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart to manage Atlas resources with Atlas operator
 
 type: application
 
-version: 2.8.1
+version: 2.8.0
 
 keywords:
 - mongodb
@@ -12,7 +12,7 @@ keywords:
 - nosql
 home: https://github.com/mongodb/mongodb-enterprise-kubernetes
 icon: https://webimages.mongodb.com/_com_assets/cms/kuyjf3vea2hg34taa-horizontal_default_slate_blue.svg
-appVersion: "2.8.1"
+appVersion: "2.8.0"
 maintainers:
   - name: MongoDB
     email: support@mongodb.com

--- a/scripts/bump-helm-chart-version.sh
+++ b/scripts/bump-helm-chart-version.sh
@@ -18,7 +18,6 @@ set -euo pipefail
 version=${VERSION:?}
 
 FILES=(
-  "helm-charts/atlas-deployment/Chart.yaml"
   "helm-charts/atlas-operator-crds/Chart.yaml"
   "helm-charts/atlas-operator/Chart.yaml"
 )


### PR DESCRIPTION
# Summary

Fixup the deployment chart no tto bump its version with the AKO releases. That was a mistake.

## Proof of Work

Upon merging, this should NOT create a sync PR in the helm charts repo.

## Checklist
- [X] Have you linked a jira ticket and/or is the ticket in the title?
- [X] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you checked for release_note changes?
- [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?

## Reminder (Please remove this when merging)
- Please try to Approve or Reject Changes the PR, keep PRs in review as short as possible
- Remember the following Communication Standards - use comment prefixes for clarity:
  * **blocking**: Must be addressed before approval.
  * **follow-up**: Can be addressed in a later PR or ticket.
  * **q**: Clarifying question.
  * **nit**: Non-blocking suggestions.
  * **note**: Side-note, non-actionable. Example: Praise 
  * --> no prefix is considered a question

