### PR TITLE
Do not copy kustomization.yaml file to deploy/crds

### DIFF
--- a/.github/actions/gen-install-scripts/entrypoint.sh
+++ b/.github/actions/gen-install-scripts/entrypoint.sh
@@ -63,7 +63,7 @@ kustomize build "config/crd" >"${namespaced_dir}/crds.yaml"
 echo "Created namespaced config"
 
 # crds
-cp config/crd/bases/* "${crds_dir}"
+find config/crd/bases -type f ! -name 'kustomization.yaml' -exec cp {} "${crds_dir}" \;
 
 # CSV bundle
 operator-sdk generate kustomize manifests --input-dir=config/manifests-template --interactive=false -q --apis-dir=api


### PR DESCRIPTION
# Summary

Currently we copy `kustomization.yaml` in the `deploy` directory, however the latter is not supposed to be kustomization source code but a final artifact so we have to omit the file.

## Proof of Work

Green CI

## Checklist
- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you checked for release_note changes?
- [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?

## Reminder (Please remove this when merging)
- Please try to Approve or Reject Changes the PR, keep PRs in review as short as possible
- Remember the following Communication Standards - use comment prefixes for clarity:
  * **blocking**: Must be addressed before approval.
  * **follow-up**: Can be addressed in a later PR or ticket.
  * **q**: Clarifying question.
  * **nit**: Non-blocking suggestions.
  * **note**: Side-note, non-actionable. Example: Praise 
  * --> no prefix is considered a question

