### PR TITLE
openapi2crd: fix KinOpeAPI typo to KinOpenAPI

### DIFF
--- a/tools/openapi2crd/cmd/run.go
+++ b/tools/openapi2crd/cmd/run.go
@@ -148,7 +148,7 @@ func runOpenapi2crd(ctx context.Context, fs afero.Fs, runnerConfig *RunnerConfig
 		return fmt.Errorf("error creating plugin set: %w", err)
 	}
 
-	openapiLoader := config.NewKinOpeAPI(fs)
+	openapiLoader := config.NewKinOpenAPI(fs)
 	atlasLoader := config.NewAtlas(openapiLoader)
 
 	// Collect the CRD configs to process, respecting the kind filter.

--- a/tools/openapi2crd/pkg/config/openapi.go
+++ b/tools/openapi2crd/pkg/config/openapi.go
@@ -32,21 +32,21 @@ type Loader interface {
 	Load(ctx context.Context, path string) (*openapi3.T, error)
 }
 
-type KinOpeAPI struct {
+type KinOpenAPI struct {
 	fs    afero.Fs
 	mu    sync.Mutex
 	cache map[string]*openapi3.T
 	group singleflight.Group
 }
 
-func NewKinOpeAPI(fs afero.Fs) *KinOpeAPI {
-	return &KinOpeAPI{
+func NewKinOpenAPI(fs afero.Fs) *KinOpenAPI {
+	return &KinOpenAPI{
 		fs:    fs,
 		cache: make(map[string]*openapi3.T),
 	}
 }
 
-func (a *KinOpeAPI) Load(_ context.Context, path string) (*openapi3.T, error) {
+func (a *KinOpenAPI) Load(_ context.Context, path string) (*openapi3.T, error) {
 	// Fast path: return the cached spec without entering singleflight.
 	// The mutex-guarded cache avoids the overhead of singleflight.Do on
 	// every call after the spec has already been parsed.
@@ -97,7 +97,7 @@ func (a *KinOpeAPI) Load(_ context.Context, path string) (*openapi3.T, error) {
 	return v.(*openapi3.T), nil //nolint:forcetypeassert // singleflight returns interface{}; type is guaranteed by the closure above.
 }
 
-func (a *KinOpeAPI) transform(path string) ([]byte, error) {
+func (a *KinOpenAPI) transform(path string) ([]byte, error) {
 	filePath := filepath.Clean(path)
 
 	data, err := afero.ReadFile(a.fs, filePath)

--- a/tools/openapi2crd/pkg/config/openapi_test.go
+++ b/tools/openapi2crd/pkg/config/openapi_test.go
@@ -37,11 +37,11 @@ func writeSpec(t *testing.T, fs afero.Fs, path string) {
 	require.NoError(t, afero.WriteFile(fs, path, []byte(testOpenAPISpec), 0644))
 }
 
-func TestKinOpeAPILoadCachesResult(t *testing.T) {
+func TestKinOpenAPILoadCachesResult(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	writeSpec(t, fs, "spec.yaml")
 
-	loader := NewKinOpeAPI(fs)
+	loader := NewKinOpenAPI(fs)
 
 	first, err := loader.Load(context.Background(), "spec.yaml")
 	require.NoError(t, err)
@@ -53,11 +53,11 @@ func TestKinOpeAPILoadCachesResult(t *testing.T) {
 	assert.Same(t, first, second)
 }
 
-func TestKinOpeAPILoadConcurrent(t *testing.T) {
+func TestKinOpenAPILoadConcurrent(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	writeSpec(t, fs, "spec.yaml")
 
-	loader := NewKinOpeAPI(fs)
+	loader := NewKinOpenAPI(fs)
 
 	const goroutines = 20
 	var wg sync.WaitGroup
@@ -80,7 +80,7 @@ func TestKinOpeAPILoadConcurrent(t *testing.T) {
 	}
 }
 
-func TestKinOpeAPILoad(t *testing.T) {
+func TestKinOpenAPILoad(t *testing.T) {
 	tests := map[string]struct {
 		file            string
 		filePath        string
@@ -129,7 +129,7 @@ paths:
 
 			tt.expectedOpenAPI.Paths.Extensions = map[string]any{}
 
-			loader := NewKinOpeAPI(fs)
+			loader := NewKinOpenAPI(fs)
 			openapi, err := loader.Load(context.Background(), tt.filePath)
 			assert.Equal(t, tt.expectError, err)
 			assert.Equal(t, tt.expectedOpenAPI, openapi)


### PR DESCRIPTION
# Summary

Fixes a typo in the `openapi2crd` tool: renames `KinOpeAPI` to `KinOpenAPI` across the struct, constructor, methods, and tests.

## Proof of Work

- `make unit-test` passes
- Pure rename refactor, no behavior change

## Checklist
- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you checked for release_note changes?
- [x] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?