### PR TITLE
CLOUDP-320196: fix skew detection for disabled compute autoscaling

### DIFF
--- a/internal/controller/atlasdeployment/advanced_deployment_test.go
+++ b/internal/controller/atlasdeployment/advanced_deployment_test.go
@@ -577,6 +577,14 @@ func TestHandleAdvancedDeployment(t *testing.T) {
 										InstanceSize: "M10",
 										NodeCount:    pointer.MakePtr(3),
 									},
+									AutoScaling: &akov2.AdvancedAutoScalingSpec{
+										Compute: &akov2.ComputeSpec{
+											Enabled: pointer.MakePtr(false),
+										},
+										DiskGB: &akov2.DiskGB{
+											Enabled: pointer.MakePtr(false),
+										},
+									},
 								},
 							},
 						},
@@ -659,6 +667,14 @@ func TestHandleAdvancedDeployment(t *testing.T) {
 									ElectableSpecs: &akov2.Specs{
 										InstanceSize: "M10",
 										NodeCount:    pointer.MakePtr(3),
+									},
+									AutoScaling: &akov2.AdvancedAutoScalingSpec{
+										Compute: &akov2.ComputeSpec{
+											Enabled: pointer.MakePtr(false),
+										},
+										DiskGB: &akov2.DiskGB{
+											Enabled: pointer.MakePtr(false),
+										},
 									},
 								},
 							},

--- a/internal/controller/atlasdeployment/advanced_deployment_test.go
+++ b/internal/controller/atlasdeployment/advanced_deployment_test.go
@@ -551,6 +551,7 @@ func TestHandleAdvancedDeployment(t *testing.T) {
 					},
 				},
 			},
+			//nolint:dupl
 			deploymentInAtlas: &deployment.Cluster{
 				ProjectID: "project-id",
 				State:     "IDLE",
@@ -642,6 +643,7 @@ func TestHandleAdvancedDeployment(t *testing.T) {
 					},
 				},
 			},
+			//nolint:dupl
 			deploymentInAtlas: &deployment.Cluster{
 				ProjectID: "project-id",
 				State:     "IDLE",

--- a/internal/translation/deployment/conversion.go
+++ b/internal/translation/deployment/conversion.go
@@ -426,7 +426,13 @@ func normalizeRegionConfigs(regionConfigs []*akov2.AdvancedRegionConfig, isTenan
 			regionConfig.AutoScaling.Compute.Enabled == nil || !*regionConfig.AutoScaling.Compute.Enabled
 		diskUnsetOrDisabled := regionConfig.AutoScaling == nil || regionConfig.AutoScaling.DiskGB == nil ||
 			regionConfig.AutoScaling.DiskGB.Enabled == nil || !*regionConfig.AutoScaling.DiskGB.Enabled
-		if computeUnsetOrDisabled && diskUnsetOrDisabled {
+
+		switch {
+		case computeUnsetOrDisabled && regionConfig.AutoScaling != nil:
+			regionConfig.AutoScaling.Compute = &akov2.ComputeSpec{
+				Enabled: pointer.MakePtr(false),
+			}
+		case computeUnsetOrDisabled && diskUnsetOrDisabled:
 			regionConfig.AutoScaling = nil
 		}
 	}

--- a/internal/translation/deployment/conversion.go
+++ b/internal/translation/deployment/conversion.go
@@ -427,13 +427,20 @@ func normalizeRegionConfigs(regionConfigs []*akov2.AdvancedRegionConfig, isTenan
 		diskUnsetOrDisabled := regionConfig.AutoScaling == nil || regionConfig.AutoScaling.DiskGB == nil ||
 			regionConfig.AutoScaling.DiskGB.Enabled == nil || !*regionConfig.AutoScaling.DiskGB.Enabled
 
-		switch {
-		case computeUnsetOrDisabled && regionConfig.AutoScaling != nil:
+		if regionConfig.AutoScaling == nil {
+			regionConfig.AutoScaling = &akov2.AdvancedAutoScalingSpec{}
+		}
+
+		if computeUnsetOrDisabled {
 			regionConfig.AutoScaling.Compute = &akov2.ComputeSpec{
 				Enabled: pointer.MakePtr(false),
 			}
-		case computeUnsetOrDisabled && diskUnsetOrDisabled:
-			regionConfig.AutoScaling = nil
+		}
+
+		if diskUnsetOrDisabled {
+			regionConfig.AutoScaling.DiskGB = &akov2.DiskGB{
+				Enabled: pointer.MakePtr(false),
+			}
 		}
 	}
 }

--- a/internal/translation/deployment/conversion_test.go
+++ b/internal/translation/deployment/conversion_test.go
@@ -200,6 +200,14 @@ func TestNewDeployment(t *testing.T) {
 										InstanceSize: "M10",
 										NodeCount:    pointer.MakePtr(3),
 									},
+									AutoScaling: &akov2.AdvancedAutoScalingSpec{
+										Compute: &akov2.ComputeSpec{
+											Enabled: pointer.MakePtr(false),
+										},
+										DiskGB: &akov2.DiskGB{
+											Enabled: pointer.MakePtr(false),
+										},
+									},
 								},
 							},
 						},
@@ -547,6 +555,14 @@ func TestNormalizeClusterDeployment(t *testing.T) {
 									AnalyticsSpecs: nil,
 									ElectableSpecs: nil,
 									ReadOnlySpecs:  nil,
+									AutoScaling: &akov2.AdvancedAutoScalingSpec{
+										Compute: &akov2.ComputeSpec{
+											Enabled: pointer.MakePtr(false),
+										},
+										DiskGB: &akov2.DiskGB{
+											Enabled: pointer.MakePtr(false),
+										},
+									},
 								},
 							},
 						},
@@ -591,6 +607,14 @@ func TestNormalizeClusterDeployment(t *testing.T) {
 									AnalyticsSpecs: nil,
 									ElectableSpecs: nil,
 									ReadOnlySpecs:  nil,
+									AutoScaling: &akov2.AdvancedAutoScalingSpec{
+										Compute: &akov2.ComputeSpec{
+											Enabled: pointer.MakePtr(false),
+										},
+										DiskGB: &akov2.DiskGB{
+											Enabled: pointer.MakePtr(false),
+										},
+									},
 								},
 							},
 						},
@@ -645,6 +669,9 @@ func TestNormalizeClusterDeployment(t *testing.T) {
 									ReadOnlySpecs:  nil,
 									AutoScaling: &akov2.AdvancedAutoScalingSpec{
 										Compute: &akov2.ComputeSpec{
+											Enabled: pointer.MakePtr(false),
+										},
+										DiskGB: &akov2.DiskGB{
 											Enabled: pointer.MakePtr(false),
 										},
 									},
@@ -746,6 +773,14 @@ func TestNormalizeClusterDeployment(t *testing.T) {
 									ElectableSpecs: &akov2.Specs{
 										InstanceSize: "M10",
 										NodeCount:    pointer.MakePtr(3),
+									},
+									AutoScaling: &akov2.AdvancedAutoScalingSpec{
+										Compute: &akov2.ComputeSpec{
+											Enabled: pointer.MakePtr(false),
+										},
+										DiskGB: &akov2.DiskGB{
+											Enabled: pointer.MakePtr(false),
+										},
 									},
 								},
 							},

--- a/internal/translation/deployment/conversion_test.go
+++ b/internal/translation/deployment/conversion_test.go
@@ -598,6 +598,63 @@ func TestNormalizeClusterDeployment(t *testing.T) {
 				},
 			},
 		},
+		"regionconfig specs with autoscaling": {
+			deployment: &Cluster{
+				AdvancedDeploymentSpec: &akov2.AdvancedDeploymentSpec{
+					ReplicationSpecs: []*akov2.AdvancedReplicationSpec{
+						{
+							RegionConfigs: []*akov2.AdvancedRegionConfig{
+								{
+									AnalyticsSpecs: &akov2.Specs{},
+									ElectableSpecs: &akov2.Specs{},
+									ReadOnlySpecs:  &akov2.Specs{},
+									AutoScaling: &akov2.AdvancedAutoScalingSpec{
+										Compute: &akov2.ComputeSpec{
+											Enabled:          pointer.MakePtr(false),
+											ScaleDownEnabled: pointer.MakePtr(false),
+											MinInstanceSize:  "M10",
+											MaxInstanceSize:  "M10",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: &Cluster{
+				AdvancedDeploymentSpec: &akov2.AdvancedDeploymentSpec{
+					ClusterType:              "REPLICASET",
+					EncryptionAtRestProvider: "NONE",
+					MongoDBMajorVersion:      "7.0",
+					VersionReleaseSystem:     "LTS",
+					Paused:                   pointer.MakePtr(false),
+					PitEnabled:               pointer.MakePtr(false),
+					RootCertType:             "ISRGROOTX1",
+					BackupEnabled:            pointer.MakePtr(false),
+					Tags:                     []*akov2.TagSpec{},
+
+					ReplicationSpecs: []*akov2.AdvancedReplicationSpec{
+						{
+							NumShards: 1,
+							ZoneName:  "Zone 1",
+							RegionConfigs: []*akov2.AdvancedRegionConfig{
+								{
+									AnalyticsSpecs: nil,
+									ElectableSpecs: nil,
+									ReadOnlySpecs:  nil,
+									AutoScaling: &akov2.AdvancedAutoScalingSpec{
+										Compute: &akov2.ComputeSpec{
+											Enabled: pointer.MakePtr(false),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 		"normalize deployment configuration": {
 			deployment: &Cluster{
 				AdvancedDeploymentSpec: &akov2.AdvancedDeploymentSpec{


### PR DESCRIPTION
# Summary

This fixes skew detection if compute autoscaling is disabled but the user still configures remaining autoscaling fields (like instance sizes).

Previously, skew was always detected, causing indefinite reconciles. See the referenced HELP ticket for more details.

## Proof of Work

Added new unit test and changed existing unit tests reflecting the changed translation layer behavior.

## Checklist
- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you checked for release_note changes?
- [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?

## Reminder (Please remove this when merging)
- Please try to Approve or Reject Changes the PR, keep PRs in review as short as possible
- Remember the following Communication Standards - use comment prefixes for clarity:
  * **blocking**: Must be addressed before approval.
  * **follow-up**: Can be addressed in a later PR or ticket.
  * **q**: Clarifying question.
  * **nit**: Non-blocking suggestions.
  * **note**: Side-note, non-actionable. Example: Praise 
  * --> no prefix is considered a question

