### PR TITLE
CLOUDP-323996: Fix make multiarch image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -324,8 +324,10 @@ bundle: manifests  ## Generate bundle manifests and metadata, then validate gene
 image: ## Build the operator image
 	$(MAKE) bin/linux/amd64/manager TARGET_OS=linux TARGET_ARCH=amd64 VERSION=$(VERSION)
 	$(MAKE) bin/linux/arm64/manager TARGET_OS=linux TARGET_ARCH=arm64 VERSION=$(VERSION)
-	$(CONTAINER_ENGINE) build -f fast.Dockerfile --build-arg VERSION=$(VERSION) -t $(OPERATOR_IMAGE) .
-	$(CONTAINER_ENGINE) push $(OPERATOR_IMAGE)
+	$(CONTAINER_ENGINE) buildx create --use --name multiarch-builder \
+	--driver docker-container --bootstrap || echo "reusing multiarch-builder"
+	$(CONTAINER_ENGINE) buildx build --platform linux/amd64,linux/arm64 --push \
+	-f fast.Dockerfile --build-arg VERSION=$(VERSION) -t $(OPERATOR_IMAGE) .
 
 .PHONY: bundle-build
 bundle-build: ## Build the bundle image.

--- a/Makefile
+++ b/Makefile
@@ -321,7 +321,14 @@ bundle: manifests  ## Generate bundle manifests and metadata, then validate gene
 	operator-sdk bundle validate ./bundle
 
 .PHONY: image
-image: ## Build the operator image
+image: ## Build an operator image for local development
+	$(MAKE) bin/linux/amd64/manager TARGET_OS=linux TARGET_ARCH=amd64 VERSION=$(VERSION)
+	$(MAKE) bin/linux/arm64/manager TARGET_OS=linux TARGET_ARCH=arm64 VERSION=$(VERSION)
+	$(CONTAINER_ENGINE) build -f fast.Dockerfile --build-arg VERSION=$(VERSION) -t $(OPERATOR_IMAGE) .
+	$(CONTAINER_ENGINE) push $(OPERATOR_IMAGE)
+
+.PHONY: image-multiarch
+image-multiarch: ## Build releaseable multi-architecture operator image
 	$(MAKE) bin/linux/amd64/manager TARGET_OS=linux TARGET_ARCH=amd64 VERSION=$(VERSION)
 	$(MAKE) bin/linux/arm64/manager TARGET_OS=linux TARGET_ARCH=arm64 VERSION=$(VERSION)
 	$(CONTAINER_ENGINE) buildx create --use --name multiarch-builder \

--- a/fast.Dockerfile
+++ b/fast.Dockerfile
@@ -1,9 +1,9 @@
 # TODO: Eventually replace main Dockerfile
-FROM golang:1.24 as certs-source
+FROM golang:1.24 AS certs-source
 ARG GOTOOLCHAIN=auto
 
 # Using rolling tag to stay on latest UBI 9
-FROM registry.access.redhat.com/ubi9/ubi:latest as ubi-certs
+FROM registry.access.redhat.com/ubi9/ubi:latest AS ubi-certs
 FROM registry.access.redhat.com/ubi9/ubi-micro:latest
 
 ARG TARGETOS


### PR DESCRIPTION
# Summary

This fixes the Makefile to produce multi-arch images, just like the CI already does:

1. Create a `multiarch-builder` buildx builder configured to support multi architecture builds.
2. Build & push using `multiarch-builder` buildx builder for all target platforms at once.

## Proof of Work

Command `make image VERSION=...` produced a proper prerelease multi-archi image as expected.

## Checklist
- [X] Have you linked a jira ticket and/or is the ticket in the title?
- [X] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you checked for release_note changes?
- [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?

## Reminder (Please remove this when merging)
- Please try to Approve or Reject Changes the PR, keep PRs in review as short as possible
- Remember the following Communication Standards - use comment prefixes for clarity:
  * **blocking**: Must be addressed before approval.
  * **follow-up**: Can be addressed in a later PR or ticket.
  * **q**: Clarifying question.
  * **nit**: Non-blocking suggestions.
  * **note**: Side-note, non-actionable. Example: Praise 
  * --> no prefix is considered a question

