### PR TITLE
Fix: Remove redundant tag calculation for E2E tests

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -27,6 +27,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       REPOSITORY: ${{ github.repository_owner }}/mongodb-atlas-kubernetes-operator-prerelease
+    outputs:
+        tag: ${{ steps.prepare.outputs.tag }}
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -34,11 +36,13 @@ jobs:
           ref: ${{github.event.pull_request.head.sha}}
           submodules: true
           fetch-depth: 0
+
       - name: Prepare tag
         id: prepare
         uses: ./.github/actions/set-tag
       - name: Log in to ghcr.io registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
+
       - name: Build and Push image
         uses: ./.github/actions/build-push-image
         with:
@@ -48,6 +52,7 @@ jobs:
           tags: ghcr.io/${{ env.REPOSITORY }}:${{ steps.prepare.outputs.tag }}
           platforms: linux/amd64
           push_to_docker: false
+
       - name: Do preflight-check on test image
         uses: ./.github/actions/certify-openshift-images
         with:
@@ -180,9 +185,7 @@ jobs:
         uses: jetify-com/devbox-install-action@v0.12.0
         with:
           enable-cache: 'true'
-      - name: Prepare tag
-        id: prepare
-        uses: ./.github/actions/set-tag
+          
       - name: Set properties
         id: properties
         run: |
@@ -194,8 +197,8 @@ jobs:
       - name: Generate configuration for the tests
         uses: ./.github/actions/gen-install-scripts
         with:
-          IMAGE_URL: ${{ env.GHCR_REPO }}:${{ steps.prepare.outputs.tag }}
-          VERSION: ${{ steps.prepare.outputs.tag }}
+          IMAGE_URL: ${{ env.GHCR_REPO }}:${{ needs.prepare-e2e.outputs.tag }}
+          VERSION: ${{ needs.prepare-e2e.outputs.tag }}
           ENV: dev
 
       - name: Change path for the test
@@ -226,11 +229,11 @@ jobs:
           MCLI_PRIVATE_API_KEY: ${{ secrets.ATLAS_PRIVATE_KEY }}
           MCLI_ORG_ID: ${{ secrets.ATLAS_ORG_ID}}
           MCLI_OPS_MANAGER_URL: "https://cloud-qa.mongodb.com/"
-          IMAGE_URL: "${{ env.GHCR_REPO }}:${{ steps.prepare.outputs.tag }}"
+          IMAGE_URL: "${{ env.GHCR_REPO }}:${{ needs.prepare-e2e.outputs.tag }}"
           IMAGE_PULL_SECRET_REGISTRY: ghcr.io
           IMAGE_PULL_SECRET_USERNAME: $
           IMAGE_PULL_SECRET_PASSWORD: "${{ secrets.GITHUB_TOKEN }}"
-          BUNDLE_IMAGE: "${{ env.GHCR_BUNDLES_REPO}}:${{ steps.prepare.outputs.tag }}"
+          BUNDLE_IMAGE: "${{ env.GHCR_BUNDLES_REPO}}:${{ needs.prepare-e2e.outputs.tag }}"
           K8S_PLATFORM: "${{ steps.properties.outputs.k8s_platform }}"
           K8S_VERSION: "${{ steps.properties.outputs.k8s_version }}"
           TEST_NAME: "${{ matrix.test }}"


### PR DESCRIPTION
# Summary

Remove redundant tag calculation for E2E tests

## Checklist
- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you checked for release_note changes?
- [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?

