### PR TITLE
CLOUDP-338773: Run e2e2 only when selected or on nightlies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,8 +83,6 @@ jobs:
       - validate-manifests
       - check-licenses
       - cloud-tests-filter
-    if: |
-      github.event_name == 'merge_group' || needs.cloud-tests-filter.outputs.run-cloud-tests == 'true'
     uses: ./.github/workflows/tests-e2e2.yaml
     secrets: inherit
 

--- a/.github/workflows/tests-e2e2.yaml
+++ b/.github/workflows/tests-e2e2.yaml
@@ -77,7 +77,7 @@ jobs:
           NIGHTLY_MATRIX: "[\"nightly-core\",\"nightly-integration\",\"nightly-flex2dedicated\"]"
         run: |
           # Nightly runs all tests, overriding PR labels as '["test/e2e2/*"]'
-          if [ "${{ github.ref }}" == "refs/heads/main" ];then
+          if [ "${{ github.ref }}" == "refs/heads/main" && "${{ github.event_name }}" == "schedule" ];then
             PR_LABELS='["test/e2e2/*"]'
             echo "Nightly runs all tests"
           fi


### PR DESCRIPTION
# Summary

Currently e2e2 will always run on merge, even when cloud tests are not triggered. Instead they should run only when selected or on nightlies.

## Proof of Work

✅ [Skips without selection](https://github.com/mongodb/mongodb-atlas-kubernetes/actions/runs/17046896740/job/48324943370?pr=2591)
✅ [Runs with selection](https://github.com/mongodb/mongodb-atlas-kubernetes/actions/runs/17044503480/job/48317402709?pr=2591)
✅  [Skips after merge (test post merge)](https://github.com/mongodb/mongodb-atlas-kubernetes/actions/runs/17061108259/job/48368198111)
🔴  [Nightlies run e2e2 (test post merge)](https://github.com/mongodb/mongodb-atlas-kubernetes/actions/runs/17085181091/job/48472010914)

## Checklist
- [X] Have you linked a jira ticket and/or is the ticket in the title?
- [X] Have you checked whether your jira ticket required DOCSP changes?
- [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?

