### PR TITLE
CLOUDP-347174: Don't run cloud tests on push (to main)

### DIFF
--- a/.github/workflows/cloud-tests-filter.yml
+++ b/.github/workflows/cloud-tests-filter.yml
@@ -66,9 +66,6 @@ jobs:
             # Release branches always run all tests
             elif [[ "${GH_HEAD_REF}" == release/* ]];then
               RUN_CLOUD_TESTS='true'
-            # push events run all tests when code was changed
-            elif [ "${EVENT}" == "push" ] && [ "${CODE_CHANGED}" == "true" ];then
-              RUN_CLOUD_TESTS='true'
             # cloud-tests label forces cloud tests to run, BUT only on AKO PRs, not from forked repos 
             elif [ "${CLOUD_TESTS_LABEL}" == "true" ] && [ "${FORKED}" == "false" ];then
               RUN_CLOUD_TESTS='true'


### PR DESCRIPTION
# Summary

We no longer run cloud tests in any case when pushing to main. Only the Nightly scheduled or run on demand may do so.

## Proof of Work

Ci works, merges should not run cloud tests.

## Checklist
- [X] Have you linked a jira ticket and/or is the ticket in the title?
- [X] Have you checked whether your jira ticket required DOCSP changes?
- [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
