### PR TITLE
CLOUDP-338822: Bump AKO charts to release 2.10

### DIFF
--- a/helm-charts/atlas-operator-crds/Chart.yaml
+++ b/helm-charts/atlas-operator-crds/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: mongodb-atlas-operator-crds
 description: MongoDB Atlas Operator CRDs - Helm chart for installing and upgrading Custom Resource Definitions (CRDs) for the Atlas Operator.
 type: application
-version: 2.9.1
-appVersion: 2.9.1
+version: 2.10.0
+appVersion: 2.10.0
 kubeVersion: ">=1.15.0-0"
 keywords:
   - mongodb

--- a/helm-charts/atlas-operator/Chart.yaml
+++ b/helm-charts/atlas-operator/Chart.yaml
@@ -3,8 +3,8 @@ name: mongodb-atlas-operator
 description: |-
   MongoDB Atlas Operator - a Helm chart for installing and upgrading Atlas Operator: the official Kubernetes operator allowing to manage MongoDB Atlas resources from Kubernetes
 type: application
-version: 2.9.1
-appVersion: 2.9.1
+version: 2.10.0
+appVersion: 2.10.0
 kubeVersion: ">=1.15.0-0"
 keywords:
   - mongodb
@@ -19,6 +19,6 @@ maintainers:
     email: support@mongodb.com
 dependencies:
   - name: mongodb-atlas-operator-crds
-    version: "2.9.1"
+    version: "2.10.0"
     repository:  "file://../../helm-charts/atlas-operator-crds"
     condition: mongodb-atlas-operator-crds.enabled


### PR DESCRIPTION
# Summary

After release 2.10, the helm chart image references need to be updated to the latest release.

Created with:
```shell
VERSION=2.10.0 ./scripts/bump-helm-chart-version.sh
```

## Proof of Work

- Automation should stop generating PRs such as [Helm charts PR #485](https://github.com/mongodb/helm-charts/pull/485)

## Checklist
- [X] Have you linked a jira ticket and/or is the ticket in the title?
- [X] Have you checked whether your jira ticket required DOCSP changes?
- [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
