### PR TITLE
CLOUDP-332646: fix structured logging using desugared logger

### DIFF
--- a/internal/httputil/diff.go
+++ b/internal/httputil/diff.go
@@ -47,9 +47,9 @@ func (t *TransportWithDiff) RoundTrip(req *http.Request) (*http.Response, error)
 		if err != nil {
 			t.log.Debug("failed to calculate diff", zap.Error(err))
 		} else {
-			t.log.Debug("JSON diff text",
+			t.log.Desugar().Debug("JSON diff",
 				zap.String("url", req.URL.String()),
-				zap.Any("diff", diffString),
+				zap.String("diff", diffString),
 			)
 		}
 	}


### PR DESCRIPTION
# Summary

https://github.com/mongodb/mongodb-atlas-kubernetes/pull/2525 introduced structured logging output.

However, this internally uses the sugared logger which does not take key value pairs and renders a **msg** field only.

```
{
  "level": "DEBUG",
  "time": "2025-07-21T12:08:02.749+0200",
  "msg": "JSON diff text{url 15 0 https://cloud-qa.mongodb.com/api/atlas/v2/groups/687e0db8823af9166efd3a18/flexClusters/test <nil>} {diff 15 0  {\n-  \"backupSettings\": {\n-    \"enabled\": true\n-  },\n-  \"clusterType\": \"REPLICASET\",\n-  \"connectionStrings\": {\n-    \"standard\": \"mongodb://ac-vcv4uwg-shard-00-00.7oqlwif.mongodb-qa.net:27017,ac-vcv4uwg-shard-00-01.7oqlwif.mongodb-qa.net:27017,ac-vcv4uwg-shard-00-02.7oqlwif.mongodb-qa.net:27017/?ssl=true&authSource=admin&replicaSet=atlas-eznwg7-shard-0\",\n-    \"standardSrv\": \"mongodb+srv://test.7oqlwif.mongodb-qa.net\"\n-  },\n-  \"createDate\": \"2025-07-21T09:52:06Z\",\n-  \"groupId\": \"687e0db8823af9166efd3a18\",\n-  \"id\": \"687e0dc6426db7026b5f38ac\",\n-  \"mongoDBVersion\": \"8.0.11\",\n-  \"name\": \"test\",\n-  \"providerSettings\": {\n-    \"backingProviderName\": \"AWS\",\n-    \"diskSizeGB\": 5,\n-    \"providerName\": \"FLEX\",\n-    \"regionName\": \"US_EAST_1\"\n-  },\n-  \"stateName\": \"IDLE\",\n   \"tags\": [\n   ],\n-  \"terminationProtectionEnabled\": true,\n+  \"terminationProtectionEnabled\": false,\n-  \"versionReleaseSystem\": \"LTS\"\n }\n <nil>}"
}
```

This needs to use the desugar'ed logger to properly render output the **url** and **diff** fields separately:
```
{
  "level": "DEBUG",
  "time": "2025-07-21T12:22:20.004+0200",
  "msg": "JSON diff",
  "url": "https://cloud-qa.mongodb.com/api/atlas/v2/groups/687e0db8823af9166efd3a18/flexClusters/test",
  "diff": " {\n-  \"backupSettings\": {\n-    \"enabled\": true\n-  },\n-  \"clusterType\": \"REPLICASET\",\n-  \"connectionStrings\": {\n-    \"standard\": \"mongodb://ac-vcv4uwg-shard-00-00.7oqlwif.mongodb-qa.net:27017,ac-vcv4uwg-shard-00-01.7oqlwif.mongodb-qa.net:27017,ac-vcv4uwg-shard-00-02.7oqlwif.mongodb-qa.net:27017/?ssl=true&authSource=admin&replicaSet=atlas-eznwg7-shard-0\",\n-    \"standardSrv\": \"mongodb+srv://test.7oqlwif.mongodb-qa.net\"\n-  },\n-  \"createDate\": \"2025-07-21T09:52:06Z\",\n-  \"groupId\": \"687e0db8823af9166efd3a18\",\n-  \"id\": \"687e0dc6426db7026b5f38ac\",\n-  \"mongoDBVersion\": \"8.0.11\",\n-  \"name\": \"test\",\n-  \"providerSettings\": {\n-    \"backingProviderName\": \"AWS\",\n-    \"diskSizeGB\": 5,\n-    \"providerName\": \"FLEX\",\n-    \"regionName\": \"US_EAST_1\"\n-  },\n-  \"stateName\": \"IDLE\",\n   \"tags\": [\n   ],\n-  \"terminationProtectionEnabled\": true,\n+  \"terminationProtectionEnabled\": false,\n-  \"versionReleaseSystem\": \"LTS\"\n }\n"
}
```

This now properly works with a structured logging tool as well:
```
 1 | diff: |
 2 |    {
 3 |   -  "backupSettings": {
 4 |   -    "enabled": true
 5 |   -  },
 6 |   -  "clusterType": "REPLICASET",
 7 |   -  "connectionStrings": {
 8 |   -    "standard": "mongodb://ac-vcv4uwg-shard-00-00.7oqlwif.mongodb-qa.net:27017,ac-vcv4uwg-shard-00-01.7oqlwif.mongodb-qa.net:27017,ac-vcv4uwg-shard-00-02.7oqlwif.mongodb-qa.net:27017/?ssl=true&authSource=admin&replicaSet=atlas-eznwg7-shard-0",
 9 |   -    "standardSrv": "mongodb+srv://test.7oqlwif.mongodb-qa.net"
10 |   -  },
11 |   -  "createDate": "2025-07-21T09:52:06Z",
12 |   -  "groupId": "687e0db8823af9166efd3a18",
13 |   -  "id": "687e0dc6426db7026b5f38ac",
14 |   -  "mongoDBVersion": "8.0.11",
15 |   -  "name": "test",
16 |   -  "providerSettings": {
17 |   -    "backingProviderName": "AWS",
18 |   -    "diskSizeGB": 5,
19 |   -    "providerName": "FLEX",
20 |   -    "regionName": "US_EAST_1"
21 |   -  },
22 |   -  "stateName": "IDLE",
23 |      "tags": [
24 |      ],
25 |   -  "terminationProtectionEnabled": false,
26 |   +  "terminationProtectionEnabled": true,
27 |   -  "versionReleaseSystem": "LTS"
28 |    }
29 | level: DEBUG
30 | msg: JSON diff
31 | time: 2025-07-21T12:24:37.761+0200
32 | url: https://cloud-qa.mongodb.com/api/atlas/v2/groups/687e0db8823af9166efd3a18/flexClusters/test
```

## Proof of Work

unit tests still apply

## Checklist
- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you checked for release_note changes?
- [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?

## Reminder (Please remove this when merging)
- Please try to Approve or Reject Changes the PR, keep PRs in review as short as possible
- Remember the following Communication Standards - use comment prefixes for clarity:
  * **blocking**: Must be addressed before approval.
  * **follow-up**: Can be addressed in a later PR or ticket.
  * **q**: Clarifying question.
  * **nit**: Non-blocking suggestions.
  * **note**: Side-note, non-actionable. Example: Praise 
  * --> no prefix is considered a question

