### PR TITLE
Developer productivity: make klog configurable

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -68,8 +69,9 @@ func main() {
 		os.Exit(1)
 	}
 
-	ctrl.SetLogger(zapr.NewLogger(logger))
-	klog.SetLogger(zapr.NewLogger(logger))
+	logrLogger := zapr.NewLogger(logger)
+	ctrl.SetLogger(logrLogger.WithName("ctrl"))
+	klog.SetLogger(logrLogger.WithName("klog"))
 	setupLog := logger.Named("setup").Sugar()
 	setupLog.Info("starting with configuration", zap.Any("config", config), zap.Any("version", version.Version))
 
@@ -127,7 +129,7 @@ func parseConfiguration() Config {
 	flag.BoolVar(&config.EnableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
-	flag.StringVar(&config.LogLevel, "log-level", "info", "Log level. Available values: debug | info | warn | error | dpanic | panic | fatal")
+	flag.StringVar(&config.LogLevel, "log-level", "info", "Log level. Available values: debug | info | warn | error | dpanic | panic | fatal or a numeric value from -9 to 5, where -9 is the most verbose and 5 is the least verbose.")
 	flag.StringVar(&config.LogEncoder, "log-encoder", "json", "Log encoder. Available values: json | console")
 	flag.BoolVar(&config.ObjectDeletionProtection, objectDeletionProtectionFlag, objectDeletionProtectionDefault, "Defines if the operator deletes Atlas resource "+
 		"when a Custom Resource is deleted")
@@ -191,9 +193,31 @@ func operatorGlobalKeySecretOrDefault(secretNameOverride string) client.ObjectKe
 
 func initCustomZapLogger(level, encoding string) (*zap.Logger, error) {
 	lv := zap.AtomicLevel{}
-	err := lv.UnmarshalText([]byte(strings.ToLower(level)))
+
+	numericLevel, err := strconv.Atoi(level)
 	if err != nil {
-		return nil, err
+		// not a numeric level, try to unmarshal it as a zapcore.Level ("debug", "info", "warn", "error", "dpanic", "panic", or "fatal")
+		err := lv.UnmarshalText([]byte(strings.ToLower(level)))
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		// numeric level:
+		// 1. configure klog if the numeric log level is negative and the absolute value of the negative numeric value represents the klog level.
+		// 2. configure the atomic zap level based on the numeric value (5..-9).
+
+		klogLevel := 0
+		if numericLevel < 0 {
+			klogLevel = -numericLevel
+		}
+
+		klogFlagSet := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+		klog.InitFlags(klogFlagSet)
+		if err := klogFlagSet.Set("v", strconv.Itoa(klogLevel)); err != nil {
+			return nil, err
+		}
+
+		lv = zap.NewAtomicLevelAt(zapcore.Level(numericLevel))
 	}
 
 	enc := strings.ToLower(encoding)

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap/zapcore"
 )
 
 func Test_configureDeletionProtection(t *testing.T) {
@@ -193,4 +194,56 @@ func Test_configureDeletionProtection(t *testing.T) {
 			config,
 		)
 	})
+}
+
+func TestInitCustomZapLogger(t *testing.T) {
+	tests := []struct {
+		name      string
+		level     string
+		wantLevel zapcore.Level
+		wantErr   bool
+	}{
+		{
+			name:      "valid string level info with json encoding",
+			level:     "info",
+			wantLevel: zapcore.InfoLevel,
+			wantErr:   false,
+		},
+		{
+			name:      "valid string level debug with console encoding",
+			level:     "debug",
+			wantLevel: zapcore.DebugLevel,
+			wantErr:   false,
+		},
+		{
+			name:      "valid numeric level",
+			level:     "-1",
+			wantLevel: zapcore.Level(-1),
+			wantErr:   false,
+		},
+		{
+			name:    "invalid level",
+			level:   "invalid",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger, err := initCustomZapLogger(tt.level, "json")
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Nil(t, logger)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.NotNil(t, logger)
+
+			// Verify logger configuration
+			loggerImpl := logger.Core()
+			assert.True(t, loggerImpl.Enabled(tt.wantLevel))
+		})
+	}
 }


### PR DESCRIPTION
# Summary

This enables klog configuration using numeric values while retaining existing string based logger configuration. This is  useful for local development against Kubernetes API-Server.

## Proof of Work

Added unit test.

## Checklist
- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you checked for release_note changes?
- [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?

## Reminder (Please remove this when merging)
- Please try to Approve or Reject Changes the PR, keep PRs in review as short as possible
- Remember the following Communication Standards - use comment prefixes for clarity:
  * **blocking**: Must be addressed before approval.
  * **follow-up**: Can be addressed in a later PR or ticket.
  * **q**: Clarifying question.
  * **nit**: Non-blocking suggestions.
  * **note**: Side-note, non-actionable. Example: Praise 
  * --> no prefix is considered a question

