### PR TITLE
CLOUDP-334946: Fix contributions selectable test failure

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,6 +76,13 @@ jobs:
       - run-tests
     uses: ./.github/workflows/cloud-tests-filter.yml
 
+  tests-selectable:
+    needs:
+      - lint
+      - unit-tests
+    uses: ./.github/workflows/tests-selectable.yaml
+    secrets: inherit
+
   e2e2:
     needs:
       - lint

--- a/.github/workflows/tests-selectable.yaml
+++ b/.github/workflows/tests-selectable.yaml
@@ -8,8 +8,7 @@ name: Tests-selectable
 # Tests in the ./e2e directory are considered a GOV test ONLY IF their labels contain "atlas-gov" and executed in a separate job
 
 on:
-  pull_request:
-    types: [opened, synchronize, labeled, unlabeled]
+  workflow_call:
   workflow_dispatch:
     inputs:
       testLabels:


### PR DESCRIPTION
# Summary

Make test-selectable workflow to be kicked as part of the overall test workflow. That way it is triggered with the same events and using the same safeguards.

## Proof of Work

Will have to merge and rebase dummy contrib to fully test this.

## Checklist
- [X] Have you linked a jira ticket and/or is the ticket in the title?
- [X] Have you checked whether your jira ticket required DOCSP changes?
- [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?


