### PR TITLE
Fix v2.10.0: cp released bundle to root dir

### DIFF
--- a/.github/workflows/license-header-check.yml
+++ b/.github/workflows/license-header-check.yml
@@ -24,4 +24,5 @@ jobs:
             -ignore "**/*.md" \
             -ignore "**/*.yaml" \
             -ignore "**/*.yml" \
-            -ignore "**/*Dockerfile" .
+            -ignore "**/*Dockerfile" \
+            -ignore "**/*.nix" .

--- a/bundle/manifests/atlas.mongodb.com_atlasdeployments.yaml
+++ b/bundle/manifests/atlas.mongodb.com_atlasdeployments.yaml
@@ -201,6 +201,9 @@ spec:
                       Can only contain ASCII letters, numbers, and hyphens.
                     pattern: ^[a-zA-Z0-9][a-zA-Z0-9-]*$
                     type: string
+                    x-kubernetes-validations:
+                    - message: Name cannot be modified after deployment creation
+                      rule: self == oldSelf
                   paused:
                     description: Flag that indicates whether the deployment should
                       be paused.
@@ -918,6 +921,12 @@ spec:
                 - name
                 - providerSettings
                 type: object
+              upgradeToDedicated:
+                description: |2-
+                   upgradeToDedicated, when set to true, triggers the migration from a Flex to a
+                   Dedicated cluster. The user MUST provide the new dedicated cluster configuration.
+                   This flag is ignored if the cluster is already dedicated.
+                type: boolean
             type: object
             x-kubernetes-validations:
             - message: must define only one project reference through externalProjectRef

--- a/bundle/manifests/atlas.mongodb.com_atlasprojects.yaml
+++ b/bundle/manifests/atlas.mongodb.com_atlasprojects.yaml
@@ -750,6 +750,9 @@ spec:
                 description: Name is the name of the Project that is created in Atlas
                   by the Operator if it doesn't exist yet.
                 type: string
+                x-kubernetes-validations:
+                - message: Name cannot be modified after project creation
+                  rule: self == oldSelf
               networkPeers:
                 description: NetworkPeers is a list of Network Peers configured for
                   the current Project.

--- a/bundle/manifests/mongodb-atlas-kubernetes.clusterserviceversion.yaml
+++ b/bundle/manifests/mongodb-atlas-kubernetes.clusterserviceversion.yaml
@@ -534,7 +534,7 @@ metadata:
       ]
     capabilities: Full Lifecycle
     categories: Database
-    createdAt: "2025-07-02T13:39:49Z"
+    createdAt: "2025-08-01T15:12:11Z"
     description: The MongoDB Atlas Kubernetes Operator enables easy management of Clusters in MongoDB Atlas
     features.operators.openshift.io/disconnected: "false"
     features.operators.openshift.io/fips-compliant: "false"
@@ -547,12 +547,12 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     repository: https://github.com/mongodb/mongodb-atlas-kubernetes
     support: support@mongodb.com
-    containerImage: mongodb/mongodb-atlas-kubernetes-operator:2.9.1
+    containerImage: mongodb/mongodb-atlas-kubernetes-operator:2.10.0
   labels:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.arm64: supported
     operatorframework.io/os.linux: supported
-  name: mongodb-atlas-kubernetes.v2.9.1
+  name: mongodb-atlas-kubernetes.v2.10.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -808,7 +808,7 @@ spec:
                         valueFrom:
                           fieldRef:
                             fieldPath: metadata.annotations['olm.targetNamespaces']
-                    image: mongodb/mongodb-atlas-kubernetes-operator:2.9.1
+                    image: mongodb/mongodb-atlas-kubernetes-operator:2.10.0
                     imagePullPolicy: Always
                     livenessProbe:
                       httpGet:
@@ -892,5 +892,5 @@ spec:
   maturity: beta
   provider:
     name: MongoDB, Inc
-  version: 2.9.1
-  replaces: mongodb-atlas-kubernetes.v2.9.0
+  version: 2.10.0
+  replaces: mongodb-atlas-kubernetes.v2.9.1

--- a/releases/v2.10.0/bundle/manifests/mongodb-atlas-kubernetes.clusterserviceversion.yaml
+++ b/releases/v2.10.0/bundle/manifests/mongodb-atlas-kubernetes.clusterserviceversion.yaml
@@ -534,7 +534,7 @@ metadata:
       ]
     capabilities: Full Lifecycle
     categories: Database
-    createdAt: "2025-07-30T15:52:06Z"
+    createdAt: "2025-08-01T15:12:11Z"
     description: The MongoDB Atlas Kubernetes Operator enables easy management of Clusters in MongoDB Atlas
     features.operators.openshift.io/disconnected: "false"
     features.operators.openshift.io/fips-compliant: "false"
@@ -547,12 +547,12 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     repository: https://github.com/mongodb/mongodb-atlas-kubernetes
     support: support@mongodb.com
-    containerImage: docker.io/mongodb/mongodb-atlas-kubernetes-operator:v2.10.0
+    containerImage: mongodb/mongodb-atlas-kubernetes-operator:2.10.0
   labels:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.arm64: supported
     operatorframework.io/os.linux: supported
-  name: mongodb-atlas-kubernetes.v0.0.0
+  name: mongodb-atlas-kubernetes.v2.10.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -808,7 +808,7 @@ spec:
                         valueFrom:
                           fieldRef:
                             fieldPath: metadata.annotations['olm.targetNamespaces']
-                    image: docker.io/mongodb/mongodb-atlas-kubernetes-operator:v2.10.0
+                    image: mongodb/mongodb-atlas-kubernetes-operator:2.10.0
                     imagePullPolicy: Always
                     livenessProbe:
                       httpGet:
@@ -892,5 +892,5 @@ spec:
   maturity: beta
   provider:
     name: MongoDB, Inc
-  version: 0.0.0
+  version: 2.10.0
   replaces: mongodb-atlas-kubernetes.v2.9.1


### PR DESCRIPTION
# Summary

```shell
cp -r releases/v2.10.0/bundle .
```

This is to fix the `v2.10.0` tag to get the `bundle/` folder updated, so that released versions of CLI plugin can find it as expected using version 2.10.

This will **NOT** merge into main but into the `v.2.10.0-branch`, which should be used to replace the `v2.10.0` tag.

## Proof of Work

N/A

## Checklist
- [X] Have you linked a jira ticket and/or is the ticket in the title?
- [X] Have you checked whether your jira ticket required DOCSP changes?
- [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?

