### PR TITLE
CLOUDP-335401: Fixing release docs and scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,8 +33,6 @@ endif
 # This happens if you use exported YAMLs from CLI and the dirty version is deemed a pre-release
 NEXT_VERSION = 99.99.99-next
 
-MAJOR_VERSION = $(shell cat major-version)
-
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "preview,fast,stable")
 # To re-generate a bundle for other specific channels without changing the standard setup, you can:
@@ -150,6 +148,8 @@ HELM_AKO_INSTALL_NAME = local-ako-install
 HELM_AKO_NAMESPACE = $(OPERATOR_NAMESPACE)
 
 GH_RUN_ID=$(shell gh run list -w Test -b main -e schedule -s success --json databaseId | jq '.[0] | .databaseId')
+
+SBOMS_DIR ?= temp
 
 .DEFAULT_GOAL := help
 .PHONY: help
@@ -632,7 +632,7 @@ augment-sbom: ## augment the latest SBOM for a given architecture on a given dir
 
 .PHONY: store-augmented-sboms
 store-augmented-sboms: ## Augment & Store the latest SBOM for a given version & architecture
-	KONDUKTO_BRANCH_PREFIX=$(KONDUKTO_BRANCH_PREFIX) ./scripts/store-sbom-in-s3.sh $(VERSION) $(TARGET_ARCH)
+	KONDUKTO_BRANCH_PREFIX=$(KONDUKTO_BRANCH_PREFIX) ./scripts/store-sbom-in-s3.sh $(VERSION) $(TARGET_ARCH) $(SBOMS_DIR)
 
 .PHONY: install-ako-helm
 install-ako-helm:

--- a/scripts/store-sbom-in-s3.sh
+++ b/scripts/store-sbom-in-s3.sh
@@ -41,12 +41,14 @@ version=$1
 [ -z "${version}" ] && echo "Missing version parameter #1" && exit 1
 arch=$2
 [ -z "${arch}" ] && echo "Missing arch parameter #2" && exit 1
+dir=$3
+[ -z "${dir}" ] && echo "Missing dir parameter #3" && exit 1
 
 # Environment inputs
 kondukto_branch_prefix="${KONDUKTO_BRANCH_PREFIX:?KONDUKTO_BRANCH_PREFIX must be set}"
 
 # Computed values
-sbom_lite_json="docs/releases/v${version}/linux_${arch}.sbom.json"
+sbom_lite_json="${dir}/linux_${arch}.sbom.json"
 sbom_json="tmp/linux-${arch}.sbom.json"
 lite_name=$(jq -r < "${sbom_lite_json}" '.metadata.component.name')
 name=$(jq -r < "${sbom_json}" '.metadata.component.name')


### PR DESCRIPTION
# Summary

Fix the release docs with the learnings from the AKO 2.11.0 issues.

## Proof of Work

Most code changes were already tested to make the release happen as per the updated instructions.

## Checklist
- [X] Have you linked a jira ticket and/or is the ticket in the title?
- [X] Have you checked whether your jira ticket required DOCSP changes?
- [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?

