### PR TITLE
CLOUDP-345374: Group k8s.io dependencies updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,10 @@ updates:
       - "josvazg"
       - "roothorp"
       - "s-urbaniak"
+    groups:
+      kubernetes:
+        patterns:
+          - "k8s.io*"
   - package-ecosystem: github-actions
     directory: "/"
     schedule:


### PR DESCRIPTION
# Summary

Make dependabot group kubernetes dependencies updates in a single PR

## Proof of Work

Single dependabot PR containing all updates coming from k8s.io

## Checklist
- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you checked for release_note changes?
- [x] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?

## Reminder (Please remove this when merging)
- Please try to Approve or Reject Changes the PR, keep PRs in review as short as possible
- Remember the following Communication Standards - use comment prefixes for clarity:
  * **blocking**: Must be addressed before approval.
  * **follow-up**: Can be addressed in a later PR or ticket.
  * **q**: Clarifying question.
  * **nit**: Non-blocking suggestions.
  * **note**: Side-note, non-actionable. Example: Praise 
  * --> no prefix is considered a question

