### PR TITLE
Bump Go to 1.24.7 to avoid GO-2025-3956

### DIFF
--- a/flakes/go/flake.nix
+++ b/flakes/go/flake.nix
@@ -8,13 +8,15 @@
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = import nixpkgs { inherit system; };
+        version = "1.24.7";
       in
       {
         packages.default = pkgs.go_1_24.overrideAttrs (old: {
-          version = "1.24.4";
+          pname = "go";
+          inherit version;
           src = pkgs.fetchurl {
-            url = "https://golang.org/dl/go1.24.4.linux-amd64.tar.gz";
-            sha256 = "sha256-d+XaM7tyrq7xukQYtv5RG8TQQYc8v4LlqmMYdA35hxc=";
+            url = "https://golang.org/dl/go${version}.linux-amd64.tar.gz";
+            sha256 = "sha256-2hgZHdt9uKkzmBbz4rVL3e2AR83CpdZwWUePjRWVxD8=";
           };
         });
       });

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/mongodb/mongodb-atlas-kubernetes/v2
 
 go 1.24.0
 
-toolchain go1.24.4
+toolchain go1.24.7
 
 require (
 	cloud.google.com/go/kms v1.23.0

--- a/tools/openapi2crd/go.mod
+++ b/tools/openapi2crd/go.mod
@@ -2,7 +2,7 @@ module tools/openapi2crd
 
 go 1.24
 
-toolchain go1.24.0
+toolchain go1.24.7
 
 require (
 	github.com/getkin/kin-openapi v0.131.0


### PR DESCRIPTION
# Summary

Go 1.24.4 is vulnerable to [GO-2025-3956](https://pkg.go.dev/vuln/GO-2025-3956)

## Proof of Work

CI should pass

## Checklist
- [X] Have you linked a jira ticket and/or is the ticket in the title?
- [X] Have you checked whether your jira ticket required DOCSP changes?
- [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?

