### PR TITLE
CLOUDP-349340: use manifests-template rather than previous release as bundle template

### DIFF
--- a/.github/actions/gen-install-scripts/entrypoint.sh
+++ b/.github/actions/gen-install-scripts/entrypoint.sh
@@ -17,7 +17,6 @@
 set -xeou pipefail
 
 # copy the initial bundle dir state from teh latest released bundle
-latest_release_dir=$(find releases -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | sort -Vr | head -n 1)
 mkdir -p bundle/manifests
 cp config/manifests-template/bases/mongodb-atlas-kubernetes.clusterserviceversion.yaml bundle/manifests
 


### PR DESCRIPTION
# Summary

https://github.com/mongodb/mongodb-atlas-kubernetes/pull/2733 did a quick-fix using the previous release bundle as the template. This fixes it by using the template locally checked in. Previously the locally checked in bundle template was ignored.

## Proof of Work

Green CI

## Checklist
- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you checked for release_note changes?
- [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?

## Reminder (Please remove this when merging)
- Please try to Approve or Reject Changes the PR, keep PRs in review as short as possible
- Remember the following Communication Standards - use comment prefixes for clarity:
  * **blocking**: Must be addressed before approval.
  * **follow-up**: Can be addressed in a later PR or ticket.
  * **q**: Clarifying question.
  * **nit**: Non-blocking suggestions.
  * **note**: Side-note, non-actionable. Example: Praise 
  * --> no prefix is considered a question

