### PR TITLE
Disaggregate kube client and CRD asserts

### DIFF
--- a/test/e2e2/ako_test.go
+++ b/test/e2e2/ako_test.go
@@ -49,11 +49,12 @@ var _ = Describe("Atlas Operator Start and Stop test", Ordered, Label("ako-start
 		ako.Start(GinkgoT())
 
 		ctx = context.Background()
-		client, err := kube.NewK8sTest(ctx, &apiextensionsv1.CustomResourceDefinition{
-			ObjectMeta: v1.ObjectMeta{Name: AtlasProjectCRDName},
-		})
+		client, err := kube.NewTestClient()
 		Expect(err).To(Succeed())
 		kubeClient = client
+		Expect(kube.AssertCRDs(ctx, kubeClient, &apiextensionsv1.CustomResourceDefinition{
+			ObjectMeta: v1.ObjectMeta{Name: AtlasProjectCRDName},
+		})).To(Succeed())
 	})
 
 	_ = AfterAll(func() {

--- a/test/e2e2/all_in_one_test.go
+++ b/test/e2e2/all_in_one_test.go
@@ -32,10 +32,9 @@ var _ = Describe("all-in-one.yaml", Ordered, Label("all-in-one"), func() {
 	var kubeClient client.Client
 
 	_ = BeforeAll(func() {
-		ctx := context.Background()
-		c, err := kube.NewK8sTest(ctx)
-		kubeClient = c
+		c, err := kube.NewTestClient()
 		Expect(err).To(Succeed())
+		kubeClient = c
 	})
 
 	It("applies all-in-one.yaml", func() {

--- a/test/e2e2/integration_test.go
+++ b/test/e2e2/integration_test.go
@@ -59,11 +59,12 @@ var _ = Describe("Atlas Third-Party Integrations Controller", Ordered, Label("in
 		ako.Start(GinkgoT())
 
 		ctx = context.Background()
-		client, err := kube.NewK8sTest(ctx, &apiextensionsv1.CustomResourceDefinition{
-			ObjectMeta: v1.ObjectMeta{Name: AtlasThirdPartyIntegrationsCRDName},
-		})
+		client, err := kube.NewTestClient()
 		Expect(err).To(Succeed())
 		kubeClient = client
+		Expect(kube.AssertCRDs(ctx, kubeClient, &apiextensionsv1.CustomResourceDefinition{
+			ObjectMeta: v1.ObjectMeta{Name: AtlasThirdPartyIntegrationsCRDName},
+		})).To(Succeed())
 	})
 
 	_ = AfterAll(func() {

--- a/test/helper/e2e2/kube/kube.go
+++ b/test/helper/e2e2/kube/kube.go
@@ -40,28 +40,20 @@ type ObjectWithStatus interface {
 	GetConditions() []metav1.Condition
 }
 
-// NewK8sTest initializes a test environment on Kubernetes.
-// It requires:
-// - A running Kubernetes cluster with a local configuration bound to it.
-// - The given set CRDs installed in that cluster
-func NewK8sTest(ctx context.Context, crds ...*apiextensionsv1.CustomResourceDefinition) (client.Client, error) {
-	kubeClient, err := TestKubeClient()
-	if err != nil {
-		return nil, fmt.Errorf("failed to setup Kubernetes test env client: %w", err)
-	}
-
+// AssertCRDs check that the given CRDs are installed in the accesible cluster
+func AssertCRDs(ctx context.Context, kubeClient client.Client, crds ...*apiextensionsv1.CustomResourceDefinition) error {
 	for _, targetCRD := range crds {
 		if err := assertCRD(ctx, kubeClient, targetCRD); err != nil {
-			return nil, fmt.Errorf("failed to asert for test-required CRD: %w", err)
+			return fmt.Errorf("failed to asert for test-required CRD: %w", err)
 		}
 	}
-	return kubeClient, nil
+	return nil
 }
 
-// TestKubeClient returns a Kubernetes client for tests.
+// NewTestClient returns a Kubernetes client for tests.
 // It requires a running Kubernetes cluster and a local configuration to it.
 // It supports core Kubernetes types, production and experimental CRDs.
-func TestKubeClient() (client.Client, error) {
+func NewTestClient() (client.Client, error) {
 	testScheme := runtime.NewScheme()
 	utilruntime.Must(corev1.AddToScheme(testScheme))
 	utilruntime.Must(apiextensionsv1.AddToScheme(testScheme))


### PR DESCRIPTION
# Summary

Disaggregate the kube client creation from the assertion of CRDs

## Proof of Work

E2e2 should continue to pass after this.

## Checklist
- [X] Have you linked a jira ticket and/or is the ticket in the title?
- [X] Have you checked whether your jira ticket required DOCSP changes?
- [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?

