### PR TITLE
Make Release Image not update deploy or bundle in main

### DIFF
--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -257,11 +257,10 @@ jobs:
           git checkout -f -b "$BRANCH" origin/main
           git push -f origin "$BRANCH"
 
-          # Update Helm Charts & Deploy on main
+          # Update Helm Charts on main
           cp -r "$RELEASE_DIR/helm-charts" .
-          cp -r "$RELEASE_DIR/deploy" .
 
-          git add -f "$RELEASE_DIR" helm-charts deploy
+          git add -f "$RELEASE_DIR" helm-charts
           scripts/create-signed-commit.sh
 
           gh pr create \


### PR DESCRIPTION
# Summary

This undoes fix from CLOUDP-338956. As the CLI is now fixed to use the release directory of each version, instead of the version tag, and it has been fixed retroactively fro `2.9` and `2.8` next release should happen after ir with the CLI fix in place and therefore we do not need to copy the deploy dir to `main`.

Note this PR changes nothing about `helm-charts`. That cannot be changed until we revisit the way the helm charts dir syncs with the helm charts, as automation is set so that this repository is the source of truth over Atlas helm charts.

## Proof of Work

✅ [Release image run properly for a pre-release dryrun](https://github.com/mongodb/mongodb-atlas-kubernetes/actions/runs/17435347186/job/49503557214)
✅ [PR #2653 is the pre-release PR](https://github.com/mongodb/mongodb-atlas-kubernetes/pull/2653/files) Shows only the release dir and the `helm-charts`.

## Checklist
- [X] Have you linked a jira ticket and/or is the ticket in the title?
- [X] Have you checked whether your jira ticket required DOCSP changes?
- [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?

