### PR TITLE
CLOUDP-349340: use make target for unit testing including dependencies

### DIFF
--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -19,7 +19,7 @@ jobs:
           enable-cache: 'true'
 
       - name: Run testing
-        run: devbox run -- 'go test -race -v ./... -coverprofile=coverage.out'
+        run: devbox run -- 'GO_TEST_FLAGS="-coverprofile=coverage.out" make unit-test'
 
       - name: Test tools
         run: devbox run -- 'make test-tools'

--- a/Makefile
+++ b/Makefile
@@ -193,8 +193,8 @@ check-licenses:  ## Check licenses are compliant with our restrictions
 	@echo "Licenses check: PASS"
 
 .PHONY: unit-test
-unit-test:
-	go test -race -cover $(GO_UNIT_TEST_FOLDERS)
+unit-test: manifests
+	go test -race -cover $(GO_UNIT_TEST_FOLDERS) $(GO_TEST_FLAGS)
 
 ## Run integration tests. Sample with labels: `make test/int GINKGO_FILTER_LABEL=AtlasProject`
 test/int: envtest


### PR DESCRIPTION
# Summary

This moves a direct `go test ...` call from github actions into make so we can consolidate logic.

## Proof of Work

green CI

## Checklist
- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you checked for release_note changes?
- [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?

## Reminder (Please remove this when merging)
- Please try to Approve or Reject Changes the PR, keep PRs in review as short as possible
- Remember the following Communication Standards - use comment prefixes for clarity:
  * **blocking**: Must be addressed before approval.
  * **follow-up**: Can be addressed in a later PR or ticket.
  * **q**: Clarifying question.
  * **nit**: Non-blocking suggestions.
  * **note**: Side-note, non-actionable. Example: Praise 
  * --> no prefix is considered a question

