### PR TITLE
CLOUDP-341680: Remove concurrency limit on basic tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,10 +26,6 @@ on:
           - "true"
           - "false"
 
-concurrency:
-  group: test-${{ github.head_ref || github.ref_name }}
-  cancel-in-progress: true
-
 jobs:
   run-tests:
     name: Run Tests


### PR DESCRIPTION
# Summary

Otherwise the `pull_request_target` runs (which have `github.ref == `refs/heads/main`) will cancel unrelated runs such as nightlies or merges. Also there is no need to limit concurrency on check or selected tests.

## Proof of Work

Must merge to be sure it works.

## Checklist
- [X] Have you linked a jira ticket and/or is the ticket in the title?
- [X] Have you checked whether your jira ticket required DOCSP changes?
- [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?

