### PR TITLE
Fix AKO integrations CRD RBAC entries

### DIFF
--- a/config/rbac/clusterwide/role.yaml
+++ b/config/rbac/clusterwide/role.yaml
@@ -43,6 +43,7 @@ rules:
   - atlasstreamconnections
   - atlasstreaminstances
   - atlasteams
+  - atlasthirdpartyintegrations
   verbs:
   - create
   - delete
@@ -71,6 +72,7 @@ rules:
   - atlasstreamconnections/status
   - atlasstreaminstances/status
   - atlasteams/status
+  - atlasthirdpartyintegrations/status
   verbs:
   - get
   - patch
@@ -81,5 +83,6 @@ rules:
   - atlasipaccesslists/finalizers
   - atlasnetworkcontainers/finalizers
   - atlasnetworkpeerings/finalizers
+  - atlasthirdpartyintegrations/finalizers
   verbs:
   - update

--- a/config/rbac/namespaced/role.yaml
+++ b/config/rbac/namespaced/role.yaml
@@ -42,6 +42,7 @@ rules:
   - atlasstreamconnections
   - atlasstreaminstances
   - atlasteams
+  - atlasthirdpartyintegrations
   verbs:
   - create
   - delete
@@ -67,6 +68,7 @@ rules:
   - atlasstreamconnections/status
   - atlasstreaminstances/status
   - atlasteams/status
+  - atlasthirdpartyintegrations/status
   verbs:
   - get
   - patch
@@ -75,5 +77,6 @@ rules:
   - atlas.mongodb.com
   resources:
   - atlasipaccesslists/finalizers
+  - atlasthirdpartyintegrations/finalizers
   verbs:
   - update


### PR DESCRIPTION
# Summary

Some RBAC files were missing the new atlasthirdpartyintegrations entries

## Proof of Work

TBD

## Checklist
- [X] Have you linked a jira ticket and/or is the ticket in the title?
- [X] Have you checked whether your jira ticket required DOCSP changes?
- [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
