### PR TITLE
CLOUDP-341749: Do not build image on a PR

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -118,6 +118,6 @@ jobs:
       - check-licenses
       - e2e2
       - cloud-tests
-    if: github.ref_name == 'main'
+    if: github.ref_name == 'main' && github.event_name != 'pull_request_target' && github.event_name != 'pull_request'
     uses: ./.github/workflows/promote-image.yml
     secrets: inherit


### PR DESCRIPTION
# Summary

PRs should not be allowed to build an image even after all tests passed.

## Proof of Work

Must merge before we can verify it works.

## Checklist
- [X] Have you linked a jira ticket and/or is the ticket in the title?
- [X] Have you checked whether your jira ticket required DOCSP changes?
- [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
