### PR TITLE
Hash translated names with deterministic outputs

### DIFF
--- a/internal/v3/translate/names.go
+++ b/internal/v3/translate/names.go
@@ -1,0 +1,37 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package translate
+
+import (
+	"fmt"
+	"hash/fnv"
+
+	"k8s.io/apimachinery/pkg/util/rand"
+)
+
+func HashNames(name string, args ...string) string {
+	hasher := fnv.New64a()
+	hasher.Write([]byte(name))
+	for _, arg := range args {
+		hasher.Write([]byte(arg))
+	}
+	rawHash := hasher.Sum64()
+
+	return rand.SafeEncodeString(fmt.Sprint(rawHash))
+}
+
+func PrefixedName(prefix string, name string, args ...string) string {
+	return fmt.Sprintf("%s-%s", prefix, HashNames(name, args...))
+}

--- a/internal/v3/translate/names_test.go
+++ b/internal/v3/translate/names_test.go
@@ -1,0 +1,58 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package translate_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/v3/translate"
+)
+
+func TestPrefixedName(t *testing.T) {
+	for _, tc := range []struct {
+		title  string
+		prefix string
+		name   string
+		args   []string
+		want   string
+	}{
+		{
+			title:  "just A",
+			prefix: "just",
+			name:   "A",
+			want:   "just-56b7d6667d8f6cc88c8d",
+		},
+		{
+			title:  "a very long name",
+			prefix: "a",
+			name:   "very logn name with several parts",
+			want:   "a-54fd46599bbf74b8db44",
+		},
+		{
+			title:  "names",
+			prefix: "several",
+			name:   "names",
+			args:   []string{"name0", "name1"},
+			want:   "several-75db99b58df57d54bd6",
+		},
+	} {
+		t.Run(tc.title, func(t *testing.T) {
+			got := translate.PrefixedName(tc.prefix, tc.name, tc.args...)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/internal/v3/translate/ref.go
+++ b/internal/v3/translate/ref.go
@@ -145,7 +145,7 @@ func (ref *namedRef) Name(prefix string, path []string) string {
 	if path[0] == "entry" {
 		path = path[1:]
 	}
-	return strings.ToLower(strings.Join(append([]string{prefix}, path...), "-"))
+	return PrefixedName(prefix, path[0], path[1:]...)
 }
 
 func (ref *namedRef) Collapse(deps DependencyRepo, path []string, obj map[string]any) error {

--- a/internal/v3/translate/translator_test.go
+++ b/internal/v3/translate/translator_test.go
@@ -284,7 +284,7 @@ func TestFromAPI(t *testing.T) {
 										{
 											DatadogApiKeySecretRef: &v1.ApiTokenSecretRef{
 												Key:  pointer.MakePtr("datadogApiKey"),
-												Name: pointer.MakePtr("groupalertscfg-notifications-datadogapikey"),
+												Name: pointer.MakePtr("groupalertscfg-5b8c46f7fd54484b88b4"),
 											},
 											DatadogRegion: pointer.MakePtr("US"),
 											DelayMin:      pointer.MakePtr(42),
@@ -315,7 +315,7 @@ func TestFromAPI(t *testing.T) {
 					},
 					&corev1.Secret{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      "groupalertscfg-notifications-datadogapikey",
+							Name:      "groupalertscfg-5b8c46f7fd54484b88b4",
 							Namespace: "ns",
 						},
 						Data: map[string][]byte{
@@ -366,7 +366,7 @@ func TestFromAPI(t *testing.T) {
 								Entry: &v1.ThirdPartyIntegrationSpecV20250312Entry{
 									Type: pointer.MakePtr("SLACK"),
 									ApiTokenSecretRef: &v1.ApiTokenSecretRef{
-										Name: pointer.MakePtr("3rdparty-slack-apitoken"),
+										Name: pointer.MakePtr("3rdparty-slack-5f444b9b4cc55b5b8cb"),
 										Key:  pointer.MakePtr("apiToken"),
 									},
 									ChannelName: pointer.MakePtr("alert-channel"),
@@ -387,7 +387,7 @@ func TestFromAPI(t *testing.T) {
 					},
 					&corev1.Secret{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      "3rdparty-slack-apitoken",
+							Name:      "3rdparty-slack-5f444b9b4cc55b5b8cb",
 							Namespace: "ns",
 						},
 						Data: map[string][]byte{


### PR DESCRIPTION
# Summary

Deterministic outputs are easily testable and follow a similar pattern as already used in generating some Kubernetes names.

## Proof of Work

CI works.

## Checklist
- [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
