### PR TITLE
CLOUDP-328306: Find integration in replies

### DIFF
--- a/internal/translation/thirdpartyintegration/conversion.go
+++ b/internal/translation/thirdpartyintegration/conversion.go
@@ -330,6 +330,17 @@ func fromAtlas(ai *admin.ThirdPartyIntegration) (*ThirdPartyIntegration, error) 
 	return tpi, nil
 }
 
+func assertType(typeName string) error {
+	switch typeName {
+	case "DATADOG", "MICROSOFT_TEAMS", "NEW_RELIC",
+		"OPS_GENIE", "PAGER_DUTY", "PROMETHEUS", "SLACK",
+		"VICTOR_OPS", "WEBHOOK":
+		return nil
+	default:
+		return fmt.Errorf("%w %v", ErrUnsupportedIntegrationType, typeName)
+	}
+}
+
 func isEnabled(field *string) bool {
 	if field == nil {
 		return false


### PR DESCRIPTION
# Summary

Atlas API might reply to creation and updates with the whole list of integrations, not just the one created or updated. This fix makes it so that the AKO client code in the translation layer correctly filters out other entries and retains only the one created or updated.

## Proof of Work

Extra test cases in unit tests validate the new behaviour expected.

## Checklist
- [X] Have you linked a jira ticket and/or is the ticket in the title?
- [X] Have you checked whether your jira ticket required DOCSP changes?
- [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?

