### PR TITLE
CLOUDP-316083: Fix initialisation breaking rate limiting

### DIFF
--- a/internal/controller/atlasthirdpartyintegrations/setup_test.go
+++ b/internal/controller/atlasthirdpartyintegrations/setup_test.go
@@ -36,6 +36,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -122,7 +123,7 @@ func TestSetupWithManager(t *testing.T) {
 		deletionProtection: false,
 	}
 
-	require.NoError(t, handler.SetupWithManager(fakeMgr, &fakeReconciler{}))
+	require.NoError(t, handler.SetupWithManager(fakeMgr, &fakeReconciler{}, controller.Options{}))
 }
 
 func TestNewReconcileRequest(t *testing.T) {

--- a/internal/controller/registry.go
+++ b/internal/controller/registry.go
@@ -134,7 +134,7 @@ func (r *Registry) registerControllers(c cluster.Cluster, ap atlas.Provider) {
 			r.globalSecretRef,
 			r.reapplySupport,
 		)
-		compatibleIntegrationsReconciler := newCtrlStateReconciler(*integrationsReconciler)
+		compatibleIntegrationsReconciler := newCtrlStateReconciler(integrationsReconciler)
 		reconcilers = append(reconcilers, compatibleIntegrationsReconciler)
 	}
 	r.reconcilers = reconcilers
@@ -152,10 +152,10 @@ func (r *Registry) defaultPredicates() []predicate.Predicate {
 }
 
 type ctrlStateReconciler[T any] struct {
-	ctrlstate.Reconciler[T]
+	*ctrlstate.Reconciler[T]
 }
 
-func newCtrlStateReconciler[T any](r ctrlstate.Reconciler[T]) *ctrlStateReconciler[T] {
+func newCtrlStateReconciler[T any](r *ctrlstate.Reconciler[T]) *ctrlStateReconciler[T] {
 	return &ctrlStateReconciler[T]{Reconciler: r}
 }
 

--- a/internal/controller/registry.go
+++ b/internal/controller/registry.go
@@ -48,6 +48,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/version"
 	ctrlstate "github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/controller/state"
+	"github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/ratelimit"
 )
 
 const DefaultReapplySupport = true
@@ -159,12 +160,9 @@ func newCtrlStateReconciler[T any](r ctrlstate.Reconciler[T]) *ctrlStateReconcil
 }
 
 func (nr *ctrlStateReconciler[T]) SetupWithManager(mgr ctrl.Manager, skipNameValidation bool) error {
-	skipNameOptionFn := func(skipNameValidation bool) ctrlstate.SetupManagerOption {
-		return func(builder *ctrlstate.ControllerSetupBuilder) *ctrlstate.ControllerSetupBuilder {
-			return builder.WithOptions(controller.TypedOptions[reconcile.Request]{
-				SkipNameValidation: pointer.MakePtr(skipNameValidation),
-			})
-		}
+	defaultReconcilerOptions := controller.TypedOptions[reconcile.Request]{
+		RateLimiter:        ratelimit.NewRateLimiter[reconcile.Request](),
+		SkipNameValidation: pointer.MakePtr(skipNameValidation),
 	}
-	return nr.Reconciler.SetupWithManager(mgr, skipNameOptionFn(skipNameValidation))
+	return nr.Reconciler.SetupWithManager(mgr, defaultReconcilerOptions)
 }

--- a/internal/controller/registry_test.go
+++ b/internal/controller/registry_test.go
@@ -1,0 +1,61 @@
+// Copyright 2025 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/pointer"
+	ctrlstate "github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/controller/state"
+	"github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/ratelimit"
+)
+
+func TestCtrlStateReconciler_SetupWithManager_NoGomock(t *testing.T) {
+	fakeMgr := &fakeManager{}
+	mock := mockStateReconciler{}
+	fakeReconciler := ctrlstate.NewStateReconciler(&mock)
+	skipNameValidation := true
+
+	r := newCtrlStateReconciler(fakeReconciler)
+	require.NoError(t, r.SetupWithManager(fakeMgr, skipNameValidation))
+	require.Equal(t, fakeMgr, mock.ReceivedMgr)
+	wantOpts := controller.TypedOptions[reconcile.Request]{
+		SkipNameValidation: pointer.MakePtr(skipNameValidation),
+		RateLimiter:        ratelimit.NewRateLimiter[reconcile.Request](),
+	}
+	assert.Equal(t, wantOpts, mock.ReceivedOpts)
+}
+
+type fakeManager struct {
+	ctrl.Manager
+}
+
+type mockStateReconciler struct {
+	ctrlstate.StateHandler[mockStateReconciler]
+	ReceivedMgr  ctrl.Manager
+	ReceivedOpts controller.TypedOptions[reconcile.Request]
+}
+
+func (m *mockStateReconciler) SetupWithManager(mgr ctrl.Manager, reconciler reconcile.Reconciler, opts controller.Options) error {
+	m.ReceivedMgr = mgr
+	m.ReceivedOpts = opts
+	return nil
+}

--- a/pkg/controller/state/reconciler_test.go
+++ b/pkg/controller/state/reconciler_test.go
@@ -34,6 +34,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/state"
@@ -538,7 +539,7 @@ type dummyPodReconciler struct {
 	handleState func(context.Context, *dummyObject) (Result, error)
 }
 
-func (d *dummyPodReconciler) SetupWithManager(_ ctrl.Manager, _ reconcile.Reconciler, _ ...SetupManagerOption) error {
+func (d *dummyPodReconciler) SetupWithManager(_ ctrl.Manager, _ reconcile.Reconciler, _ controller.Options) error {
 	return nil
 }
 func (d *dummyPodReconciler) For() (client.Object, builder.Predicates) {


### PR DESCRIPTION
# Summary

The SetupManagerOption var args did not take into account that options overwrite others each time they are applied in the builder. Instead, we now pass a default options value that can be overridden by each reconciler on the setup function, and otherwise use the defaults given.

## Proof of Work

TBD

## Checklist
- [X] Have you linked a jira ticket and/or is the ticket in the title?
- [X] Have you checked whether your jira ticket required DOCSP changes?
- [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?

