### PR TITLE
Legacy ConnectionSecret refactoring

### DIFF
--- a/internal/controller/atlasdatabaseuser/atlasdatabaseuser_controller.go
+++ b/internal/controller/atlasdatabaseuser/atlasdatabaseuser_controller.go
@@ -39,7 +39,6 @@ import (
 	akov2 "github.com/mongodb/mongodb-atlas-kubernetes/v2/api/v1"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/api/v1/status"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/controller/atlas"
-	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/controller/connectionsecret"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/controller/customresource"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/controller/reconciler"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/controller/statushandler"
@@ -142,7 +141,7 @@ func (r *AtlasDatabaseUserReconciler) terminate(
 
 // unmanage remove finalizer and release resource
 func (r *AtlasDatabaseUserReconciler) unmanage(ctx *workflow.Context, projectID string, atlasDatabaseUser *akov2.AtlasDatabaseUser) (ctrl.Result, error) {
-	err := connectionsecret.RemoveStaleSecretsByUserName(ctx.Context, r.Client, projectID, atlasDatabaseUser.Spec.Username, *atlasDatabaseUser, r.Log)
+	err := RemoveStaleSecretsByUserName(ctx.Context, r.Client, projectID, atlasDatabaseUser.Spec.Username, *atlasDatabaseUser, r.Log)
 	if err != nil {
 		return r.terminate(ctx, atlasDatabaseUser, api.DatabaseUserReadyType, workflow.DatabaseUserConnectionSecretsNotDeleted, true, err)
 	}

--- a/internal/controller/atlasdatabaseuser/connectionsecrets.go
+++ b/internal/controller/atlasdatabaseuser/connectionsecrets.go
@@ -26,13 +26,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	akov2 "github.com/mongodb/mongodb-atlas-kubernetes/v2/api/v1"
+	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/controller/secretservice"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/controller/workflow"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/kube"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/stringutil"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/translation/deployment"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/translation/project"
-
-	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/controller/secretservice"
 )
 
 const ConnectionSecretsEnsuredEvent = "ConnectionSecretsEnsured"

--- a/internal/controller/atlasdatabaseuser/connectionsecrets_test.go
+++ b/internal/controller/atlasdatabaseuser/connectionsecrets_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package connectionsecret_test
+package atlasdatabaseuser
 
 import (
 	"context"
@@ -28,7 +28,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	akov2 "github.com/mongodb/mongodb-atlas-kubernetes/v2/api/v1"
-	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/controller/connectionsecret"
+	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/controller/secretservice"
 )
 
 const (
@@ -72,7 +72,7 @@ func TestReapOrphanConnectionSecrets(t *testing.T) {
 			fakeClient := fake.NewClientBuilder().
 				WithScheme(scheme).
 				WithObjects(tc.objects...).Build()
-			removedOrphans, err := connectionsecret.ReapOrphanConnectionSecrets(
+			removedOrphans, err := ReapOrphanConnectionSecrets(
 				context.Background(),
 				fakeClient,
 				testProjectID,
@@ -96,9 +96,9 @@ func matchingSecrets() []client.Object {
 				Name:      "secret1",
 				Namespace: testNamespace,
 				Labels: map[string]string{
-					connectionsecret.ClusterLabelKey: "cluster1",
-					connectionsecret.ProjectLabelKey: testProjectID,
-					connectionsecret.TypeLabelKey:    connectionsecret.CredLabelVal,
+					secretservice.ClusterLabelKey: "cluster1",
+					secretservice.ProjectLabelKey: testProjectID,
+					secretservice.TypeLabelKey:    secretservice.CredLabelVal,
 				},
 			},
 		},
@@ -108,9 +108,9 @@ func matchingSecrets() []client.Object {
 				Name:      "secret2",
 				Namespace: testNamespace,
 				Labels: map[string]string{
-					connectionsecret.ClusterLabelKey: "serverless2",
-					connectionsecret.ProjectLabelKey: testProjectID,
-					connectionsecret.TypeLabelKey:    connectionsecret.CredLabelVal,
+					secretservice.ClusterLabelKey: "serverless2",
+					secretservice.ProjectLabelKey: testProjectID,
+					secretservice.TypeLabelKey:    secretservice.CredLabelVal,
 				},
 			},
 		},
@@ -124,9 +124,9 @@ func nonMatchingSecrets() []client.Object {
 				Name:      "secret3",
 				Namespace: testNamespace,
 				Labels: map[string]string{
-					connectionsecret.ClusterLabelKey: "cluster3",
-					connectionsecret.ProjectLabelKey: testProjectID,
-					connectionsecret.TypeLabelKey:    connectionsecret.CredLabelVal,
+					secretservice.ClusterLabelKey: "cluster3",
+					secretservice.ProjectLabelKey: testProjectID,
+					secretservice.TypeLabelKey:    secretservice.CredLabelVal,
 				},
 			},
 		},
@@ -136,9 +136,9 @@ func nonMatchingSecrets() []client.Object {
 				Name:      "secret4",
 				Namespace: testNamespace,
 				Labels: map[string]string{
-					connectionsecret.ClusterLabelKey: "serverless4",
-					connectionsecret.ProjectLabelKey: testProjectID,
-					connectionsecret.TypeLabelKey:    connectionsecret.CredLabelVal,
+					secretservice.ClusterLabelKey: "serverless4",
+					secretservice.ProjectLabelKey: testProjectID,
+					secretservice.TypeLabelKey:    secretservice.CredLabelVal,
 				},
 			},
 		},

--- a/internal/controller/atlasdatafederation/datafederation_controller.go
+++ b/internal/controller/atlasdatafederation/datafederation_controller.go
@@ -37,9 +37,9 @@ import (
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/api"
 	akov2 "github.com/mongodb/mongodb-atlas-kubernetes/v2/api/v1"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/controller/atlas"
-	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/controller/connectionsecret"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/controller/customresource"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/controller/reconciler"
+	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/controller/secretservice"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/controller/statushandler"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/controller/workflow"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/indexer"
@@ -308,7 +308,7 @@ func (r *AtlasDataFederationReconciler) deleteConnectionSecrets(ctx context.Cont
 	log = log.With("projectID", project.Status.ID, "dataFederationName", dataFederation.Spec.Name)
 
 	// We always remove the connection secrets even if the deployment is not removed from Atlas
-	secrets, err := connectionsecret.ListByDeploymentName(ctx, r.Client, dataFederation.Namespace, project.ID(), dataFederation.Spec.Name)
+	secrets, err := secretservice.ListByDeploymentName(ctx, r.Client, dataFederation.Namespace, project.ID(), dataFederation.Spec.Name)
 	if err != nil {
 		return fmt.Errorf("failed to find connection secrets for the user: %w", err)
 	}

--- a/internal/controller/atlasdatafederation/datafederation_controller_test.go
+++ b/internal/controller/atlasdatafederation/datafederation_controller_test.go
@@ -34,8 +34,8 @@ import (
 	akov2 "github.com/mongodb/mongodb-atlas-kubernetes/v2/api/v1"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/api/v1/common"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/api/v1/status"
-	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/controller/connectionsecret"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/controller/customresource"
+	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/controller/secretservice"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/controller/workflow"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/indexer"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/mocks/translation"
@@ -145,9 +145,9 @@ func TestDeleteConnectionSecrets(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "fooSecret", Namespace: "bar",
 						Labels: map[string]string{
-							connectionsecret.TypeLabelKey:    connectionsecret.CredLabelVal,
-							connectionsecret.ProjectLabelKey: "123",
-							connectionsecret.ClusterLabelKey: "data-federation-name",
+							secretservice.TypeLabelKey:    secretservice.CredLabelVal,
+							secretservice.ProjectLabelKey: "123",
+							secretservice.ClusterLabelKey: "data-federation-name",
 						},
 					},
 				},
@@ -155,9 +155,9 @@ func TestDeleteConnectionSecrets(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "keepSecret", Namespace: "bar",
 						Labels: map[string]string{
-							connectionsecret.TypeLabelKey:    connectionsecret.CredLabelVal,
-							connectionsecret.ProjectLabelKey: "123",
-							connectionsecret.ClusterLabelKey: "some-cluster",
+							secretservice.TypeLabelKey:    secretservice.CredLabelVal,
+							secretservice.ProjectLabelKey: "123",
+							secretservice.ClusterLabelKey: "some-cluster",
 						},
 					},
 				},
@@ -167,9 +167,9 @@ func TestDeleteConnectionSecrets(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "keepSecret", Namespace: "bar",
 						Labels: map[string]string{
-							connectionsecret.TypeLabelKey:    connectionsecret.CredLabelVal,
-							connectionsecret.ProjectLabelKey: "123",
-							connectionsecret.ClusterLabelKey: "some-cluster",
+							secretservice.TypeLabelKey:    secretservice.CredLabelVal,
+							secretservice.ProjectLabelKey: "123",
+							secretservice.ClusterLabelKey: "some-cluster",
 						},
 					},
 				},

--- a/internal/controller/atlasdeployment/atlasdeployment_controller.go
+++ b/internal/controller/atlasdeployment/atlasdeployment_controller.go
@@ -41,9 +41,9 @@ import (
 	akov2 "github.com/mongodb/mongodb-atlas-kubernetes/v2/api/v1"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/api/v1/status"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/controller/atlas"
-	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/controller/connectionsecret"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/controller/customresource"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/controller/reconciler"
+	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/controller/secretservice"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/controller/statushandler"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/controller/validate"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/controller/workflow"
@@ -256,7 +256,7 @@ func (r *AtlasDeploymentReconciler) deleteDeploymentFromAtlas(
 
 func (r *AtlasDeploymentReconciler) deleteConnectionStrings(ctx *workflow.Context, deployment deployment.Deployment) error {
 	// We always remove the connection secrets even if the deployment is not removed from Atlas
-	secrets, err := connectionsecret.ListByDeploymentName(ctx.Context, r.Client, "", deployment.GetProjectID(), deployment.GetName())
+	secrets, err := secretservice.ListByDeploymentName(ctx.Context, r.Client, "", deployment.GetProjectID(), deployment.GetName())
 	if err != nil {
 		return fmt.Errorf("failed to find connection secrets for the user: %w", err)
 	}

--- a/internal/controller/secretservice/ensuresecret.go
+++ b/internal/controller/secretservice/ensuresecret.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package connectionsecret
+package secretservice
 
 import (
 	"context"

--- a/internal/controller/secretservice/ensuresecret_test.go
+++ b/internal/controller/secretservice/ensuresecret_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package connectionsecret
+package secretservice
 
 import (
 	"context"

--- a/internal/controller/secretservice/listsecrets.go
+++ b/internal/controller/secretservice/listsecrets.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package connectionsecret
+package secretservice
 
 import (
 	"context"

--- a/internal/controller/secretservice/listsecrets_test.go
+++ b/internal/controller/secretservice/listsecrets_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package connectionsecret
+package secretservice
 
 import (
 	"context"

--- a/internal/operator/builder.go
+++ b/internal/operator/builder.go
@@ -41,7 +41,7 @@ import (
 
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/controller"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/controller/atlas"
-	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/controller/connectionsecret"
+	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/controller/secretservice"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/controller/watch"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/dryrun"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/featureflags"
@@ -191,7 +191,7 @@ func (b *Builder) Build(ctx context.Context) (cluster.Cluster, error) {
 		cacheOpts.ByObject = map[client.Object]cache.ByObject{
 			&corev1.Secret{}: {
 				Label: labels.SelectorFromSet(labels.Set{
-					connectionsecret.TypeLabelKey: connectionsecret.CredLabelVal,
+					secretservice.TypeLabelKey: secretservice.CredLabelVal,
 				}),
 			},
 		}

--- a/test/e2e/alert_config_test.go
+++ b/test/e2e/alert_config_test.go
@@ -29,7 +29,7 @@ import (
 	akov2 "github.com/mongodb/mongodb-atlas-kubernetes/v2/api/v1"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/api/v1/common"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/compare"
-	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/controller/connectionsecret"
+	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/controller/secretservice"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/test/helper/e2e/actions"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/test/helper/e2e/api/atlas"
@@ -315,7 +315,7 @@ var _ = Describe("Alert configuration with secrets test", Label("alert-config", 
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "datadog-creds",
 			Labels: map[string]string{
-				connectionsecret.TypeLabelKey: connectionsecret.CredLabelVal,
+				secretservice.TypeLabelKey: secretservice.CredLabelVal,
 			},
 		},
 		Data: map[string][]byte{

--- a/test/e2e/atlas_gov_test.go
+++ b/test/e2e/atlas_gov_test.go
@@ -33,7 +33,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/api/v1/common"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/api/v1/project"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/api/v1/status"
-	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/controller/connectionsecret"
+	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/controller/secretservice"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/controller/workflow"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/test/helper/conditions"
@@ -103,7 +103,7 @@ var _ = Describe("Atlas for Government", Label("atlas-gov"), func() {
 					Name:      "pager-duty-service-key",
 					Namespace: testData.Resources.Namespace,
 					Labels: map[string]string{
-						connectionsecret.TypeLabelKey: connectionsecret.CredLabelVal,
+						secretservice.TypeLabelKey: secretservice.CredLabelVal,
 					},
 				},
 				StringData: map[string]string{"password": os.Getenv("PAGER_DUTY_SERVICE_KEY")},
@@ -323,7 +323,7 @@ var _ = Describe("Atlas for Government", Label("atlas-gov"), func() {
 					Name:      "aws-secret",
 					Namespace: testData.Resources.Namespace,
 					Labels: map[string]string{
-						connectionsecret.TypeLabelKey: connectionsecret.CredLabelVal,
+						secretservice.TypeLabelKey: secretservice.CredLabelVal,
 					},
 				},
 				Data: map[string][]byte{
@@ -553,7 +553,7 @@ var _ = Describe("Atlas for Government", Label("atlas-gov"), func() {
 					Name:      fmt.Sprintf("%s-dbuser-pass", projectName),
 					Namespace: testData.Resources.Namespace,
 					Labels: map[string]string{
-						connectionsecret.TypeLabelKey: connectionsecret.CredLabelVal,
+						secretservice.TypeLabelKey: secretservice.CredLabelVal,
 					},
 				},
 				StringData: map[string]string{"password": "myHardPass2MyDB"},

--- a/test/e2e/encryption_at_rest_test.go
+++ b/test/e2e/encryption_at_rest_test.go
@@ -31,7 +31,7 @@ import (
 	akov2 "github.com/mongodb/mongodb-atlas-kubernetes/v2/api/v1"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/api/v1/common"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/api/v1/status"
-	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/controller/connectionsecret"
+	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/controller/secretservice"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/test/helper/e2e/actions"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/test/helper/e2e/actions/cloud"
@@ -214,7 +214,7 @@ func fillKMSforAWS(userData *model.TestDataProvider, encAtRest *akov2.Encryption
 			Name:      "aws-secret",
 			Namespace: userData.Resources.Namespace,
 			Labels: map[string]string{
-				connectionsecret.TypeLabelKey: connectionsecret.CredLabelVal,
+				secretservice.TypeLabelKey: secretservice.CredLabelVal,
 			},
 		},
 		Data: map[string][]byte{
@@ -251,7 +251,7 @@ func fillVaultforAzure(userData *model.TestDataProvider, encAtRest *akov2.Encryp
 			Name:      "az-secret",
 			Namespace: userData.Resources.Namespace,
 			Labels: map[string]string{
-				connectionsecret.TypeLabelKey: connectionsecret.CredLabelVal,
+				secretservice.TypeLabelKey: secretservice.CredLabelVal,
 			},
 		},
 		Data: map[string][]byte{
@@ -289,7 +289,7 @@ func fillKMSforGCP(userData *model.TestDataProvider, encAtRest *akov2.Encryption
 			Name:      "gcp-secret",
 			Namespace: userData.Resources.Namespace,
 			Labels: map[string]string{
-				connectionsecret.TypeLabelKey: connectionsecret.CredLabelVal,
+				secretservice.TypeLabelKey: secretservice.CredLabelVal,
 			},
 		},
 		Data: map[string][]byte{

--- a/test/e2e2/integration_test.go
+++ b/test/e2e2/integration_test.go
@@ -31,7 +31,7 @@ import (
 
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/api"
 	akov2 "github.com/mongodb/mongodb-atlas-kubernetes/v2/api/v1"
-	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/controller/connectionsecret"
+	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/controller/secretservice"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/state"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/test/helper/control"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/test/helper/e2e/utils"
@@ -238,7 +238,7 @@ var _ = Describe("Atlas Third-Party Integrations Controller", Ordered, Label("in
 				Name:      "victor-ops-secret",
 				Namespace: testNamespace.Name,
 				Labels: map[string]string{
-					connectionsecret.TypeLabelKey: connectionsecret.CredLabelVal,
+					secretservice.TypeLabelKey: secretservice.CredLabelVal,
 				},
 			},
 			Data: map[string][]byte{

--- a/test/helper/e2e/k8s/k8s.go
+++ b/test/helper/e2e/k8s/k8s.go
@@ -35,7 +35,7 @@ import (
 
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/api"
 	akov2 "github.com/mongodb/mongodb-atlas-kubernetes/v2/api/v1"
-	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/controller/connectionsecret"
+	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/controller/secretservice"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/test/helper/e2e/config"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/test/helper/e2e/utils"
 )
@@ -239,7 +239,7 @@ func CreateUserSecret(ctx context.Context, k8sClient client.Client, secret, name
 		},
 	}
 	secretObj.SetLabels(map[string]string{
-		connectionsecret.TypeLabelKey: connectionsecret.CredLabelVal,
+		secretservice.TypeLabelKey: secretservice.CredLabelVal,
 	})
 	err := k8sClient.Create(ctx, secretObj)
 	if err != nil {
@@ -253,21 +253,21 @@ func CreateDefaultSecret(ctx context.Context, k8sClient client.Client, name, ns 
 }
 
 func CreateSecret(ctx context.Context, k8sClient client.Client, publicKey, privateKey, name, ns string) error {
-	connectionSecret := corev1.Secret{
+	secretservice := corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: ns,
 			Labels: map[string]string{
-				connectionsecret.TypeLabelKey: connectionsecret.CredLabelVal,
+				secretservice.TypeLabelKey: secretservice.CredLabelVal,
 			},
 		},
 		StringData: map[string]string{"orgId": os.Getenv("MCLI_ORG_ID"), "publicApiKey": publicKey, "privateApiKey": privateKey},
 	}
-	err := k8sClient.Create(ctx, &connectionSecret)
+	err := k8sClient.Create(ctx, &secretservice)
 	if err != nil && !k8serrors.IsAlreadyExists(err) {
 		return fmt.Errorf("error creating secret: %w", err)
 	}
-	err = k8sClient.Update(ctx, &connectionSecret)
+	err = k8sClient.Update(ctx, &secretservice)
 	if err != nil {
 		return fmt.Errorf("error updating existing secret: %w", err)
 	}
@@ -326,7 +326,7 @@ func CreateCertificateX509(ctx context.Context, k8sClient client.Client, name, n
 		},
 	}
 	certificateSecret.Labels = map[string]string{
-		connectionsecret.TypeLabelKey: connectionsecret.CredLabelVal,
+		secretservice.TypeLabelKey: secretservice.CredLabelVal,
 	}
 	err = k8sClient.Create(ctx, certificateSecret)
 	if err != nil {

--- a/test/int/clusterwide/dbuser_test.go
+++ b/test/int/clusterwide/dbuser_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/api"
 	akov2 "github.com/mongodb/mongodb-atlas-kubernetes/v2/api/v1"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/api/v1/project"
-	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/controller/connectionsecret"
+	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/controller/secretservice"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/controller/workflow"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/test/helper/conditions"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/test/helper/resources"
@@ -152,7 +152,7 @@ func buildConnectionSecret(name string) corev1.Secret {
 			Name:      name,
 			Namespace: namespace.Name,
 			Labels: map[string]string{
-				connectionsecret.TypeLabelKey: connectionsecret.CredLabelVal,
+				secretservice.TypeLabelKey: secretservice.CredLabelVal,
 			},
 		},
 		StringData: map[string]string{"orgId": orgID, "publicApiKey": publicKey, "privateApiKey": privateKey},
@@ -165,7 +165,7 @@ func buildPasswordSecret(namespace, name, password string) corev1.Secret {
 			Name:      name,
 			Namespace: namespace,
 			Labels: map[string]string{
-				connectionsecret.TypeLabelKey: connectionsecret.CredLabelVal,
+				secretservice.TypeLabelKey: secretservice.CredLabelVal,
 			},
 		},
 		StringData: map[string]string{"password": password},

--- a/test/int/databaseuser_unprotected_test.go
+++ b/test/int/databaseuser_unprotected_test.go
@@ -37,8 +37,8 @@ import (
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/api"
 	akov2 "github.com/mongodb/mongodb-atlas-kubernetes/v2/api/v1"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/api/v1/project"
-	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/controller/connectionsecret"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/controller/customresource"
+	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/controller/secretservice"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/controller/workflow"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/kube"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/test/helper/atlas"
@@ -766,7 +766,7 @@ func buildPasswordSecret(namespace, name, password string) corev1.Secret {
 			Name:      name,
 			Namespace: namespace,
 			Labels: map[string]string{
-				connectionsecret.TypeLabelKey: connectionsecret.CredLabelVal,
+				secretservice.TypeLabelKey: secretservice.CredLabelVal,
 			},
 		},
 		StringData: map[string]string{"password": password},
@@ -800,7 +800,7 @@ func validateSecret(k8sClient client.Client, project akov2.AtlasProject, deploym
 	expectedLabels := map[string]string{
 		"atlas.mongodb.com/project-id":   project.ID(),
 		"atlas.mongodb.com/cluster-name": deployment.GetDeploymentName(),
-		connectionsecret.TypeLabelKey:    connectionsecret.CredLabelVal,
+		secretservice.TypeLabelKey:       secretservice.CredLabelVal,
 	}
 	Expect(secret.Data).To(Equal(expectedData))
 	Expect(secret.Labels).To(Equal(expectedLabels))
@@ -826,7 +826,7 @@ func buildConnectionURL(connURL, userName, password string) string {
 		return ""
 	}
 
-	u, err := connectionsecret.AddCredentialsToConnectionURL(connURL, userName, password)
+	u, err := secretservice.AddCredentialsToConnectionURL(connURL, userName, password)
 	Expect(err).NotTo(HaveOccurred())
 	return u
 }

--- a/test/int/datafederation_test.go
+++ b/test/int/datafederation_test.go
@@ -29,8 +29,8 @@ import (
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/api"
 	akov2 "github.com/mongodb/mongodb-atlas-kubernetes/v2/api/v1"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/api/v1/project"
-	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/controller/connectionsecret"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/controller/customresource"
+	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/controller/secretservice"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/kube"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/test/helper/resources"
 )
@@ -58,7 +58,7 @@ var _ = Describe("AtlasDataFederation", Label("AtlasDataFederation"), func() {
 				Name:      ConnectionSecretName,
 				Namespace: namespace.Name,
 				Labels: map[string]string{
-					connectionsecret.TypeLabelKey: connectionsecret.CredLabelVal,
+					secretservice.TypeLabelKey: secretservice.CredLabelVal,
 				},
 			},
 			StringData: secretData(),

--- a/test/int/deployment_test.go
+++ b/test/int/deployment_test.go
@@ -40,8 +40,8 @@ import (
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/api/v1/status"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/compat"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/controller/atlasdeployment"
-	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/controller/connectionsecret"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/controller/customresource"
+	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/controller/secretservice"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/controller/workflow"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/kube"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/pointer"
@@ -1615,7 +1615,7 @@ func createConnectionSecret() *corev1.Secret {
 			Name:      ConnectionSecretName,
 			Namespace: namespace.Name,
 			Labels: map[string]string{
-				connectionsecret.TypeLabelKey: connectionsecret.CredLabelVal,
+				secretservice.TypeLabelKey: secretservice.CredLabelVal,
 			},
 		},
 		StringData: secretData(),


### PR DESCRIPTION
# Summary

<!-- Enter your issue summary here.-->

The ConnectionSecret package was originally designed to serve multiple components, including Atlas Data Federation, Atlas Database users, and Atlas Deployments. To better align with its purpose, I have renamed ConnectionSecret to SecretService, as this name more accurately reflects its role. This change also frees up the ConnectionSecret package name, which can now be reused for experimental code in the future. I have also moved some logic only used by AtlasDatabaseUsers in that package.

## Proof of Work

<!-- Enter your proof that it works here.-->

## Checklist
- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you checked for release_note changes?
- [x] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?

## Reminder (Please remove this when merging)
- Please try to Approve or Reject Changes the PR, keep PRs in review as short as possible
- Remember the following Communication Standards - use comment prefixes for clarity:
  * **blocking**: Must be addressed before approval.
  * **follow-up**: Can be addressed in a later PR or ticket.
  * **q**: Clarifying question.
  * **nit**: Non-blocking suggestions.
  * **note**: Side-note, non-actionable. Example: Praise 
  * --> no prefix is considered a question

