### PR TITLE
CLOUDP-341680: Fix cloud test concurrency

### DIFF
--- a/.github/workflows/cloud-tests.yml
+++ b/.github/workflows/cloud-tests.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
 
 concurrency:
-  group: cloud-tests-${{ (github.ref == 'refs/heads/main' && github.event == 'schedule' && 'nightly') || (github.ref == 'refs/heads/main' && github.event == 'push' && 'merge') || github.actor || github.triggering_actor }}
+  group: cloud-tests-${{ (github.ref == 'refs/heads/main' && github.event_name == 'schedule' && 'nightly') || (github.ref == 'refs/heads/main' && github.event_name == 'push' && 'merge') || github.actor || github.triggering_actor }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/cloud-tests.yml
+++ b/.github/workflows/cloud-tests.yml
@@ -4,8 +4,8 @@ on:
   workflow_call:
 
 concurrency:
-    group: cloud-tests-${{ github.ref == 'refs/heads/main' && 'main' || github.actor || github.triggering_actor }}
-    cancel-in-progress: true
+  group: cloud-tests-${{ (github.ref == 'refs/heads/main' && github.event == 'schedule' && 'nightly') || (github.ref == 'refs/heads/main' && github.event == 'push' && 'merge') || github.actor || github.triggering_actor }}
+  cancel-in-progress: true
 
 jobs:
   allowed:


### PR DESCRIPTION
# Summary

We want Nigthly runs to not be cancelled by merges into main. We also not want merges stopped by PRs. And for PRs each developer can run only one at a time,  one per developer (actor):

- **Nightlies** are **scheduled** in **main** right now. E.g `concurrency.group =cloud-tests-nightly`
- **Merges** are a **push** to **main**. E.g. `concurrency.group = cloud-tests-merge`
- The rest are **PRs** to classify by actor (or triggering actor). E.g. `concurrency.group = cloud-tests-johndoe`

## Proof of Work

Should verify proper concurrency, but only after this is merged into main.

## Checklist
- [X] Have you linked a jira ticket and/or is the ticket in the title?
- [X] Have you checked whether your jira ticket required DOCSP changes?
- [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?

