### PR TITLE
Remove goimports from golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -95,11 +95,6 @@ issues:
 formatters:
   enable:
     - gofmt
-    - goimports
-  settings:
-    goimports:
-      local-prefixes:
-        - github.com/mongodb/mongodb-atlas-kubernetes/v2
   exclusions:
     generated: lax
     paths:


### PR DESCRIPTION
# Summary

Remove the goimports linter from our golangci-lint config.
This takes the runtime of our `make lint` from ~4m20s to ~1m

## Proof of Work

<!-- Enter your proof that it works here.-->

## Checklist
- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you checked for release_note changes?
- [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?

## Reminder (Please remove this when merging)
- Please try to Approve or Reject Changes the PR, keep PRs in review as short as possible
- Remember the following Communication Standards - use comment prefixes for clarity:
  * **blocking**: Must be addressed before approval.
  * **follow-up**: Can be addressed in a later PR or ticket.
  * **q**: Clarifying question.
  * **nit**: Non-blocking suggestions.
  * **note**: Side-note, non-actionable. Example: Praise 
  * --> no prefix is considered a question

