### PR TITLE
Downgrade mockery to 2.x, rerun, and add to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -289,6 +289,7 @@ generate: ${GO_SOURCES} ## Generate code
 ifdef EXPERIMENTAL
 	controller-gen object:headerFile="hack/boilerplate.go.txt" paths="./internal/nextapi/v1/..."
 endif
+	mockery
 	$(MAKE) fmt
 
 .PHONY: check-missing-files

--- a/devbox.json
+++ b/devbox.json
@@ -23,7 +23,7 @@
     "kubernetes-controller-tools@0.17.2",
     "setup-envtest@0.19.0",
     "awscli2@latest",
-    "go-mockery@latest",
+    "go-mockery@2",
     "docker-sbom@latest",
     "openshift@latest",
     "gci@latest"

--- a/devbox.lock
+++ b/devbox.lock
@@ -529,51 +529,51 @@
       "last_modified": "2025-08-22T02:25:05Z",
       "resolved": "github:NixOS/nixpkgs/f937f8ecd1c70efd7e9f90ba13dfb400cf559de4?lastModified=1755829505&narHash=sha256-4%2FJd%2BLkQ2ssw8luQVkqVs9spDBVE6h%2Fu%2FhC%2FtzngsPo%3D"
     },
-    "go-mockery@latest": {
-      "last_modified": "2025-08-08T08:05:48Z",
-      "resolved": "github:NixOS/nixpkgs/a3f3e3f2c983e957af6b07a1db98bafd1f87b7a1#go-mockery",
+    "go-mockery@2": {
+      "last_modified": "2025-07-13T22:45:35Z",
+      "resolved": "github:NixOS/nixpkgs/a421ac6595024edcfbb1ef950a3712b89161c359#go-mockery",
       "source": "devbox-search",
-      "version": "3.5.2",
+      "version": "2.53.3",
       "systems": {
         "aarch64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/invvvbcrzs6y6m5nfl4qdm28ggpz0bbn-go-mockery-3.5.2",
+              "path": "/nix/store/gymm44dbi3sp824ghj28z7xdp5y0z8ij-go-mockery-2.53.3",
               "default": true
             }
           ],
-          "store_path": "/nix/store/invvvbcrzs6y6m5nfl4qdm28ggpz0bbn-go-mockery-3.5.2"
+          "store_path": "/nix/store/gymm44dbi3sp824ghj28z7xdp5y0z8ij-go-mockery-2.53.3"
         },
         "aarch64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/j7j71sgwgnvhj3avxqm9kwp91zmc2i6f-go-mockery-3.5.2",
+              "path": "/nix/store/7almddm7x5spkllll4avz0fd19slcvvj-go-mockery-2.53.3",
               "default": true
             }
           ],
-          "store_path": "/nix/store/j7j71sgwgnvhj3avxqm9kwp91zmc2i6f-go-mockery-3.5.2"
+          "store_path": "/nix/store/7almddm7x5spkllll4avz0fd19slcvvj-go-mockery-2.53.3"
         },
         "x86_64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/zhffkpkqwjiwd68k3p2qly27nmsbd3cq-go-mockery-3.5.2",
+              "path": "/nix/store/xxd8ynzjqi4v0jahgzs9k45mj0ymcsns-go-mockery-2.53.3",
               "default": true
             }
           ],
-          "store_path": "/nix/store/zhffkpkqwjiwd68k3p2qly27nmsbd3cq-go-mockery-3.5.2"
+          "store_path": "/nix/store/xxd8ynzjqi4v0jahgzs9k45mj0ymcsns-go-mockery-2.53.3"
         },
         "x86_64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/a756rmcg59ff3p4m89rja816w3gdm0h3-go-mockery-3.5.2",
+              "path": "/nix/store/p7cdcd71qnf8k6h1fyrsx42a768w02c2-go-mockery-2.53.3",
               "default": true
             }
           ],
-          "store_path": "/nix/store/a756rmcg59ff3p4m89rja816w3gdm0h3-go-mockery-3.5.2"
+          "store_path": "/nix/store/p7cdcd71qnf8k6h1fyrsx42a768w02c2-go-mockery-2.53.3"
         }
       }
     },


### PR DESCRIPTION
# Summary

1. mockery was not part of any Makefile, now it is
2. The automated devbox upgrade upgraded it to an incompatible version, this pulls it back
3. There was drift so this commit includes the changes

## Proof of Work

it works