### PR TITLE
CLOUDP-335401: Ensure to commit the bumped version.json

### DIFF
--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -270,10 +270,6 @@ jobs:
         run: |
           devbox run -- 'make build-licenses.csv'
 
-      - name: Bump version.json
-        run: |
-          devbox run -- 'make bump-version-file'
-
       # Create PR on release branch with all updates generated
       - name: Create release pr with all updated artefacts
         env:
@@ -294,15 +290,17 @@ jobs:
           cp bundle.Dockerfile "$RELEASE_DIR/bundle.Dockerfile"
           cp licenses.csv "$RELEASE_DIR/"
 
-
           git fetch origin
           git checkout -f -b "$BRANCH" origin/main
           git push -f origin "$BRANCH"
 
+          # bump version.json
+          devbox run -- 'make bump-version-file'
+
           # Update Helm Charts on main
           cp -r "$RELEASE_DIR/helm-charts" .
 
-          git add -f "$RELEASE_DIR" helm-charts
+          git add -f "$RELEASE_DIR" helm-charts version.json
           scripts/create-signed-commit.sh
 
           gh pr create \


### PR DESCRIPTION
# Summary

The version bump must be merged in the post release PR in order to take effect.

## Proof of Work

A dry run release on this change would update the version.json in the draft PR.

## Checklist
- [X] Have you linked a jira ticket and/or is the ticket in the title?
- [X] Have you checked whether your jira ticket required DOCSP changes?
- [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
