### PR TITLE
CLOUDP-338773: Fix typo in nightly fix

### DIFF
--- a/.github/workflows/tests-e2e2.yaml
+++ b/.github/workflows/tests-e2e2.yaml
@@ -80,7 +80,7 @@ jobs:
         run: |
           # Nightly runs all tests, overriding PR labels as '["test/e2e2/*"]'
           if [ "${GITHUB_REF}" == "refs/heads/main" ] && [ "${EVENT_NAME}" == "schedule" ];then
-            PR_LABELS="${NIGHTLY_MATRIX}"
+            PR_LABELS='["test/e2e2/*"]'
             echo "Nightly runs all tests"
           fi
           echo PR_LABELS="${PR_LABELS}"


### PR DESCRIPTION
# Summary

This fixes a typo from #2606 that broke the nightlies it was intended to fix.

## Proof of Work

[ ] Skips without selection without script failures
[ ] Runs with selection
[ ] Skips after merge without script failures
[ ] Nightlies run e2e2 (test post merge, but schedule ASAP)

## Checklist
- [X] Have you linked a jira ticket and/or is the ticket in the title?
- [X] Have you checked whether your jira ticket required DOCSP changes?
- [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?


