### PR TITLE
Ensure e2e local script installs CRDs properly

### DIFF
--- a/scripts/e2e_local.sh
+++ b/scripts/e2e_local.sh
@@ -48,7 +48,7 @@ if [[ "${build}" == "true" ]]; then
     docker push "${bundle_image}"
 fi
 
-kubectl apply -f deploy/crds
+kustomize build --load-restrictor LoadRestrictionsNone deploy/crds | kubectl apply -f -
 
 export MCLI_OPS_MANAGER_URL="${MCLI_OPS_MANAGER_URL:-https://cloud-qa.mongodb.com/}"
 export MCLI_PUBLIC_API_KEY="${MCLI_PUBLIC_API_KEY:-$public_key}"


### PR DESCRIPTION
# Summary

Files in `deploy/crds` are not final CRD YAML files that Kubernetes can consume, instead they are templates taht need to be expanded by **kustomize** before they become CRDs.

This is a left over fix from the recent cleanup of intermediate files in the repo. And also not seem before as the CI e2e test code path and the local one differ.

## Proof of Work

✅ `time make e2e label=flex`

## Checklist
- [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
