### PR TITLE
Ignore license headers in tools from main CI

### DIFF
--- a/.github/workflows/license-header-check.yml
+++ b/.github/workflows/license-header-check.yml
@@ -25,4 +25,5 @@ jobs:
             -ignore "**/*.yaml" \
             -ignore "**/*.yml" \
             -ignore "**/*.nix" \
+            -ignore "tools/**" \
             -ignore "**/*Dockerfile" .

--- a/.github/workflows/license-header-check.yml
+++ b/.github/workflows/license-header-check.yml
@@ -9,12 +9,17 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
+        with:
+          ref: ${{github.event.pull_request.head.sha}}
+
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
           go-version-file: "${{ github.workspace }}/go.mod"
+
       - name: Install addlicense
         run: go install github.com/google/addlicense@latest
+
       - name: Check license headers
         run: |
           $(go env GOPATH)/bin/addlicense \


### PR DESCRIPTION
# Summary

Do not check license headers on toold from main CI. Tools CIs should do that themselves.

## Proof of Work

CI will be green again in main.

```shell
$ addlicense \
            -check \
            -l apache \
            -c "MongoDB Inc" \
            -ignore "**/*.md" \
            -ignore "**/*.yaml" \
            -ignore "**/*.yml" \
            -ignore "**/*.nix" \
            -ignore "tools/**" \
            -ignore "**/*Dockerfile" . && echo PASS
PASS
```

## Checklist
- [] Have you linked a jira ticket and/or is the ticket in the title?
- [X] Have you checked whether your jira ticket required DOCSP changes?
- [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
