### PR TITLE
CLOUDP-333238: add configServerManagementMode to AtlasDeployment

### DIFF
--- a/api/v1/atlasdeployment_types.go
+++ b/api/v1/atlasdeployment_types.go
@@ -153,6 +153,10 @@ type AdvancedDeploymentSpec struct {
 	// A list of atlas search indexes configuration for the current deployment
 	// +optional
 	SearchIndexes []SearchIndex `json:"searchIndexes,omitempty"`
+	// Config Server Management Mode for creating or updating a sharded cluster.
+	// +kubebuilder:validation:Enum=ATLAS_MANAGED;FIXED_TO_DEDICATED
+	// +optional
+	ConfigServerManagementMode string `json:"configServerManagementMode,omitempty"`
 }
 
 func (s *AdvancedDeploymentSpec) SearchNodesToAtlas() []admin.ApiSearchDeploymentSpec {

--- a/config/crd/bases/atlas.mongodb.com_atlasdeployments.yaml
+++ b/config/crd/bases/atlas.mongodb.com_atlasdeployments.yaml
@@ -113,6 +113,13 @@ spec:
                     - SHARDED
                     - GEOSHARDED
                     type: string
+                  configServerManagementMode:
+                    description: Config Server Management Mode for creating or updating
+                      a sharded cluster.
+                    enum:
+                    - ATLAS_MANAGED
+                    - FIXED_TO_DEDICATED
+                    type: string
                   customZoneMapping:
                     items:
                       properties:

--- a/internal/translation/deployment/compare.go
+++ b/internal/translation/deployment/compare.go
@@ -48,6 +48,7 @@ func ComputeChanges(desired, current *Cluster) (*Cluster, bool) {
 			VersionReleaseSystem:         desired.VersionReleaseSystem,
 			BackupEnabled:                desired.BackupEnabled,
 			EncryptionAtRestProvider:     desired.EncryptionAtRestProvider,
+			ConfigServerManagementMode:   desired.ConfigServerManagementMode,
 			BiConnector:                  desired.BiConnector,
 			PitEnabled:                   desired.PitEnabled,
 			RootCertType:                 desired.RootCertType,
@@ -142,6 +143,10 @@ func specAreEqual(desired, current *Cluster) bool {
 	}
 
 	if desired.EncryptionAtRestProvider != "" && !areEqual(&desired.EncryptionAtRestProvider, &current.EncryptionAtRestProvider) {
+		return false
+	}
+
+	if desired.ConfigServerManagementMode != "" && !areEqual(&desired.ConfigServerManagementMode, &current.ConfigServerManagementMode) {
 		return false
 	}
 

--- a/internal/translation/deployment/compare_test.go
+++ b/internal/translation/deployment/compare_test.go
@@ -640,6 +640,18 @@ func TestSpecAreEqual(t *testing.T) {
 				EncryptionAtRestProvider: pointer.MakePtr("NONE"),
 			},
 		},
+		"should return false when config server management are different": {
+			ako: &akov2.AtlasDeployment{
+				Spec: akov2.AtlasDeploymentSpec{
+					DeploymentSpec: &akov2.AdvancedDeploymentSpec{
+						ConfigServerManagementMode: "ATLAS_MANAGED",
+					},
+				},
+			},
+			atlas: &admin.ClusterDescription20240805{
+				ConfigServerManagementMode: pointer.MakePtr("FIXED_TO_DEDICATED"),
+			},
+		},
 		"should return false when mongodb version are different": {
 			ako: &akov2.AtlasDeployment{
 				Spec: akov2.AtlasDeploymentSpec{

--- a/internal/translation/deployment/conversion.go
+++ b/internal/translation/deployment/conversion.go
@@ -598,6 +598,7 @@ func clusterFromAtlas(clusterDesc *admin.ClusterDescription20240805) *Cluster {
 			TerminationProtectionEnabled: clusterDesc.GetTerminationProtectionEnabled(),
 			SearchNodes:                  nil,
 			SearchIndexes:                nil,
+			ConfigServerManagementMode:   clusterDesc.GetConfigServerManagementMode(),
 		},
 	}
 	normalizeClusterDeployment(cluster)
@@ -625,6 +626,7 @@ func clusterCreateToAtlas(cluster *Cluster) *admin.ClusterDescription20240805 {
 		RootCertType:                 pointer.MakePtrOrNil(cluster.RootCertType),
 		Tags:                         tag.ToAtlas(cluster.Tags),
 		TerminationProtectionEnabled: pointer.MakePtrOrNil(cluster.TerminationProtectionEnabled),
+		ConfigServerManagementMode:   pointer.MakePtrOrNil(cluster.ConfigServerManagementMode),
 	}
 }
 
@@ -643,6 +645,7 @@ func clusterUpdateToAtlas(cluster *Cluster) *admin.ClusterDescription20240805 {
 		RootCertType:                 pointer.MakePtrOrNil(cluster.RootCertType),
 		Tags:                         tag.ToAtlas(cluster.Tags),
 		TerminationProtectionEnabled: pointer.MakePtrOrNil(cluster.TerminationProtectionEnabled),
+		ConfigServerManagementMode:   pointer.MakePtrOrNil(cluster.ConfigServerManagementMode),
 	}
 }
 
@@ -1293,5 +1296,6 @@ func flexUpgradeToAtlas(cluster *Cluster) *admin.AtlasTenantClusterUpgradeReques
 		RootCertType:                 pointer.MakePtrOrNil(spec.RootCertType),
 		Tags:                         tag.ToAtlas(spec.Tags),
 		TerminationProtectionEnabled: pointer.MakePtrOrNil(spec.TerminationProtectionEnabled),
+		ConfigServerManagementMode:   pointer.MakePtrOrNil(spec.ConfigServerManagementMode),
 	}
 }

--- a/internal/translation/deployment/conversion_test.go
+++ b/internal/translation/deployment/conversion_test.go
@@ -150,6 +150,7 @@ func TestNewDeployment(t *testing.T) {
 							},
 						},
 						TerminationProtectionEnabled: true,
+						ConfigServerManagementMode:   "ATLAS_MANAGED",
 						Labels: []common.LabelSpec{
 							{
 								Key:   "name",
@@ -213,6 +214,7 @@ func TestNewDeployment(t *testing.T) {
 						},
 					},
 					TerminationProtectionEnabled: true,
+					ConfigServerManagementMode:   "ATLAS_MANAGED",
 					Labels: []common.LabelSpec{
 						{
 							Key:   "name",
@@ -268,6 +270,7 @@ func TestNewDeployment(t *testing.T) {
 								},
 							},
 							TerminationProtectionEnabled: true,
+							ConfigServerManagementMode:   "ATLAS_MANAGED",
 							Labels: []common.LabelSpec{
 								{
 									Key:   "name",


### PR DESCRIPTION
# Summary

This adds the ability to set configServerManagementMode

## Proof of Work

It should work

## Checklist
- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you checked for release_note changes?
- [x] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
