### PR TITLE
Exclude tools from main AKO sources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ endif
 # Track changes to sources to avoid repeating operations on sourced when soruces did not change
 TMPDIR ?= /tmp
 TIMESTAMPS_DIR := $(TMPDIR)/mongodb-atlas-kubernetes
-GO_SOURCES = $(shell find . -type f -name '*.go' -not -path './vendor/*')
+GO_SOURCES = $(shell find . -type f -name '*.go' -not -path './vendor/*' -not -path './tools/*')
 
 # Defaults for make run
 OPERATOR_POD_NAME = mongodb-atlas-operator


### PR DESCRIPTION
# Summary

Exclude tools from main AKO sources. 

Should allow tools to be added without breaking the CI tests.

## Proof of Work

Ci should pass

## Checklist
- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [X] Have you checked whether your jira ticket required DOCSP changes?
- [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
