### PR TITLE
CLOUDP-334946: Trigger selectable tests also on pull_request_target

### DIFF
--- a/.github/workflows/tests-e2e2.yaml
+++ b/.github/workflows/tests-e2e2.yaml
@@ -44,7 +44,7 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            if (context.eventName === 'pull_request') {
+            if (context.eventName === 'pull_request' ||  context.eventName === 'pull_request_target') {
               prLabels = context.payload.pull_request.labels.map(label => label.name);
               console.log("PR Labels:", prLabels);
               return prLabels;

--- a/.github/workflows/tests-selectable.yaml
+++ b/.github/workflows/tests-selectable.yaml
@@ -49,7 +49,7 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            if (context.eventName === 'pull_request') {
+            if (context.eventName === 'pull_request' ||  context.eventName === 'pull_request_target') {
               prLabels = context.payload.pull_request.labels.map(label => label.name);
               console.log("PR Labels:", prLabels);
               return prLabels;


### PR DESCRIPTION
# Summary

Previously selectable run on `pull_request` events only, this makes it so that it runs `pull_request_target`.

## Proof of Work

Would need to merge to test it with a contribution.

## Checklist
- [X] Have you linked a jira ticket and/or is the ticket in the title?
- [X] Have you checked whether your jira ticket required DOCSP changes?
- [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?

