### PR TITLE
CLOUDP-339193: Allow release dryruns

### DIFF
--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -70,6 +70,7 @@ jobs:
   # official-release is mongodb/mongodb-atlas-kubernetes-operator
   # pre-release is mongodb/mongodb-atlas-kubernetes-operator-prerelease
   compute-repo:
+    name: Compute target repos
     runs-on: ubuntu-latest
     env:
       RELEASE_TYPE: ${{ github.event.inputs.release_type }}
@@ -90,6 +91,7 @@ jobs:
   # Release-image: Created and uploads a release for the specified operator version given in the image_sha
   # Note, with new releases, all the release artifacts will be stored within docs/releases/{version}
   release-image:
+    name: Release images
     runs-on: ubuntu-latest
     environment: release
     needs:
@@ -191,6 +193,7 @@ jobs:
 
       - name: Certify Openshift images
         uses: ./.github/actions/certify-openshift-images
+        if: github.event.inputs.release_type == 'official-release'
         with:
           registry: quay.io
           repository: ${{ needs.compute-repo.outputs.repo }}

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -16,6 +16,13 @@ on:
         required: false
         default: "latest"
         type: string
+      release_type:
+        description: "Official releases post to official registries, otherwise post to pre-release registries"
+        required: true
+        default: official-release
+        options:
+        - official-release
+        - pre-release
 
 permissions:
   contents: write
@@ -59,28 +66,51 @@ jobs:
       - name: Echo resolved commit
         run: |
           echo "Resolved commit: ${{ needs.image2commit.outputs.commit_sha }}"
+        
+  # Computes the release repo depending on release_type
+  # official-release is mongodb/mongodb-atlas-kubernetes-operator
+  # pre-release is mongodb/mongodb-atlas-kubernetes-operator-prerelease
+  compute-repo:
+    runs-on: ubuntu-latest
+    env:
+      RELEASE_TYPE: ${{ github.event.inputs.release_type }}
+    outputs:
+      repo: ${{ steps.compute.outputs.repo }}
+    steps:
+     - name: Compute
+       id: compute
+       run: |
+          if [ "${RELEASE_TYPE}" == "official-release" ]; then
+            echo "Setting official release repo mongodb/mongodb-atlas-kubernetes-operator"
+            echo "repo=mongodb/mongodb-atlas-kubernetes-operator" | tee -a $GITHUB_OUTPUT
+          else
+            echo "Setting pre-release repo mongodb/mongodb-atlas-kubernetes-operator-prerelease"
+            echo "repo=mongodb/mongodb-atlas-kubernetes-operator-prerelease" | tee -a $GITHUB_OUTPUT
+          fi
 
   # Release-image: Created and uploads a release for the specified operator version given in the image_sha
   # Note, with new releases, all the release artifacts will be stored within docs/releases/{version}
   release-image:
     runs-on: ubuntu-latest
     environment: release
-    needs: image2commit
+    needs:
+    - image2commit
+    - compute-repo
     env:
       VERSION: ${{ github.event.inputs.version }}
       RELEASE_TAG: v${{ github.event.inputs.version }}
       AUTHORS: ${{ github.event.inputs.authors }}
       IMAGE_SHA: ${{ github.event.inputs.image_sha }}
       DOCKER_SIGNATURE_REPO: docker.io/mongodb/signatures
-      DOCKER_RELEASE_REPO: mongodb/mongodb-atlas-kubernetes-operator
+      DOCKER_RELEASE_REPO: mongodb/${{ needs.compute-repo.outputs.repo }}
       DOCKER_PRERELEASE_REPO: docker.io/mongodb/mongodb-atlas-kubernetes-operator-prerelease
-      QUAY_RELEASE_REPO: quay.io/mongodb/mongodb-atlas-kubernetes-operator
+      QUAY_RELEASE_REPO: quay.io/${{ needs.compute-repo.outputs.repo }}
       QUAY_PRERELEASE_REPO: quay.io/mongodb/mongodb-atlas-kubernetes-operator-prerelease
       PROMOTED_TAG: promoted-${{ github.event.inputs.image_sha }}
       CERTIFIED_TAG: ${{ github.event.inputs.version }}-certified
-      DOCKER_IMAGE_URL: mongodb/mongodb-atlas-kubernetes-operator:${{ github.event.inputs.version }}
-      QUAY_IMAGE_URL: quay.io/mongodb/mongodb-atlas-kubernetes-operator:${{ github.event.inputs.version }}
-      QUAY_CERTIFIED_IMAGE_URL: quay.io/mongodb/mongodb-atlas-kubernetes-operator:${{ github.event.inputs.version }}-certified
+      DOCKER_IMAGE_URL: ${{ needs.compute-repo.outputs.repo }}:${{ github.event.inputs.version }}
+      QUAY_IMAGE_URL: quay.io/${{ needs.compute-repo.outputs.repo }}:${{ github.event.inputs.version }}
+      QUAY_CERTIFIED_IMAGE_URL: quay.io/${{ needs.compute-repo.outputs.repo }}:${{ github.event.inputs.version }}-certified
     steps:
       - name: Checkout code
         uses: actions/checkout@v5

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -18,8 +18,7 @@ on:
         type: string
       release_type:
         description: "Official releases post to official registries, otherwise post to pre-release registries"
-        required: true
-        default: official-release
+        type: choice
         options:
         - official-release
         - pre-release

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -102,7 +102,7 @@ jobs:
       AUTHORS: ${{ github.event.inputs.authors }}
       IMAGE_SHA: ${{ github.event.inputs.image_sha }}
       DOCKER_SIGNATURE_REPO: docker.io/mongodb/signatures
-      DOCKER_RELEASE_REPO: mongodb/${{ needs.compute-repo.outputs.repo }}
+      DOCKER_RELEASE_REPO: ${{ needs.compute-repo.outputs.repo }}
       DOCKER_PRERELEASE_REPO: docker.io/mongodb/mongodb-atlas-kubernetes-operator-prerelease
       QUAY_RELEASE_REPO: quay.io/${{ needs.compute-repo.outputs.repo }}
       QUAY_PRERELEASE_REPO: quay.io/mongodb/mongodb-atlas-kubernetes-operator-prerelease
@@ -194,7 +194,7 @@ jobs:
         uses: ./.github/actions/certify-openshift-images
         with:
           registry: quay.io
-          repository: mongodb/mongodb-atlas-kubernetes-operator
+          repository: ${{ needs.compute-repo.outputs.repo }}
           version: ${{ env.CERTIFIED_TAG }}
           registry_password: ${{ secrets.QUAY_PASSWORD }}
           rhcc_project: ${{ secrets.RH_CERTIFICATION_OSPID }}


### PR DESCRIPTION
# Summary

This change allows us to trigger official release or dryrun pre-releases by selecting the target registry repo to use:

- `official release`-> `mongodb/mongodb-atlas-kubernetes-operator`
- `pre prelease` -> `mongodb/mongodb-atlas-kubernetes-operator-prerelease`

## Proof of Work

✅ [Managed to produce a pre-release image PR](https://github.com/mongodb/mongodb-atlas-kubernetes/pull/2610)  **(NOT MERGED)** 
- See [Successful dry-run release image](https://github.com/mongodb/mongodb-atlas-kubernetes/actions/runs/17126159949)

## Checklist
- [X] Have you linked a jira ticket and/or is the ticket in the title?
- [X] Have you checked whether your jira ticket required DOCSP changes?
- [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
