### PR TITLE
CLOUDP-335401: Make pre-release the default option

### DIFF
--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -19,9 +19,10 @@ on:
       release_type:
         description: "Official releases post to official registries, otherwise post to pre-release registries"
         type: choice
+        default: pre-release
         options:
-        - official-release
         - pre-release
+        - official-release
 
 permissions:
   contents: write


### PR DESCRIPTION
# Summary

Given that `release-image.yml` will create a PR to review **after** the image has already released to the registries, it is safer to leave the `pre-release` option as default, so that an `official-release` does not happen by accident.

## Proof of Work

<img width="498" height="687" alt="Screenshot 2025-09-25 at 09 33 06" src="https://github.com/user-attachments/assets/9888e142-65b4-48e3-9e2c-45f77fe90eba" />

## Checklist
- [X] Have you linked a jira ticket and/or is the ticket in the title?
- [X] Have you checked whether your jira ticket required DOCSP changes?
- [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?


