### PR TITLE
CLOUDP-355439: Backport signatures fix to tag 2.11.1 (#2847)

### DIFF
--- a/flakes/go/flake.nix
+++ b/flakes/go/flake.nix
@@ -8,7 +8,7 @@
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = import nixpkgs { inherit system; };
-        version = "1.24.7";
+        version = "1.24.9";
       in
       {
         packages.default = pkgs.go_1_24.overrideAttrs (old: {
@@ -16,7 +16,7 @@
           inherit version;
           src = pkgs.fetchurl {
             url = "https://golang.org/dl/go${version}.linux-amd64.tar.gz";
-            sha256 = "sha256-2hgZHdt9uKkzmBbz4rVL3e2AR83CpdZwWUePjRWVxD8=";
+            sha256 = "sha256-W3iZWRwt1unaGAn95KL62ELEXT9rnesjW6giFuMeNKY=";
           };
         });
       });

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/mongodb/mongodb-atlas-kubernetes/v2
 
-go 1.24.0
-
-toolchain go1.24.7
+go 1.24.9
 
 require (
 	cloud.google.com/go/kms v1.23.0

--- a/scripts/sign.sh
+++ b/scripts/sign.sh
@@ -45,4 +45,4 @@ docker run \
   -v "$(pwd):$(pwd)" \
   -w "$(pwd)" \
   artifactory.corp.mongodb.com/release-tools-container-registry-local/garasign-cosign \
-  cosign sign --key "${PKCS11_URI}" --tlog-upload=false "${img}"
+  cosign sign --key "${PKCS11_URI}" --tlog-upload=false --use-signing-config=false --new-bundle-format=false "${img}"


### PR DESCRIPTION
# Summary

**Backport** to tag v2.11.0 the fix for properly signing daily builds.

This is required because the dailies use their own tag to rebuild. Problem is, rebuilds are not reproducible, not only dependent libraries might change, which is expected and hence the reason to rebuild, but also tools are not all pinned. The cosing tool bundled with garasign for singing as MongoDB project got updated and broke the signatures this week:
https://github.com/sigstore/cosign/issues/4503

Had to also bump Go and its flake to avoid test issues.

## Proof of Work

Once the tag is updated with this fix the daily build should now work.

## Checklist
- [X] Have you linked a jira ticket and/or is the ticket in the title?
- [X] Have you checked whether your jira ticket required DOCSP changes?
- [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?

