### PR TITLE
Set flex 2 dedicated nightly tag to run after merge

### DIFF
--- a/.github/workflows/tests-e2e2.yaml
+++ b/.github/workflows/tests-e2e2.yaml
@@ -74,7 +74,7 @@ jobs:
           E2E2_LABELS: ${{ env.e2e2_labels }}
           USE_JSON: true
           SKIP_PREFIXES: "[\"nightly\"]"
-          NIGHTLY_MATRIX: "[\"nightly-core\",\"nightly-integration\"]"
+          NIGHTLY_MATRIX: "[\"nightly-core\",\"nightly-integration\",\"nightly-flex2dedicated\"]"
         run: |
           # Nightly runs all tests, overriding PR labels as '["test/e2e2/*"]'
           if [ "${{ github.ref }}" == "refs/heads/main" ];then

--- a/test/e2e2/flex_to_dedicated_test.go
+++ b/test/e2e2/flex_to_dedicated_test.go
@@ -40,7 +40,7 @@ import (
 //go:embed flex2dedicated/*
 var flex2dedicated embed.FS
 
-var _ = Describe("Flex to Dedicated Upgrade", Ordered, Label("flex-to-dedicated"), func() {
+var _ = Describe("Flex to Dedicated Upgrade", Ordered, Label("nightly-flex2dedicated", "flex-to-dedicated"), func() {
 	var ctx context.Context
 	var kubeClient client.Client
 	var ako operator.Operator


### PR DESCRIPTION
# Summary

Ensure nightly and after merge test run the new e2e2 tests for flex to dedicated.

## Proof of Work

CI will run those tests **after** merge.

## Checklist
- [X] Have you linked a jira ticket and/or is the ticket in the title?
- [X] Have you checked whether your jira ticket required DOCSP changes?
- [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
