### PR TITLE
CLOUDP-340194: Fix privatelink CI test and typo

### DIFF
--- a/test/e2e/private_link_test.go
+++ b/test/e2e/private_link_test.go
@@ -46,7 +46,7 @@ type privateEndpoint struct {
 	region   string
 }
 
-var _ = Describe("UserLogin", Label("privatelink"), FlakeAttempts(3), func() {
+var _ = Describe("UserLogin", Label("privatelink"), func() {
 	var testData *model.TestDataProvider
 	var providerAction cloud.Provider
 
@@ -146,9 +146,9 @@ var _ = Describe("UserLogin", Label("privatelink"), FlakeAttempts(3), func() {
 				},
 			},
 		),
-		Entry("Test[privatelink-gpc-1]: User has project which was updated with 1 GCP PrivateEndpoint", Label("privatelink-gpc-1"),
+		Entry("Test[privatelink-gcp-1]: User has project which was updated with 1 GCP PrivateEndpoint", Label("privatelink-gcp-1"),
 			model.DataProvider(
-				"privatelink-gpc-1",
+				"privatelink-gcp-1",
 				model.NewEmptyAtlasKeyType().UseDefaultFullAccess(),
 				40000,
 				[]func(*model.TestDataProvider){},


### PR DESCRIPTION
# Summary

For some strange reason, local testing found the consistent failure of the affected GCP test was happening on retry. When removing flake retries the issue disappeared.

## Proof of Work

CI should pass

## Checklist
- [X] Have you linked a jira ticket and/or is the ticket in the title?
- [X] Have you checked whether your jira ticket required DOCSP changes?
- [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
