### PR TITLE
CLOUDP-344282: Fix e2e2 labeling run on nightlies

### DIFF
--- a/.github/workflows/tests-e2e2.yaml
+++ b/.github/workflows/tests-e2e2.yaml
@@ -73,8 +73,7 @@ jobs:
           PR_LABELS: ${{ steps.get-labels.outputs.result || '["test/e2e2/*"]' }}
           E2E2_LABELS: ${{ env.e2e2_labels }}
           USE_JSON: true
-          SKIP_PREFIXES: "[\"nightly\"]"
-          NIGHTLY_MATRIX: "[\"nightly-core\",\"nightly-integration\",\"nightly-flex2dedicated\"]"
+          SKIP_PREFIXES: "[\"focus\"]"
           GITHUB_REF: ${{ github.ref }}
           EVENT_NAME: ${{ github.event_name }}
         run: |
@@ -85,12 +84,8 @@ jobs:
           fi
           echo PR_LABELS="${PR_LABELS}"
           echo E2E2_LABELS="${E2E2_LABELS}"
-          if [ "${PR_LABELS}" == '["test/e2e2/*"]' ]; then
-            echo '{"e2e2":${{ env.NIGHTLY_MATRIX }}}' > result.json
-          else
-            make compute-labels
-            ./bin/ginkgo-labels > result.json
-          fi
+          make compute-labels
+          ./bin/ginkgo-labels > result.json
           echo "E2E2 tests to execute $(cat result.json | jq -c .e2e2)"
           echo "e2e2_matrix=$(cat result.json | jq -c .e2e2)" >> $GITHUB_OUTPUT
   compute:

--- a/test/e2e2/ako_test.go
+++ b/test/e2e2/ako_test.go
@@ -37,7 +37,7 @@ const (
 	AtlasProjectCRDName = "atlasprojects.atlas.mongodb.com"
 )
 
-var _ = Describe("Atlas Operator Start and Stop test", Ordered, Label("nightly-core", "ako-start-stop"), func() {
+var _ = Describe("Atlas Operator Start and Stop test", Ordered, Label("ako-start-stop"), func() {
 	var ctx context.Context
 	var kubeClient client.Client
 	var ako operator.Operator

--- a/test/e2e2/all_in_one_test.go
+++ b/test/e2e2/all_in_one_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/test/helper/e2e2/kube"
 )
 
-var _ = Describe("all-in-one.yaml", Ordered, Label("nightly-core", "all-in-one"), func() {
+var _ = Describe("all-in-one.yaml", Ordered, Label("all-in-one"), func() {
 	var kubeClient client.Client
 
 	_ = BeforeAll(func() {

--- a/test/e2e2/flex_to_dedicated_test.go
+++ b/test/e2e2/flex_to_dedicated_test.go
@@ -40,7 +40,7 @@ import (
 //go:embed flex2dedicated/*
 var flex2dedicated embed.FS
 
-var _ = Describe("Flex to Dedicated Upgrade", Ordered, Label("nightly-flex2dedicated", "flex-to-dedicated"), func() {
+var _ = Describe("Flex to Dedicated Upgrade", Ordered, Label("flex-to-dedicated"), func() {
 	var ctx context.Context
 	var kubeClient client.Client
 	var ako operator.Operator

--- a/test/e2e2/integration_test.go
+++ b/test/e2e2/integration_test.go
@@ -47,7 +47,7 @@ const (
 	AtlasThirdPartyIntegrationsCRDName = "atlasthirdpartyintegrations.atlas.mongodb.com"
 )
 
-var _ = Describe("Atlas Third-Party Integrations Controller", Ordered, Label("nightly-integration", "integrations-ctlr"), func() {
+var _ = Describe("Atlas Third-Party Integrations Controller", Ordered, Label("integrations-ctlr"), func() {
 	var ctx context.Context
 	var kubeClient client.Client
 	var ako operator.Operator


### PR DESCRIPTION
# Summary

- The nightlies duplicated labels go away.
- CI now only ignores labels with the `focus` prefix. This allows local testing leftovers that won't affect CI.
- On nightlies, the PR labels are set as `["/test/e2e2/*"]` to force run all e2e2 tests.

## Proof of Work

Full testing of the desired behaviour on this repo can only happen after merge.

## Checklist
- [X] Have you linked a jira ticket and/or is the ticket in the title?
- [X] Have you checked whether your jira ticket required DOCSP changes?
- [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
