### PR TITLE
CLOUDP-319574: set finalizer when user is expired

### DIFF
--- a/internal/controller/atlasdatabaseuser/databaseuser.go
+++ b/internal/controller/atlasdatabaseuser/databaseuser.go
@@ -92,7 +92,7 @@ func (r *AtlasDatabaseUserReconciler) dbuLifeCycle(ctx *workflow.Context, dbUser
 			return r.terminate(ctx, atlasDatabaseUser, api.DatabaseUserReadyType, workflow.DatabaseUserConnectionSecretsNotDeleted, true, err)
 		}
 
-		return r.terminate(ctx, atlasDatabaseUser, api.DatabaseUserReadyType, workflow.DatabaseUserExpired, false, errors.New("an expired user cannot be managed"))
+		return r.unmanage(ctx, atlasProject.ID, atlasDatabaseUser)
 	}
 
 	scopesAreValid, err := r.areDeploymentScopesValid(ctx, deploymentService, atlasProject.ID, atlasDatabaseUser)

--- a/internal/controller/atlasdatabaseuser/databaseuser.go
+++ b/internal/controller/atlasdatabaseuser/databaseuser.go
@@ -92,6 +92,7 @@ func (r *AtlasDatabaseUserReconciler) dbuLifeCycle(ctx *workflow.Context, dbUser
 			return r.terminate(ctx, atlasDatabaseUser, api.DatabaseUserReadyType, workflow.DatabaseUserConnectionSecretsNotDeleted, true, err)
 		}
 
+		ctx.SetConditionFromResult(api.DatabaseUserReadyType, workflow.Terminate(workflow.DatabaseUserExpired, errors.New("an expired user cannot be managed")))
 		return r.unmanage(ctx, atlasProject.ID, atlasDatabaseUser)
 	}
 

--- a/internal/controller/atlasdatabaseuser/databaseuser_test.go
+++ b/internal/controller/atlasdatabaseuser/databaseuser_test.go
@@ -478,6 +478,11 @@ func TestDbuLifeCycle(t *testing.T) {
 				return translation.NewAtlasDeploymentsServiceMock(t)
 			},
 			expectedResult: ctrl.Result{},
+			expectedConditions: []api.Condition{
+				api.FalseCondition(api.DatabaseUserReadyType).
+					WithReason(string(workflow.DatabaseUserExpired)).
+					WithMessageRegexp("an expired user cannot be managed"),
+			},
 		},
 		"failed to validate scope": {
 			dbUserInAKO: &akov2.AtlasDatabaseUser{

--- a/internal/controller/atlasdatabaseuser/databaseuser_test.go
+++ b/internal/controller/atlasdatabaseuser/databaseuser_test.go
@@ -478,11 +478,6 @@ func TestDbuLifeCycle(t *testing.T) {
 				return translation.NewAtlasDeploymentsServiceMock(t)
 			},
 			expectedResult: ctrl.Result{},
-			expectedConditions: []api.Condition{
-				api.FalseCondition(api.DatabaseUserReadyType).
-					WithReason(string(workflow.DatabaseUserExpired)).
-					WithMessageRegexp("an expired user cannot be managed"),
-			},
 		},
 		"failed to validate scope": {
 			dbUserInAKO: &akov2.AtlasDatabaseUser{

--- a/test/e2e/db_users_test.go
+++ b/test/e2e/db_users_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package e2e
+package e2e_test
 
 import (
 	"context"


### PR DESCRIPTION
# Summary

This removes the finalizer if the underlying atlas database user is expired, allowing users to delete it.

## Proof of Work

Unit tests are already in place, changed the checked invariant.

## Checklist
- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you checked for release_note changes?
- [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?

## Reminder (Please remove this when merging)
- Please try to Approve or Reject Changes the PR, keep PRs in review as short as possible
- Remember the following Communication Standards - use comment prefixes for clarity:
  * **blocking**: Must be addressed before approval.
  * **follow-up**: Can be addressed in a later PR or ticket.
  * **q**: Clarifying question.
  * **nit**: Non-blocking suggestions.
  * **note**: Side-note, non-actionable. Example: Praise 
  * --> no prefix is considered a question

Fixes #2145
