### PR TITLE
CLOUDP-221656: FIX: Run openshift test cleaner in a separate job

### DIFF
--- a/.github/workflows/cleanup-test.yml
+++ b/.github/workflows/cleanup-test.yml
@@ -67,6 +67,11 @@ jobs:
         run: |
          devbox run -- 'cd tools/clean && ./clean atlas'
 
+  openshift-cleanup:
+    name: Cleanup Openshift upgrade test
+    runs-on: ubuntu-latest
+    environment: openshift-test
+    steps:
       - name: Run openshift test cleaner
         env:
           OC_TOKEN: ${{ secrets.OPENSHIFT_UPGRADE_TOKEN }}


### PR DESCRIPTION
# Summary

Run openshift test cleaner in a separate job

## Checklist
- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you checked for release_note changes?
- [x] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
