### PR TITLE
CLOUDP-335406: Update test coverage to support Kubernetes 1.32 to 1.34

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -22,9 +22,9 @@ jobs:
       - name: Compute K8s matrix/versions for testing
         id: compute
         run: |
-          matrix='["v1.31.9-kind"]'
+          matrix='["v1.32.9-kind"]'
           if [ "${{ github.ref }}" == "refs/heads/main" ]; then
-            matrix='["v1.31.9-kind", "v1.33.2-kind"]'
+            matrix='["v1.32.9-kind", "v1.34.1-kind"]'
           fi
           echo "matrix=${matrix}" >> "${GITHUB_OUTPUT}"
       - name: Read the next release version


### PR DESCRIPTION
# Summary

See changelog for 1.34:
https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.34.md#changelog-since-v1330

## Proof of Work

CI should still work.

## Checklist
- [X] Have you linked a jira ticket and/or is the ticket in the title?
- [X] Have you checked whether your jira ticket required DOCSP changes?
- [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?

