### PR TITLE
CLOUDP-330314: Disallow project/deployment renaming

### DIFF
--- a/api/v1/atlasdeployment_types.go
+++ b/api/v1/atlasdeployment_types.go
@@ -127,6 +127,7 @@ type AdvancedDeploymentSpec struct {
 	// Can only contain ASCII letters, numbers, and hyphens.
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Pattern:=^[a-zA-Z0-9][a-zA-Z0-9-]*$
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Name cannot be modified after deployment creation"
 	Name string `json:"name,omitempty"`
 	// Flag that indicates whether the deployment should be paused.
 	Paused *bool `json:"paused,omitempty"`

--- a/api/v1/atlasdeployment_types_test.go
+++ b/api/v1/atlasdeployment_types_test.go
@@ -1,0 +1,69 @@
+// Copyright 2025 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/mongodb/mongodb-atlas-kubernetes/v2/api/v1/common"
+	"github.com/mongodb/mongodb-atlas-kubernetes/v2/test/helper/cel"
+)
+
+func TestDeploymentCELChecks(t *testing.T) {
+	for _, tc := range []struct {
+		title          string
+		old, obj       *AtlasDeployment
+		expectedErrors []string
+	}{
+		{
+			title: "Cannot rename a deployment",
+			old: &AtlasDeployment{
+				Spec: AtlasDeploymentSpec{
+					DeploymentSpec: &AdvancedDeploymentSpec{
+						Name: "name-old",
+					},
+				},
+			},
+			obj: &AtlasDeployment{
+				Spec: AtlasDeploymentSpec{
+					DeploymentSpec: &AdvancedDeploymentSpec{
+						Name: "name-new",
+					},
+				},
+			},
+			expectedErrors: []string{"spec.deploymentSpec.name: Invalid value: \"string\": Name cannot be modified after deployment creation"},
+		},
+	} {
+		t.Run(tc.title, func(t *testing.T) {
+			// inject a project to avoid other CEL validations being hit
+			tc.obj.Spec.ProjectRef = &common.ResourceRefNamespaced{Name: "some-project"}
+			unstructuredOldObject, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&tc.old)
+			require.NoError(t, err)
+			unstructuredObject, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&tc.obj)
+			require.NoError(t, err)
+
+			crdPath := "../../config/crd/bases/atlas.mongodb.com_atlasdeployments.yaml"
+			validator, err := cel.VersionValidatorFromFile(t, crdPath, "v1")
+			assert.NoError(t, err)
+			errs := validator(unstructuredObject, unstructuredOldObject)
+
+			require.Equal(t, tc.expectedErrors, cel.ErrorListAsStrings(errs))
+		})
+	}
+}

--- a/api/v1/atlasproject_types.go
+++ b/api/v1/atlasproject_types.go
@@ -43,6 +43,7 @@ func init() {
 type AtlasProjectSpec struct {
 
 	// Name is the name of the Project that is created in Atlas by the Operator if it doesn't exist yet.
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Name cannot be modified after project creation"
 	Name string `json:"name"`
 
 	// RegionUsageRestrictions designate the project's AWS region when using Atlas for Government.

--- a/config/crd/bases/atlas.mongodb.com_atlasdeployments.yaml
+++ b/config/crd/bases/atlas.mongodb.com_atlasdeployments.yaml
@@ -197,6 +197,9 @@ spec:
                       Can only contain ASCII letters, numbers, and hyphens.
                     pattern: ^[a-zA-Z0-9][a-zA-Z0-9-]*$
                     type: string
+                    x-kubernetes-validations:
+                    - message: Name cannot be modified after deployment creation
+                      rule: self == oldSelf
                   paused:
                     description: Flag that indicates whether the deployment should
                       be paused.

--- a/config/crd/bases/atlas.mongodb.com_atlasprojects.yaml
+++ b/config/crd/bases/atlas.mongodb.com_atlasprojects.yaml
@@ -746,6 +746,9 @@ spec:
                 description: Name is the name of the Project that is created in Atlas
                   by the Operator if it doesn't exist yet.
                 type: string
+                x-kubernetes-validations:
+                - message: Name cannot be modified after project creation
+                  rule: self == oldSelf
               networkPeers:
                 description: NetworkPeers is a list of Network Peers configured for
                   the current Project.


### PR DESCRIPTION
When a project is renamed in Kube, the operator will create a new
project and leave the original intact, while other resources (such as
AtlasDeployment) still track the original clusters in the old project.
This leads to bad situations that are difficult to clean up, in
particular via the operator.

Similarly, when a deployment is renamed in Kube a new deployment is
created in Atlas, with the old one left running. Since this is almost
definitely not what the user wanted, let's ensure that name changes here
are also forbidden.


## Checklist
- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you checked for release_note changes?
- [x] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
