### PR TITLE
CLOUDP-338956: Update Helm Charts & Deploy on Release PR

### DIFF
--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -260,7 +260,7 @@ jobs:
           git checkout -f -b "$BRANCH" origin/main
           git push -f origin "$BRANCH"
 
-          git add -f "$RELEASE_DIR"
+          git add -f "$RELEASE_DIR" helm-charts
           scripts/create-signed-commit.sh
 
           gh pr create \

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -253,14 +253,15 @@ jobs:
           cp -rf helm-charts "$RELEASE_DIR/"
           cp bundle.Dockerfile "$RELEASE_DIR/bundle.Dockerfile"
 
-          # Update Helm Charts versions in main
-          ./scripts/bump-helm-chart-version.sh
-
           git fetch origin
           git checkout -f -b "$BRANCH" origin/main
           git push -f origin "$BRANCH"
 
-          git add -f "$RELEASE_DIR" helm-charts
+          # Update Helm Charts & Deploy on main
+          cp -r "$RELEASE_DIR/helm-charts" .
+          cp -r "$RELEASE_DIR/deploy" .
+
+          git add -f "$RELEASE_DIR" helm-charts deploy
           scripts/create-signed-commit.sh
 
           gh pr create \

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -245,12 +245,16 @@ jobs:
 
           git config --global user.name "release-bot[bot]"
           git config --global user.email "456789+release-bot[bot]@users.noreply.github.com"
-
+          
+          # Create release directory
           mkdir -p "$RELEASE_DIR"
           cp -rf deploy "$RELEASE_DIR/"
           cp -rf bundle "$RELEASE_DIR/"
           cp -rf helm-charts "$RELEASE_DIR/"
           cp bundle.Dockerfile "$RELEASE_DIR/bundle.Dockerfile"
+
+          # Update Helm Charts versions in main
+          ./scripts/bump-helm-chart-version.sh
 
           git fetch origin
           git checkout -f -b "$BRANCH" origin/main


### PR DESCRIPTION
# Summary

Make sure Operator and CRD Helm Charts image references in the AKO repository get updates to the image version being released.

## Proof of Work

✅ [Pre-release test generated the deploy and helm](https://github.com/mongodb/mongodb-atlas-kubernetes/pull/2614) **(NOT MERGED)**

## Checklist
- [X] Have you linked a jira ticket and/or is the ticket in the title?
- [X] Have you checked whether your jira ticket required DOCSP changes?
- [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?

