### PR TITLE
CLOUDP-321083: fix reconciliation loop on dbuser

### DIFF
--- a/internal/translation/dbuser/conversion.go
+++ b/internal/translation/dbuser/conversion.go
@@ -156,7 +156,7 @@ func toAtlas(au *User) (*admin.CloudDatabaseUser, error) {
 		X509Type:        pointer.MakePtrOrNil(au.X509Type),
 		AwsIAMType:      pointer.MakePtrOrNil(au.AWSIAMType),
 		GroupId:         au.ProjectID,
-		Description:     pointer.MakePtrOrNil(au.Description),
+		Description:     pointer.MakePtr(au.Description),
 		Labels:          labelsToAtlas(au.Labels),
 		Roles:           rolesToAtlas(au.Roles),
 		Scopes:          scopesToAtlas(au.Scopes),

--- a/internal/translation/dbuser/internal_test.go
+++ b/internal/translation/dbuser/internal_test.go
@@ -105,6 +105,34 @@ func TestToAndFromAtlas(t *testing.T) {
 	}
 }
 
+func TestToAtlas(t *testing.T) {
+	for _, tc := range []struct {
+		title     string
+		user      *User
+		atlasUser *admin.CloudDatabaseUser
+	}{
+		{
+			title: "Empty description should be converted as empty string, not nil",
+			user: func() *User {
+				user := defaultTestUser()
+				user.Description = ""
+				return user
+			}(),
+			atlasUser: func() *admin.CloudDatabaseUser {
+				inAtlas := defaultTestAtlasUser()
+				inAtlas.Description = pointer.MakePtr("")
+				return inAtlas
+			}(),
+		},
+	} {
+		t.Run(tc.title, func(t *testing.T) {
+			atlasUser, err := toAtlas(tc.user)
+			require.NoError(t, err)
+			assert.Equal(t, tc.atlasUser, atlasUser)
+		})
+	}
+}
+
 func TestToAtlasDateFailure(t *testing.T) {
 	user := defaultTestUser()
 	user.DeleteAfterDate = "bad-date-string"
@@ -143,5 +171,7 @@ func defaultTestAtlasUser() *admin.CloudDatabaseUser {
 		GroupId:      testProjectID,
 		Password:     pointer.MakePtr(testPassword),
 		Username:     testUsername,
+		Scopes:       pointer.MakePtr([]admin.UserScope{}),
+		Description:  pointer.MakePtr(""),
 	}
 }


### PR DESCRIPTION
# Summary

In 140ba21f32fd5c77c2b070b8851b7a7b23a4b2f7 I added the ability to set a description on AtlasDatabaseUser. However, I overlooked that a description could already exist on the user in Atlas, in which case the operator will fetch it, realize it's different, and then... omit the change, because `omitempty` is set on the struct field.

With this patch we send an empty string instead.

## Proof of Work

<!-- Enter your proof that it works here.-->

## Checklist
- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you checked for release_note changes?
- [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
