### PR TITLE
CLOUDP-335401: Fix bundle update from latest release

### DIFF
--- a/.github/actions/gen-install-scripts/entrypoint.sh
+++ b/.github/actions/gen-install-scripts/entrypoint.sh
@@ -16,6 +16,10 @@
 
 set -xeou pipefail
 
+# copy the initial bundle dir state from teh latest released bundle
+latest_release_dir=$(find releases -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | sort -Vr | head -n 1)
+cp -rf "releases/${latest_release_dir}/bundle" .
+
 target_dir="deploy"
 clusterwide_dir="${target_dir}/clusterwide"
 namespaced_dir="${target_dir}/namespaced"


### PR DESCRIPTION
# Summary

The release needs to take the latest released bundle as a reference to compute the next release bundle.

## Proof of Work

Tested locally:

```shell
$ ./.github/actions/gen-install-scripts/entrypoint.sh
...
$ tail bundle/manifests/mongodb-atlas-kubernetes.clusterserviceversion.yaml
    - name: MongoDB Atlas Kubernetes
      url: https://github.com/mongodb/mongodb-atlas-kubernetes
  maintainers:
    - email: support@mongodb.com
      name: MongoDB, Inc
  maturity: beta
  provider:
    name: MongoDB, Inc
  version: 2.11.0
  replaces: mongodb-atlas-kubernetes.v2.10.0
```

## Checklist
- [X] Have you linked a jira ticket and/or is the ticket in the title?
- [X] Have you checked whether your jira ticket required DOCSP changes?
- [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?

## Reminder (Please remove this when merging)
- Please try to Approve or Reject Changes the PR, keep PRs in review as short as possible
- Remember the following Communication Standards - use comment prefixes for clarity:
  * **blocking**: Must be addressed before approval.
  * **follow-up**: Can be addressed in a later PR or ticket.
  * **q**: Clarifying question.
  * **nit**: Non-blocking suggestions.
  * **note**: Side-note, non-actionable. Example: Praise 
  * --> no prefix is considered a question

