### PR TITLE
CLOUDP-347684: Document issue with changing workflows on release

### DIFF
--- a/docs/dev/release.md
+++ b/docs/dev/release.md
@@ -10,6 +10,10 @@ This is not required for [Certified Operators](https://github.com/redhat-openshi
 
 Finally, make sure you have a "RedHat Connect" account and are a [team member with org administrator role in the team list](https://connect.redhat.com/account/team-members).
 
+> [!CAUTION]
+> Ensure that the commit you are releasing (the most recent change included in the image) did not contain changes to 
+> GitHub workflows. This causes the release workflows to error.
+
 ### Tools
 
 Most tools are automatically installed for you. Most of them are Go binaries and use `go install`. There are a few that might cause issues and you might want to pre-install manually:


### PR DESCRIPTION
# Summary

Attempting to release on a commit that made changes to GitHub Actions workflows causes issues (which block the release, as happened for 2.11). We need to warn against this in the release docs. You can avoid the issue by releasing on a later commit (or any other commit that does not change GHAs).

## Proof of Work

<!-- Enter your proof that it works here.-->

## Checklist
- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you checked for release_note changes?
- [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?

## Reminder (Please remove this when merging)
- Please try to Approve or Reject Changes the PR, keep PRs in review as short as possible
- Remember the following Communication Standards - use comment prefixes for clarity:
  * **blocking**: Must be addressed before approval.
  * **follow-up**: Can be addressed in a later PR or ticket.
  * **q**: Clarifying question.
  * **nit**: Non-blocking suggestions.
  * **note**: Side-note, non-actionable. Example: Praise 
  * --> no prefix is considered a question

