### PR TITLE
CLOUDP-310817: Isolate main CI tests from tools

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,12 +8,14 @@ on:
       - 'main'
     paths-ignore:
       - 'docs/**'
+      - 'tools/**'
   pull_request_target:
     types: [opened, synchronize, reopened, ready_for_review, converted_to_draft, labeled]
     branches:
       - '**'
     paths-ignore:
       - 'docs/**'
+      - 'tools/**'
   merge_group:
   workflow_dispatch:
     inputs:
@@ -25,6 +27,9 @@ on:
         options:
           - "true"
           - "false"
+    paths-ignore:
+      - 'docs/**'
+      - 'tools/**'
 
 jobs:
   run-tests:


### PR DESCRIPTION
# Summary

The main CI test should NOT trigger just because a tool was updated. Those tools should have their own separate CI.

## Proof of Work

After merge changes in tools will not trigger the main CI tests.

## Checklist
- [X] Have you linked a jira ticket and/or is the ticket in the title?
- [X] Have you checked whether your jira ticket required DOCSP changes?
- [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?

