### PR TITLE
Update release-image.yml to fix syntax error

### DIFF
--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -26,7 +26,6 @@ on:
 permissions:
   contents: write
   pull-requests: write
-  workflows: write
 
 jobs:
   # Image2commit: Creates a mapping between the image_sha given as input and the actual git commit


### PR DESCRIPTION
Remove permission not recognised by GH

# Summary

This permission is not recognised by GitHub

## Proof of Work

✅ [The workflow was allowed to run](https://github.com/mongodb/mongodb-atlas-kubernetes/actions/runs/17981443181/job/51148311379) so the syntax error is fixed

## Checklist
- [X] Have you linked a jira ticket and/or is the ticket in the title?
- [X] Have you checked whether your jira ticket required DOCSP changes?
- [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?

