### PR TITLE
CLOUDP-347174: Enable on demand nightlies

### DIFF
--- a/.github/workflows/cloud-tests.yml
+++ b/.github/workflows/cloud-tests.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
 
 concurrency:
-  group: cloud-tests-${{ (github.ref == 'refs/heads/main' && github.event_name == 'schedule' && 'nightly') || (github.ref == 'refs/heads/main' && github.event_name == 'push' && 'merge') || github.actor || github.triggering_actor }}
+  group: cloud-tests-${{ (github.ref == 'refs/heads/main' && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && 'nightly') || (github.ref == 'refs/heads/main' && github.event_name == 'push' && 'merge') || github.actor || github.triggering_actor }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/tests-e2e2.yaml
+++ b/.github/workflows/tests-e2e2.yaml
@@ -78,7 +78,7 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
         run: |
           # Nightly runs all tests, overriding PR labels as '["test/e2e2/*"]'
-          if [ "${GITHUB_REF}" == "refs/heads/main" ] && [ "${EVENT_NAME}" == "schedule" ];then
+          if [ "${GITHUB_REF}" == "refs/heads/main" ] && [ "${EVENT_NAME}" == "schedule" -o "${EVENT_NAME}" == "workflow_dispatch" ];then
             PR_LABELS='["test/e2e2/*"]'
             echo "Nightly runs all tests"
           fi


### PR DESCRIPTION
# Summary

Enable on demand nightlies, as already intended by @andrpac 

Some fixes after the release changes broke this possibility as a nightly run had to be an schedule event. This change fixes that assumption so that workflow_dispatch events on main are also nightlies.

## Proof of Work

CI should work and we can trigger a demand nightly after merge on main.

## Checklist
- [X] Have you linked a jira ticket and/or is the ticket in the title?
- [X] Have you checked whether your jira ticket required DOCSP changes?
- [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?

