### PR TITLE
Restrict further what changes auto-trigger cloud tests

### DIFF
--- a/.github/workflows/cloud-tests-filter.yml
+++ b/.github/workflows/cloud-tests-filter.yml
@@ -26,7 +26,7 @@ jobs:
             # production code also includes changes to e2e and int tests,
             # note any other paths are covered by unit testing which run always
             # internal/v3 code for feature generation should not trigger old cloud tests
-            # .github changes should nto trigger cloud tests by default
+            # .github changes should not trigger cloud tests by default
             filters: |
               production-code-changed:
                 - 'cmd/**/!(*_test.go)'


### PR DESCRIPTION
# Summary

Being more specific should avoid cloud tests run when changing workflows or new autogeneration related code, which is not yet connected in production.

Reminders:

1. You can always force to run **cloud-tests** by using labels.
2. Auto-running **cloud-tests** should be removed soon in favor of being explicit with selectable tests in every PR.

## Proof of Work

Need to wait for merging in main to ensure the filtering works as expected.

✅ [workflow change did not trigger cloud tests](https://github.com/mongodb/mongodb-atlas-kubernetes/actions/runs/18348031444/job/52259938940)
✅ [internal/v3 dummy change and workflow change did NOT trigger cloud tests](https://github.com/mongodb/mongodb-atlas-kubernetes/actions/runs/18348160718/job/52260386119)

## Checklist
- [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?

