### PR TITLE
CLOUDP-332920/fix-openshift-releases

### DIFF
--- a/scripts/release-redhat-certified.sh
+++ b/scripts/release-redhat-certified.sh
@@ -39,7 +39,7 @@ cd -
 
 pwd
 
-cp -r bundle.Dockerfile bundle/manifests bundle/metadata bundle/tests "${REPO}/${VERSION}"
+cp -r releases/${VERSION}/bundle.Dockerfile releases/${VERSION}/bundle/manifests releases/${VERSION}/bundle/metadata bundle/tests "${REPO}/${VERSION}"
 
 # Replace deployment image version with SHA256
 value="${IMG_SHA_AMD64}" yq e -i '.spec.install.spec.deployments[0].spec.template.spec.containers[0].image = "quay.io/mongodb/mongodb-atlas-kubernetes-operator@" + env(value)' \

--- a/scripts/release-redhat.sh
+++ b/scripts/release-redhat.sh
@@ -19,7 +19,7 @@ set -eou pipefail
 version=${1:?"pass the version as the parameter, e.g \"0.5.0\""}
 repo="${RH_COMMUNITY_OPERATORHUB_REPO_PATH}/operators/mongodb-atlas-kubernetes"
 mkdir "${repo}/${version}"
-cp -r bundle.Dockerfile bundle/manifests bundle/metadata bundle/tests "${repo}/${version}"
+cp -r releases/${version}/bundle.Dockerfile releases/${version}/bundle/manifests releases/${version}/bundle/metadata bundle/tests "${repo}/${version}"
 
 cd "${repo}"
 git fetch upstream main


### PR DESCRIPTION
# Summary

OpenShift release scripts need to meet the new release format with new directory structure `releases/<version>/...`

Jira-[CLOUDP-332920](https://jira.mongodb.org/browse/CLOUDP-332920)

## Proof of Work

<!-- Enter your proof that it works here.-->

## Checklist
- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you checked for release_note changes?
- [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?

## Reminder (Please remove this when merging)
- Please try to Approve or Reject Changes the PR, keep PRs in review as short as possible
- Remember the following Communication Standards - use comment prefixes for clarity:
  * **blocking**: Must be addressed before approval.
  * **follow-up**: Can be addressed in a later PR or ticket.
  * **q**: Clarifying question.
  * **nit**: Non-blocking suggestions.
  * **note**: Side-note, non-actionable. Example: Praise 
  * --> no prefix is considered a question

