### PR TITLE
CLOUDP-338773: Fix e2e2 nightly run

### DIFF
--- a/.github/workflows/tests-e2e2.yaml
+++ b/.github/workflows/tests-e2e2.yaml
@@ -75,14 +75,16 @@ jobs:
           USE_JSON: true
           SKIP_PREFIXES: "[\"nightly\"]"
           NIGHTLY_MATRIX: "[\"nightly-core\",\"nightly-integration\",\"nightly-flex2dedicated\"]"
+          GITHUB_REF: ${{ github.ref }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
           # Nightly runs all tests, overriding PR labels as '["test/e2e2/*"]'
-          if [ "${{ github.ref }}" == "refs/heads/main" && "${{ github.event_name }}" == "schedule" ];then
-            PR_LABELS='["test/e2e2/*"]'
+          if [ "${GITHUB_REF}" == "refs/heads/main" ] && [ "${EVENT_NAME}" == "schedule" ];then
+            PR_LABELS="${NIGHTLY_MATRIX}"
             echo "Nightly runs all tests"
           fi
-          echo PR_LABELS=${{ env.PR_LABELS }}
-          echo E2E2_LABELS=${{ env.E2E2_LABELS }}
+          echo PR_LABELS="${PR_LABELS}"
+          echo E2E2_LABELS="${E2E2_LABELS}"
           if [ "${PR_LABELS}" == '["test/e2e2/*"]' ]; then
             echo '{"e2e2":${{ env.NIGHTLY_MATRIX }}}' > result.json
           else


### PR DESCRIPTION
# Summary

The expression to run with nightlies was wrong and [they did not run today](https://github.com/mongodb/mongodb-atlas-kubernetes/actions/runs/17085181091/job/48472010914).

## Proof of Work

[ ] Skips without selection without script failures.
[ ] Runs with selection
[ ]Skips after merge without script failures.
[ ] Nightlies run e2e2 (test post merge)

## Checklist
- [X] Have you linked a jira ticket and/or is the ticket in the title?
- [X] Have you checked whether your jira ticket required DOCSP changes?
- [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
