### PR TITLE
CLOUDP-350407: Simplify API & add CRD validation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/nsf/jsondiff v0.0.0-20230430225905-43f6cf3098c1
 	github.com/onsi/ginkgo/v2 v2.26.0
 	github.com/onsi/gomega v1.38.2
+	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/sethvargo/go-password v0.3.1
 	github.com/stretchr/testify v1.11.1
 	github.com/yudai/gojsondiff v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -261,6 +261,8 @@ github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoG
 github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=
 github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWNMNyH2VO9fmH0o=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 h1:lZUw3E0/J3roVtGQ+SCrUrg3ON6NgVqpn3+iol9aGu4=
+github.com/santhosh-tekuri/jsonschema/v5 v5.3.1/go.mod h1:uToXkOrWAZ6/Oc07xWQrPOhJotwFIyu2bBVN41fcDUY=
 github.com/sergi/go-diff v1.4.0 h1:n/SP9D5ad1fORl+llWyN+D6qoUETXNZARKjyY2/KVCw=
 github.com/sergi/go-diff v1.4.0/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
 github.com/sethvargo/go-password v0.3.1 h1:WqrLTjo7X6AcVYfC6R7GtSyuUQR9hGyAj/f1PYQZCJU=

--- a/internal/autogen/translate/crd.go
+++ b/internal/autogen/translate/crd.go
@@ -21,11 +21,6 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 )
 
-type CRDInfo struct {
-	definition *apiextensionsv1.CustomResourceDefinition
-	version    string
-}
-
 // selectVersion returns the version from the CRD spec that matches the given version string
 func selectVersion(spec *apiextensionsv1.CustomResourceDefinitionSpec, version string) *apiextensionsv1.CustomResourceDefinitionVersion {
 	if len(spec.Versions) == 0 {

--- a/internal/autogen/translate/unstructured/unstructured.go
+++ b/internal/autogen/translate/unstructured/unstructured.go
@@ -98,6 +98,23 @@ func CreateField[T any](obj map[string]any, value T, fields ...string) error {
 	return nil
 }
 
+// AccessOrCreateField access a field at the given path, it creates the
+// field with the given defaultValue if it did not exist
+func AccessOrCreateField[T any](obj map[string]any, defaultValue T, fields ...string) (T, error) {
+	value, err := AccessField[T](obj, fields...)
+	if err == nil {
+		return value, nil
+	}
+	var emptyValue T
+	if errors.Is(err, ErrNotFound) {
+		if err := CreateField(obj, defaultValue, fields...); err != nil {
+			return emptyValue, fmt.Errorf("failed to create field at path %v: %w", fields, err)
+		}
+		return defaultValue, nil
+	}
+	return emptyValue, fmt.Errorf("failed to check for field at path %v: %w", fields, err)
+}
+
 // AsPath translates the given simplified xpath expression into a sequence of
 // path entries
 func AsPath(xpath string) []string {


### PR DESCRIPTION
# Summary

- Use a Translation request to group non input/output parameters to a translation.
- Move some translation parsing to the Translator constructor to avoid running that on very translation.
- Add schema validation on CR value inputs for ToAPI and CR value outputs FromAPI.

## Proof of Work

CI unit tests still pass after the changes and a few fixes.

## Checklist
- [X] Have you linked a jira ticket and/or is the ticket in the title?
- [X] Have you checked whether your jira ticket required DOCSP changes?
- [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?

