### PR TITLE
CLOUDP-354451: Fix leftover IP Reservations

### DIFF
--- a/tools/clean/atlas/atlas.go
+++ b/tools/clean/atlas/atlas.go
@@ -121,6 +121,7 @@ func (c *Cleaner) cleanOrphanResources(ctx context.Context, lifetimeHours int) {
 		"europe-west3",
 		"europe-north1",
 		"europe-west6",
+		"europe-west1",
 		"asia-east2",
 		"asia-northeast2",
 		"australia-southeast2",


### PR DESCRIPTION
# Summary

Turns out we were just missing region **`europe-west1`** in orphan cleanups. That was getting full of leftover IPs and forwarding rules.

## Proof of Work

CI works, also local test run wiped out all resources we had found left over in the Google console.

## Checklist
- [X] Have you linked a jira ticket and/or is the ticket in the title?
- [X] Have you checked whether your jira ticket required DOCSP changes?
- [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?

