### PR TITLE
CLOUDP-318983: Fixed typo in tag values for deployments

### DIFF
--- a/api/v1/atlasdeployment_types.go
+++ b/api/v1/atlasdeployment_types.go
@@ -218,7 +218,7 @@ type TagSpec struct {
 	Key string `json:"key"`
 	// +kubebuilder:validation:MaxLength:=255
 	// +kubebuilder:validation:MinLength:=1
-	// +kubebuilder:validation:Pattern:=^[a-zA-Z0-9][a-zA-Z0-9@_.+`;`-]*$
+	// +kubebuilder:validation:Pattern:=^[a-zA-Z0-9][a-zA-Z0-9 @_.+`;`-]*$
 	Value string `json:"value"`
 }
 

--- a/config/crd/bases/atlas.mongodb.com_atlasdeployments.yaml
+++ b/config/crd/bases/atlas.mongodb.com_atlasdeployments.yaml
@@ -596,7 +596,7 @@ spec:
                         value:
                           maxLength: 255
                           minLength: 1
-                          pattern: ^[a-zA-Z0-9][a-zA-Z0-9@_.+`;`-]*$
+                          pattern: ^[a-zA-Z0-9][a-zA-Z0-9 @_.+`;`-]*$
                           type: string
                       required:
                       - key
@@ -676,7 +676,7 @@ spec:
                         value:
                           maxLength: 255
                           minLength: 1
-                          pattern: ^[a-zA-Z0-9][a-zA-Z0-9@_.+`;`-]*$
+                          pattern: ^[a-zA-Z0-9][a-zA-Z0-9 @_.+`;`-]*$
                           type: string
                       required:
                       - key
@@ -895,7 +895,7 @@ spec:
                         value:
                           maxLength: 255
                           minLength: 1
-                          pattern: ^[a-zA-Z0-9][a-zA-Z0-9@_.+`;`-]*$
+                          pattern: ^[a-zA-Z0-9][a-zA-Z0-9 @_.+`;`-]*$
                           type: string
                       required:
                       - key

--- a/test/int/deployment_test.go
+++ b/test/int/deployment_test.go
@@ -299,7 +299,6 @@ var _ = Describe("AtlasDeployment", Label("int", "AtlasDeployment", "deployment-
 					secret.StringData = secretData()
 				})
 				Expect(err).To(BeNil())
-
 			})
 
 			By("Checking that the Deployment is deleted", func() {
@@ -722,7 +721,7 @@ var _ = Describe("AtlasDeployment", Label("int", "AtlasDeployment", "deployment-
 
 			By("Updating the Deployment tags", func() {
 				createdDeployment = performUpdate(ctx, 30*time.Minute, client.ObjectKeyFromObject(createdDeployment), func(deployment *akov2.AtlasDeployment) {
-					deployment.Spec.DeploymentSpec.Tags = []*akov2.TagSpec{{Key: "test-1", Value: "value-1"}, {Key: "test-2", Value: "value-2"}}
+					deployment.Spec.DeploymentSpec.Tags = []*akov2.TagSpec{{Key: "test 1", Value: "value 1"}, {Key: "test-2", Value: "value-2"}}
 				})
 				doDeploymentStatusChecks()
 				checkAtlasState(func(c *admin.AdvancedClusterDescription) {
@@ -970,7 +969,6 @@ var _ = Describe("AtlasDeployment", Label("int", "AtlasDeployment", "deployment-
 
 	Describe("Setting the deployment skip annotation should skip reconciliations.", func() {
 		It("Should Succeed", func(ctx context.Context) {
-
 			By(`Creating the deployment with reconciliation policy "skip" first`, func() {
 				createdDeployment = akov2.DefaultAWSDeployment(namespace.Name, createdProject.Name).Lightweight()
 				performCreate(createdDeployment, 30*time.Minute)
@@ -1356,7 +1354,6 @@ var _ = Describe("AtlasDeployment", Ordered, Label("int", "AtlasDeployment", "de
 					}
 					return nil
 				}).WithTimeout(5 * time.Minute).WithPolling(5 * time.Second).Should(Not(HaveOccurred()))
-
 			})
 		})
 	})
@@ -1443,7 +1440,6 @@ var _ = Describe("AtlasDeployment", Ordered, Label("int", "AtlasDeployment", "de
 					}
 				})
 				Expect(err).To(BeNil())
-
 			})
 
 			By("Deployment is ready with backup and snapshot distribution configured", func() {


### PR DESCRIPTION
# Summary

Fixed typo in tag values for deployments. This PR resolves: https://github.com/mongodb/mongodb-atlas-kubernetes/issues/2329

## Checklist
- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you checked for release_note changes?
- [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?

