### PR TITLE
CLOUDP-334946: Allow contributions to run cloud tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,7 +73,6 @@ jobs:
     uses: ./.github/workflows/check-licenses.yml
   
   cloud-tests-filter:
-    if: github.event.pull_request.head.repo.fork == false
     needs:
       - run-tests
     uses: ./.github/workflows/cloud-tests-filter.yml


### PR DESCRIPTION
# Summary

Allow contributions to run cloud tests.

## Proof of Work

Contributions should run cloud tests, but need to merge to validate

## Checklist
- [X] Have you linked a jira ticket and/or is the ticket in the title?
- [X] Have you checked whether your jira ticket required DOCSP changes?
- [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
