### PR TITLE
Removal of orphan makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -231,7 +231,7 @@ bin/manager: bin/$(TARGET_OS)/$(TARGET_ARCH)/manager
 	cp bin/$(TARGET_OS)/$(TARGET_ARCH)/manager $@
 
 .PHONY: manager
-manager: generate fmt vet bin/manager recompute-licenses ## Build manager binary
+manager: generate fmt vet bin/manager ## Build manager binary
 
 .PHONY: install
 install: manifests ## Install CRDs from a cluster


### PR DESCRIPTION
# Summary

In [this PR](https://github.com/mongodb/mongodb-atlas-kubernetes/pull/2668), we removed the recompute licenses step from the default make manager target and restricted it to releases only. However, an orphaned make recompute licenses target was left behind, which makes the manager target fail.

## Checklist
- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you checked for release_note changes?
- [x] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?

## Reminder (Please remove this when merging)
- Please try to Approve or Reject Changes the PR, keep PRs in review as short as possible
- Remember the following Communication Standards - use comment prefixes for clarity:
  * **blocking**: Must be addressed before approval.
  * **follow-up**: Can be addressed in a later PR or ticket.
  * **q**: Clarifying question.
  * **nit**: Non-blocking suggestions.
  * **note**: Side-note, non-actionable. Example: Praise 
  * --> no prefix is considered a question

