### PR TITLE
CLOUDP-316083: Let integrations e2e2 run now

### DIFF
--- a/test/e2e2/integration_test.go
+++ b/test/e2e2/integration_test.go
@@ -32,7 +32,6 @@ import (
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/api"
 	akov2 "github.com/mongodb/mongodb-atlas-kubernetes/v2/api/v1"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/controller/connectionsecret"
-	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/version"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/state"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/test/helper/control"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/test/helper/e2e/utils"
@@ -55,9 +54,6 @@ var _ = Describe("Atlas Third-Party Integrations Controller", Ordered, Label("in
 	var testNamespace *corev1.Namespace
 
 	_ = BeforeAll(func() {
-		if !version.IsExperimental() {
-			Skip("Skipping experimental test on non experimental build")
-		}
 		deletionProtectionOff := false
 		ako = runTestAKO(DefaultGlobalCredentials, control.MustEnvVar("OPERATOR_NAMESPACE"), deletionProtectionOff)
 		ako.Start(GinkgoT())


### PR DESCRIPTION
# Summary

As integrations are no longer experimental, they should always run.

## Proof of Work

Ci should work and execute the e2e2 when `test/e2e2/*` label is set.

## Checklist
- [X] Have you linked a jira ticket and/or is the ticket in the title?
- [X] Have you checked whether your jira ticket required DOCSP changes?
- [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
