### PR TITLE
CLOUDP-304701: only trigger commits on vX.Y.Z tags

### DIFF
--- a/.github/workflows/release-post-merge.yml
+++ b/.github/workflows/release-post-merge.yml
@@ -7,7 +7,7 @@ name: Create Release
 on:
   push:
     tags:
-      - 'v*'
+      - 'v[0-9]+.[0-9]+.[0-9]+'
   workflow_call:
     inputs:
       tag:


### PR DESCRIPTION
# Summary

As part of the AKO and AKO plugin release processes, we'd like the release pipeline to be triggered for only "vX.Y.Z" tags

## Checklist
- [X] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you checked for release_note changes?
- [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
