### PR TITLE
Make bundle before e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -207,7 +207,7 @@ envtest-assets:
 	mkdir -p $(ENVTEST_ASSETS_DIR)
 
 .PHONY: e2e
-e2e: run-kind ## Run e2e test. Command `make e2e label=cluster-ns` run cluster-ns test
+e2e: bundle run-kind ## Run e2e test. Command `make e2e label=cluster-ns` run cluster-ns test
 	./scripts/e2e_local.sh $(label) $(build)
 
 .PHONY: e2e2


### PR DESCRIPTION
# Summary

Ensure to make the `bundle` before trying to run e2e tests. This is now required as CRDs are computed on the file.

## Proof of Work

✅ `time make e2e label=flex` after `make clean`

## Checklist
- [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?

