### PR TITLE
openapi2crd: integrate OpenAPI spec flattening

### DIFF
--- a/tools/openapi2crd/pkg/apis/config/v1alpha1/config.go
+++ b/tools/openapi2crd/pkg/apis/config/v1alpha1/config.go
@@ -42,6 +42,7 @@ type OpenAPIDefinition struct {
 	Name    string `json:"name"`
 	Path    string `json:"path"`
 	Package string `json:"package"`
+	Flatten bool   `json:"flatten,omitempty"`
 }
 
 type CRDConfig struct {

--- a/tools/openapi2crd/pkg/config/atlas.go
+++ b/tools/openapi2crd/pkg/config/atlas.go
@@ -36,6 +36,26 @@ type Atlas struct {
 }
 
 func (a *Atlas) Load(ctx context.Context, pkg string) (*openapi3.T, error) {
+	filename, err := a.resolvePackagePath(ctx, pkg)
+	if err != nil {
+		return nil, err
+	}
+
+	return a.fileLoader.Load(ctx, filename)
+}
+
+// LoadFlattened resolves the Go module package to a file path, then delegates
+// to the underlying file loader's LoadFlattened method.
+func (a *Atlas) LoadFlattened(ctx context.Context, pkg string) (*openapi3.T, error) {
+	filename, err := a.resolvePackagePath(ctx, pkg)
+	if err != nil {
+		return nil, err
+	}
+
+	return a.fileLoader.LoadFlattened(ctx, filename)
+}
+
+func (a *Atlas) resolvePackagePath(ctx context.Context, pkg string) (string, error) {
 	// Fast path: return the cached resolved path without entering singleflight.
 	// The mutex-guarded cache avoids the overhead of singleflight.Do and
 	// repeated `go list` calls after the path has already been resolved.
@@ -43,33 +63,30 @@ func (a *Atlas) Load(ctx context.Context, pkg string) (*openapi3.T, error) {
 	cachedPath, ok := a.pathCache[pkg]
 	a.mu.Unlock()
 
-	var filename string
 	if ok {
-		filename = cachedPath
-	} else {
-		// Slow path: singleflight deduplicates concurrent `go list` calls for the same package.
-		// Returns interface{} because singleflight has no generic API.
-		v, err, _ := a.group.Do(pkg, func() (interface{}, error) {
-			path, err := getGoModulePath(ctx, pkg)
-			if err != nil {
-				return nil, fmt.Errorf("failed to load module path: %w", err)
-			}
-
-			resolved := filepath.Clean(filepath.Join(path, "..", "openapi", "atlas-api-transformed.yaml"))
-
-			a.mu.Lock()
-			a.pathCache[pkg] = resolved
-			a.mu.Unlock()
-
-			return resolved, nil
-		})
-		if err != nil {
-			return nil, err
-		}
-		filename = v.(string) //nolint:forcetypeassert // singleflight returns interface{}; type is guaranteed by the closure above.
+		return cachedPath, nil
 	}
 
-	return a.fileLoader.Load(ctx, filename)
+	// Slow path: singleflight deduplicates concurrent `go list` calls for the same package.
+	// Returns interface{} because singleflight has no generic API.
+	v, err, _ := a.group.Do(pkg, func() (interface{}, error) {
+		path, err := getGoModulePath(ctx, pkg)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load module path: %w", err)
+		}
+
+		resolved := filepath.Clean(filepath.Join(path, "..", "openapi", "atlas-api-transformed.yaml"))
+
+		a.mu.Lock()
+		a.pathCache[pkg] = resolved
+		a.mu.Unlock()
+
+		return resolved, nil
+	})
+	if err != nil {
+		return "", err
+	}
+	return v.(string), nil //nolint:forcetypeassert // singleflight returns interface{}; type is guaranteed by the closure above.
 }
 
 func NewAtlas(loader Loader) *Atlas {

--- a/tools/openapi2crd/pkg/config/openapi.go
+++ b/tools/openapi2crd/pkg/config/openapi.go
@@ -26,10 +26,13 @@ import (
 	"github.com/goccy/go-yaml"
 	"github.com/spf13/afero"
 	"golang.org/x/sync/singleflight"
+
+	"github.com/mongodb/mongodb-atlas-kubernetes/tools/openapi2crd/pkg/flatten"
 )
 
 type Loader interface {
 	Load(ctx context.Context, path string) (*openapi3.T, error)
+	LoadFlattened(ctx context.Context, path string) (*openapi3.T, error)
 }
 
 type KinOpenAPI struct {
@@ -95,6 +98,51 @@ func (a *KinOpenAPI) Load(_ context.Context, path string) (*openapi3.T, error) {
 	}
 
 	return v.(*openapi3.T), nil //nolint:forcetypeassert // singleflight returns interface{}; type is guaranteed by the closure above.
+}
+
+// LoadFlattened reads an OpenAPI spec from path, applies the same transform
+// as Load (strip x-xgen-changelog), then flattens schema compositions
+// (oneOf/anyOf/allOf/discriminator) before parsing with kin-openapi.
+func (a *KinOpenAPI) LoadFlattened(_ context.Context, path string) (*openapi3.T, error) {
+	cacheKey := "flatten:" + path
+
+	a.mu.Lock()
+	if spec, ok := a.cache[cacheKey]; ok {
+		a.mu.Unlock()
+		return spec, nil
+	}
+	a.mu.Unlock()
+
+	v, err, _ := a.group.Do(cacheKey, func() (interface{}, error) {
+		data, err := a.transform(path)
+		if err != nil {
+			return nil, fmt.Errorf("failed to transform the file %s: %w", path, err)
+		}
+
+		data, err = flatten.Flatten(data)
+		if err != nil {
+			return nil, fmt.Errorf("failed to flatten the file %s: %w", path, err)
+		}
+
+		loader := &openapi3.Loader{
+			IsExternalRefsAllowed: true,
+		}
+		spec, err := loader.LoadFromData(data)
+		if err != nil {
+			return nil, err
+		}
+
+		a.mu.Lock()
+		a.cache[cacheKey] = spec
+		a.mu.Unlock()
+
+		return spec, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return v.(*openapi3.T), nil
 }
 
 func (a *KinOpenAPI) transform(path string) ([]byte, error) {

--- a/tools/openapi2crd/pkg/config/openapi_mock.go
+++ b/tools/openapi2crd/pkg/config/openapi_mock.go
@@ -105,3 +105,71 @@ func (_c *LoaderMock_Load_Call) RunAndReturn(run func(ctx context.Context, path 
 	_c.Call.Return(run)
 	return _c
 }
+
+// LoadFlattened provides a mock function for the type LoaderMock
+func (_mock *LoaderMock) LoadFlattened(ctx context.Context, path string) (*openapi3.T, error) {
+	ret := _mock.Called(ctx, path)
+
+	if len(ret) == 0 {
+		panic("no return value specified for LoadFlattened")
+	}
+
+	var r0 *openapi3.T
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (*openapi3.T, error)); ok {
+		return returnFunc(ctx, path)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) *openapi3.T); ok {
+		r0 = returnFunc(ctx, path)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*openapi3.T)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, path)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// LoaderMock_LoadFlattened_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'LoadFlattened'
+type LoaderMock_LoadFlattened_Call struct {
+	*mock.Call
+}
+
+// LoadFlattened is a helper method to define mock.On call
+//   - ctx context.Context
+//   - path string
+func (_e *LoaderMock_Expecter) LoadFlattened(ctx interface{}, path interface{}) *LoaderMock_LoadFlattened_Call {
+	return &LoaderMock_LoadFlattened_Call{Call: _e.mock.On("LoadFlattened", ctx, path)}
+}
+
+func (_c *LoaderMock_LoadFlattened_Call) Run(run func(ctx context.Context, path string)) *LoaderMock_LoadFlattened_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *LoaderMock_LoadFlattened_Call) Return(t *openapi3.T, err error) *LoaderMock_LoadFlattened_Call {
+	_c.Call.Return(t, err)
+	return _c
+}
+
+func (_c *LoaderMock_LoadFlattened_Call) RunAndReturn(run func(ctx context.Context, path string) (*openapi3.T, error)) *LoaderMock_LoadFlattened_Call {
+	_c.Call.Return(run)
+	return _c
+}

--- a/tools/openapi2crd/pkg/config/openapi_test.go
+++ b/tools/openapi2crd/pkg/config/openapi_test.go
@@ -80,6 +80,59 @@ func TestKinOpenAPILoadConcurrent(t *testing.T) {
 	}
 }
 
+func TestKinOpenAPILoadFlattened(t *testing.T) {
+	input := `openapi: 3.0.0
+info:
+  title: Test
+  version: 1.0.0
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+components:
+  schemas:
+    Pet:
+      type: object
+      oneOf:
+        - $ref: '#/components/schemas/Cat'
+        - $ref: '#/components/schemas/Dog'
+      properties:
+        name:
+          type: string
+    Cat:
+      type: object
+      properties:
+        indoor:
+          type: boolean
+    Dog:
+      type: object
+      properties:
+        breed:
+          type: string`
+
+	fs := afero.NewMemMapFs()
+	require.NoError(t, afero.WriteFile(fs, "test.yaml", []byte(input), 0644))
+
+	loader := NewKinOpenAPI(fs)
+	spec, err := loader.LoadFlattened(nil, "test.yaml")
+	require.NoError(t, err)
+	require.NotNil(t, spec)
+
+	petSchema := spec.Components.Schemas["Pet"]
+	require.NotNil(t, petSchema)
+
+	assert.Nil(t, petSchema.Value.OneOf, "oneOf should be flattened away")
+	assert.Contains(t, petSchema.Value.Properties, "name")
+	assert.Contains(t, petSchema.Value.Properties, "indoor")
+	assert.Contains(t, petSchema.Value.Properties, "breed")
+}
+
 func TestKinOpenAPILoad(t *testing.T) {
 	tests := map[string]struct {
 		file            string

--- a/tools/openapi2crd/pkg/flatten/allof.go
+++ b/tools/openapi2crd/pkg/flatten/allof.go
@@ -1,0 +1,151 @@
+package flatten
+
+import (
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+func applyAllOfTransformations(root *yaml.Node) {
+	walkMappings(root,
+		func(m *yaml.Node) bool { return mappingHas(m, "oneOf") },
+		func(path string, m *yaml.Node) {
+			if isTopLevelSchema(path) {
+				transformAllOf(m, lastPathComponent(path), root)
+			}
+		},
+	)
+}
+
+func transformAllOf(schema *yaml.Node, parentName string, root *yaml.Node) {
+	oneOf := asSequence(mappingGet(schema, "oneOf"))
+	if oneOf == nil {
+		return
+	}
+
+	// Snapshot of parent without oneOf/discriminator for injection into children.
+	expandedParent := copyExcluding(schema, "oneOf", "discriminator")
+
+	for _, item := range oneOf.Content {
+		refNode := asMapping(item)
+		if refNode == nil {
+			continue
+		}
+		ref := asString(mappingGet(refNode, "$ref"))
+		if ref == "" {
+			continue
+		}
+		_, child := resolveRef(root, ref)
+		if child == nil {
+			fmt.Fprintf(os.Stderr, "error: missing object reference %s for %s\n", ref, parentName)
+			continue
+		}
+		if removeParentFromAllOf(child, parentName) {
+			allOf := asSequence(mappingGet(child, "allOf"))
+			if allOf == nil {
+				allOf = newSequenceNode()
+				mappingSet(child, "allOf", allOf)
+			}
+			allOf.Content = append(allOf.Content, expandedParent)
+			flattenAllOf(child, root)
+		}
+	}
+
+	mappingDelete(schema, "properties")
+	mappingDelete(schema, "required")
+}
+
+// copyExcluding returns a deep copy of schema omitting the listed keys.
+func copyExcluding(schema *yaml.Node, exclude ...string) *yaml.Node {
+	excl := map[string]bool{}
+	for _, e := range exclude {
+		excl[e] = true
+	}
+	dst := newMappingNode()
+	for i := 0; i < len(schema.Content)-1; i += 2 {
+		key := schema.Content[i]
+		val := schema.Content[i+1]
+		if !excl[key.Value] {
+			dst.Content = append(dst.Content, deepCopy(key), deepCopy(val))
+		}
+	}
+	return dst
+}
+
+// removeParentFromAllOf removes allOf entries referencing parentName.
+// Returns true if anything was removed.
+func removeParentFromAllOf(child *yaml.Node, parentName string) bool {
+	allOf := asSequence(mappingGet(child, "allOf"))
+	if allOf == nil {
+		return false
+	}
+	before := len(allOf.Content)
+	var kept []*yaml.Node
+	for _, item := range allOf.Content {
+		m := asMapping(item)
+		if m != nil {
+			if ref := asString(mappingGet(m, "$ref")); schemaNameFromRef(ref) == parentName {
+				continue
+			}
+		}
+		kept = append(kept, item)
+	}
+	allOf.Content = kept
+	return len(allOf.Content) != before
+}
+
+// flattenAllOf merges all allOf entries into the object's properties/required.
+func flattenAllOf(obj *yaml.Node, root *yaml.Node) {
+	allOf := asSequence(mappingGet(obj, "allOf"))
+	if allOf == nil {
+		return
+	}
+
+	props := asMapping(mappingGet(obj, "properties"))
+	if props == nil {
+		props = newMappingNode()
+		mappingSet(obj, "properties", props)
+	}
+
+	reqSet := map[string]bool{}
+	var reqOrder []string
+	if existing := asSequence(mappingGet(obj, "required")); existing != nil {
+		for _, v := range existing.Content {
+			if s := asString(v); s != "" && !reqSet[s] {
+				reqSet[s] = true
+				reqOrder = append(reqOrder, s)
+			}
+		}
+	}
+
+	for _, item := range allOf.Content {
+		resolved := resolveOrInline(item, root)
+		if resolved == nil {
+			continue
+		}
+		if rProps := asMapping(mappingGet(resolved, "properties")); rProps != nil {
+			for i := 0; i < len(rProps.Content)-1; i += 2 {
+				mappingSet(props, rProps.Content[i].Value, deepCopy(rProps.Content[i+1]))
+			}
+		}
+		if rReq := asSequence(mappingGet(resolved, "required")); rReq != nil {
+			for _, v := range rReq.Content {
+				if s := asString(v); s != "" && !reqSet[s] {
+					reqSet[s] = true
+					reqOrder = append(reqOrder, s)
+				}
+			}
+		}
+	}
+
+	if len(reqOrder) > 0 {
+		reqNode := newSequenceNode()
+		for _, r := range reqOrder {
+			reqNode.Content = append(reqNode.Content, newStringNode(r))
+		}
+		mappingSet(obj, "required", reqNode)
+	}
+
+	mappingDelete(obj, "allOf")
+}

--- a/tools/openapi2crd/pkg/flatten/anyof.go
+++ b/tools/openapi2crd/pkg/flatten/anyof.go
@@ -1,0 +1,61 @@
+package flatten
+
+import (
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+func applyAnyOfTransformations(root *yaml.Node) {
+	walkMappings(root,
+		func(m *yaml.Node) bool { return mappingHas(m, "anyOf") },
+		func(path string, m *yaml.Node) {
+			if isTopLevelSchema(path) {
+				transformAnyOf(path, m, root)
+			}
+		},
+	)
+}
+
+func transformAnyOf(path string, schema *yaml.Node, root *yaml.Node) {
+	anyOf := asSequence(mappingGet(schema, "anyOf"))
+	if anyOf == nil {
+		return
+	}
+	children := resolveSequenceRefs(anyOf, root, "anyOf")
+
+	if allHaveEnum(children) {
+		mergeEnums(schema, children, "anyOf")
+	} else {
+		transformAnyOfProperties(path, schema, children)
+	}
+}
+
+func transformAnyOfProperties(path string, schema *yaml.Node, children []*yaml.Node) {
+	for _, child := range children {
+		props := asMapping(mappingGet(child, "properties"))
+		if props == nil {
+			props = syntheticPropsFromAllOf(child)
+			if props == nil {
+				typeStr := asString(mappingGet(child, "type"))
+				fmt.Fprintf(os.Stderr, "warning: %s: skipping non-object anyOf variant (type: %s)\n", path, typeStr)
+				continue
+			}
+			mappingSet(child, "properties", props)
+		}
+
+		childCopy := deepCopy(props)
+		parentProps := asMapping(mappingGet(schema, "properties"))
+		if parentProps == nil {
+			parentProps = newMappingNode()
+			mappingSet(schema, "properties", parentProps)
+		}
+		for i := 0; i < len(childCopy.Content)-1; i += 2 {
+			mappingSet(parentProps, childCopy.Content[i].Value, childCopy.Content[i+1])
+		}
+	}
+
+	mappingDelete(schema, "discriminator")
+	mappingDelete(schema, "anyOf")
+}

--- a/tools/openapi2crd/pkg/flatten/cleanup.go
+++ b/tools/openapi2crd/pkg/flatten/cleanup.go
@@ -1,0 +1,37 @@
+package flatten
+
+import (
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// removeUnusedSchemas removes schema definitions that are not referenced
+// anywhere in the document. Returns true if anything was removed.
+func removeUnusedSchemas(root *yaml.Node) bool {
+	refs := collectRefs(root)
+
+	used := map[string]bool{}
+	for ref := range refs {
+		if name, ok := strings.CutPrefix(ref, "#/components/schemas/"); ok {
+			used[name] = true
+		}
+	}
+
+	schemas := asMapping(getPath(root, "components", "schemas"))
+	if schemas == nil {
+		return false
+	}
+
+	before := len(schemas.Content)
+	var kept []*yaml.Node
+	for i := 0; i < len(schemas.Content)-1; i += 2 {
+		key := schemas.Content[i]
+		val := schemas.Content[i+1]
+		if used[key.Value] {
+			kept = append(kept, key, val)
+		}
+	}
+	schemas.Content = kept
+	return len(schemas.Content) != before
+}

--- a/tools/openapi2crd/pkg/flatten/discriminator.go
+++ b/tools/openapi2crd/pkg/flatten/discriminator.go
@@ -1,0 +1,67 @@
+package flatten
+
+import (
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+// applyDiscriminatorTransformations finds all top-level schemas with a
+// discriminator field (but no oneOf) and synthesises a oneOf from the
+// discriminator mapping.
+func applyDiscriminatorTransformations(root *yaml.Node) {
+	schemas := asMapping(getPath(root, "components", "schemas"))
+	if schemas == nil {
+		return
+	}
+	for i := 0; i < len(schemas.Content)-1; i += 2 {
+		name := schemas.Content[i].Value
+		schema := asMapping(schemas.Content[i+1])
+		if schema == nil {
+			continue
+		}
+		if mappingHas(schema, "discriminator") {
+			transformDiscriminatorToOneOf(name, schema)
+		}
+	}
+}
+
+func transformDiscriminatorToOneOf(name string, schema *yaml.Node) {
+	if mappingHas(schema, "oneOf") {
+		return // already has oneOf – nothing to do
+	}
+	disc := asMapping(mappingGet(schema, "discriminator"))
+	if disc == nil {
+		return
+	}
+	mapping := asMapping(mappingGet(disc, "mapping"))
+	if mapping == nil {
+		fmt.Fprintf(os.Stderr, "warning: skipping discriminator for %s: no mapping and no oneOf\n", name)
+		return
+	}
+
+	// Collect unique refs in order.
+	seen := map[string]bool{}
+	var refs []string
+	for i := 0; i < len(mapping.Content)-1; i += 2 {
+		ref := asString(mapping.Content[i+1])
+		if !seen[ref] {
+			seen[ref] = true
+			refs = append(refs, ref)
+		}
+	}
+
+	for _, ref := range refs {
+		if schemaNameFromRef(ref) == name {
+			fmt.Fprintf(os.Stderr, "error: %s.discriminator.mapping contains $ref to itself\n", name)
+			return
+		}
+	}
+
+	oneOf := newSequenceNode()
+	for _, ref := range refs {
+		oneOf.Content = append(oneOf.Content, newRefNode(ref))
+	}
+	mappingSet(schema, "oneOf", oneOf)
+}

--- a/tools/openapi2crd/pkg/flatten/flatten.go
+++ b/tools/openapi2crd/pkg/flatten/flatten.go
@@ -1,0 +1,53 @@
+// Package flatten implements OpenAPI YAML flattening: it inlines $ref schemas,
+// merges oneOf/anyOf/allOf composition, and removes unreferenced definitions.
+package flatten
+
+import (
+	"bytes"
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Flatten takes raw OpenAPI YAML bytes and returns the flattened YAML bytes.
+func Flatten(data []byte) ([]byte, error) {
+	var doc yaml.Node
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return nil, fmt.Errorf("parsing YAML: %w", err)
+	}
+	if len(doc.Content) == 0 {
+		return data, nil
+	}
+
+	root := doc.Content[0]
+	if root.Kind != yaml.MappingNode {
+		return nil, fmt.Errorf("expected root to be a YAML mapping")
+	}
+
+	applyDiscriminatorTransformations(root)
+	applyOneOfTransformations(root)
+	applyAnyOfTransformations(root)
+	applyAllOfTransformations(root)
+
+	for removeUnusedSchemas(root) {
+	}
+
+	applyStructuralTransformations(root)
+
+	normalizeScalarStyles(root)
+
+	return marshalYAML(root)
+}
+
+func marshalYAML(node *yaml.Node) ([]byte, error) {
+	var buf bytes.Buffer
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(2)
+	if err := enc.Encode(node); err != nil {
+		return nil, fmt.Errorf("marshaling YAML: %w", err)
+	}
+	if err := enc.Close(); err != nil {
+		return nil, fmt.Errorf("closing YAML encoder: %w", err)
+	}
+	return buf.Bytes(), nil
+}

--- a/tools/openapi2crd/pkg/flatten/flatten_test.go
+++ b/tools/openapi2crd/pkg/flatten/flatten_test.go
@@ -1,0 +1,57 @@
+package flatten
+
+import (
+	"flag"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+var update = flag.Bool("update", false, "regenerate golden files")
+
+// TestFlattenGolden runs Flatten on every testdata/<name>/input.yaml and
+// compares the output against testdata/<name>/golden.yaml.
+// Run with -update to regenerate the golden files.
+func TestFlattenGolden(t *testing.T) {
+	inputs, err := filepath.Glob("testdata/*/input.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(inputs) == 0 {
+		t.Fatal("no test fixtures found under testdata/")
+	}
+
+	for _, inputPath := range inputs {
+		dir := filepath.Dir(inputPath)
+		name := filepath.Base(dir)
+		goldenPath := filepath.Join(dir, "golden.yaml")
+
+		t.Run(name, func(t *testing.T) {
+			data, err := os.ReadFile(inputPath)
+			if err != nil {
+				t.Fatalf("reading input: %v", err)
+			}
+
+			got, err := Flatten(data)
+			if err != nil {
+				t.Fatalf("Flatten: %v", err)
+			}
+
+			if *update {
+				if err := os.WriteFile(goldenPath, got, 0o644); err != nil {
+					t.Fatalf("writing golden: %v", err)
+				}
+				return
+			}
+
+			want, err := os.ReadFile(goldenPath)
+			if err != nil {
+				t.Fatalf("reading golden (run with -update to create): %v", err)
+			}
+
+			if string(got) != string(want) {
+				t.Errorf("output mismatch for %s:\n\ngot:\n%s\nwant:\n%s", name, got, want)
+			}
+		})
+	}
+}

--- a/tools/openapi2crd/pkg/flatten/node.go
+++ b/tools/openapi2crd/pkg/flatten/node.go
@@ -1,0 +1,294 @@
+package flatten
+
+import (
+	"fmt"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// mappingGet returns the value node for the given key in a MappingNode, or nil.
+func mappingGet(node *yaml.Node, key string) *yaml.Node {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return nil
+	}
+	for i := 0; i < len(node.Content)-1; i += 2 {
+		if node.Content[i].Value == key {
+			return node.Content[i+1]
+		}
+	}
+	return nil
+}
+
+// mappingSet sets or adds a key-value pair in a MappingNode.
+func mappingSet(node *yaml.Node, key string, value *yaml.Node) {
+	for i := 0; i < len(node.Content)-1; i += 2 {
+		if node.Content[i].Value == key {
+			node.Content[i+1] = value
+			return
+		}
+	}
+	node.Content = append(node.Content, newStringNode(key), value)
+}
+
+// mappingDelete removes a key from a MappingNode. Returns true if the key was found.
+func mappingDelete(node *yaml.Node, key string) bool {
+	for i := 0; i < len(node.Content)-1; i += 2 {
+		if node.Content[i].Value == key {
+			node.Content = append(node.Content[:i], node.Content[i+2:]...)
+			return true
+		}
+	}
+	return false
+}
+
+// mappingHas reports whether a MappingNode contains the given key.
+func mappingHas(node *yaml.Node, key string) bool {
+	return mappingGet(node, key) != nil
+}
+
+// asMapping returns n if it is a MappingNode (resolving aliases), or nil.
+func asMapping(n *yaml.Node) *yaml.Node {
+	if n == nil {
+		return nil
+	}
+	if n.Kind == yaml.AliasNode {
+		return asMapping(n.Alias)
+	}
+	if n.Kind == yaml.MappingNode {
+		return n
+	}
+	return nil
+}
+
+// asSequence returns n if it is a SequenceNode (resolving aliases), or nil.
+func asSequence(n *yaml.Node) *yaml.Node {
+	if n == nil {
+		return nil
+	}
+	if n.Kind == yaml.AliasNode {
+		return asSequence(n.Alias)
+	}
+	if n.Kind == yaml.SequenceNode {
+		return n
+	}
+	return nil
+}
+
+// asString returns the string value of a ScalarNode (resolving aliases), or "".
+func asString(n *yaml.Node) string {
+	if n == nil {
+		return ""
+	}
+	if n.Kind == yaml.AliasNode {
+		return asString(n.Alias)
+	}
+	if n.Kind == yaml.ScalarNode {
+		return n.Value
+	}
+	return ""
+}
+
+// getPath navigates a chain of mapping keys from root, returning the final node.
+func getPath(root *yaml.Node, keys ...string) *yaml.Node {
+	cur := root
+	for _, k := range keys {
+		cur = mappingGet(cur, k)
+		if cur == nil {
+			return nil
+		}
+	}
+	return cur
+}
+
+// resolveRef resolves "#/components/schemas/<Name>" and returns (name, node).
+func resolveRef(root *yaml.Node, ref string) (string, *yaml.Node) {
+	const prefix = "#/components/schemas/"
+	if !strings.HasPrefix(ref, prefix) {
+		return "", nil
+	}
+	name := strings.TrimPrefix(ref, prefix)
+	schemas := getPath(root, "components", "schemas")
+	if schemas == nil {
+		return name, nil
+	}
+	return name, asMapping(mappingGet(schemas, name))
+}
+
+// schemaNameFromRef extracts the schema name from "#/components/schemas/<Name>".
+func schemaNameFromRef(ref string) string {
+	return strings.TrimPrefix(ref, "#/components/schemas/")
+}
+
+// isTopLevelSchema reports whether the dot-separated path is ".components.schemas.<name>".
+func isTopLevelSchema(path string) bool {
+	parts := strings.Split(path, ".")
+	// path starts with "." → ["", "components", "schemas", "<name>"]
+	return len(parts) == 4 && parts[1] == "components" && parts[2] == "schemas"
+}
+
+// lastPathComponent returns the last "."-separated component of a path.
+func lastPathComponent(path string) string {
+	parts := strings.Split(path, ".")
+	return parts[len(parts)-1]
+}
+
+// walkMappings traverses the YAML tree depth-first and calls fn for every
+// MappingNode that passes the filter, along with its dot-path.
+func walkMappings(root *yaml.Node, filter func(*yaml.Node) bool, fn func(path string, n *yaml.Node)) {
+	type item struct {
+		path string
+		node *yaml.Node
+	}
+	stack := []item{{path: "", node: root}}
+	for len(stack) > 0 {
+		cur := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+
+		n := cur.node
+		if n == nil {
+			continue
+		}
+		if n.Kind == yaml.AliasNode {
+			n = n.Alias
+		}
+
+		switch n.Kind {
+		case yaml.MappingNode:
+			if filter(n) {
+				fn(cur.path, n)
+			}
+			for i := 0; i < len(n.Content)-1; i += 2 {
+				key := n.Content[i].Value
+				val := n.Content[i+1]
+				if val.Kind == yaml.MappingNode || val.Kind == yaml.SequenceNode || val.Kind == yaml.AliasNode {
+					stack = append(stack, item{path: cur.path + "." + key, node: val})
+				}
+			}
+		case yaml.SequenceNode:
+			for i, child := range n.Content {
+				if child.Kind == yaml.MappingNode || child.Kind == yaml.SequenceNode || child.Kind == yaml.AliasNode {
+					stack = append(stack, item{
+						path: fmt.Sprintf("%s.%d", cur.path, i),
+						node: child,
+					})
+				}
+			}
+		}
+	}
+}
+
+// collectRefs returns every "$ref" value found anywhere in the tree.
+func collectRefs(node *yaml.Node) map[string]bool {
+	refs := map[string]bool{}
+	collectRefsInto(node, refs)
+	return refs
+}
+
+func collectRefsInto(node *yaml.Node, refs map[string]bool) {
+	if node == nil {
+		return
+	}
+	switch node.Kind {
+	case yaml.MappingNode:
+		for i := 0; i < len(node.Content)-1; i += 2 {
+			key := node.Content[i].Value
+			val := node.Content[i+1]
+			if key == "$ref" {
+				refs[val.Value] = true
+			} else {
+				collectRefsInto(val, refs)
+			}
+		}
+	case yaml.SequenceNode:
+		for _, child := range node.Content {
+			collectRefsInto(child, refs)
+		}
+	case yaml.DocumentNode:
+		for _, child := range node.Content {
+			collectRefsInto(child, refs)
+		}
+	case yaml.AliasNode:
+		collectRefsInto(node.Alias, refs)
+	}
+}
+
+// deepCopy returns a deep copy of a yaml.Node, inlining any aliases.
+func deepCopy(n *yaml.Node) *yaml.Node {
+	if n == nil {
+		return nil
+	}
+	if n.Kind == yaml.AliasNode {
+		return deepCopy(n.Alias)
+	}
+	dst := *n
+	if len(n.Content) > 0 {
+		dst.Content = make([]*yaml.Node, len(n.Content))
+		for i, child := range n.Content {
+			dst.Content[i] = deepCopy(child)
+		}
+	}
+	return &dst
+}
+
+// normalizeScalarStyles walks the entire tree and sets the correct quoting style
+// on every string scalar, based on YAML 1.2 core-schema rules.
+func normalizeScalarStyles(node *yaml.Node) {
+	if node == nil {
+		return
+	}
+	switch node.Kind {
+	case yaml.ScalarNode:
+		if node.Tag == "!!str" {
+			v := node.Value
+			if strings.Contains(v, "\n") {
+				node.Style = yaml.LiteralStyle
+			} else if needsQuotingYAML12(v) {
+				if strings.Contains(v, `"`) && !strings.Contains(v, "'") {
+					node.Style = yaml.SingleQuotedStyle
+				} else {
+					node.Style = yaml.DoubleQuotedStyle
+				}
+			} else {
+				node.Style = 0
+			}
+		} else {
+			node.Style = 0
+		}
+	case yaml.MappingNode, yaml.SequenceNode, yaml.DocumentNode:
+		for _, child := range node.Content {
+			normalizeScalarStyles(child)
+		}
+	case yaml.AliasNode:
+	}
+}
+
+// ---- Node constructors ----
+
+func newStringNode(value string) *yaml.Node {
+	return &yaml.Node{
+		Kind:  yaml.ScalarNode,
+		Tag:   "!!str",
+		Value: value,
+	}
+}
+
+func newMappingNode() *yaml.Node {
+	return &yaml.Node{
+		Kind: yaml.MappingNode,
+		Tag:  "!!map",
+	}
+}
+
+func newSequenceNode() *yaml.Node {
+	return &yaml.Node{
+		Kind: yaml.SequenceNode,
+		Tag:  "!!seq",
+	}
+}
+
+func newRefNode(ref string) *yaml.Node {
+	m := newMappingNode()
+	mappingSet(m, "$ref", newStringNode(ref))
+	return m
+}

--- a/tools/openapi2crd/pkg/flatten/oneof.go
+++ b/tools/openapi2crd/pkg/flatten/oneof.go
@@ -1,0 +1,230 @@
+package flatten
+
+import (
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+func applyOneOfTransformations(root *yaml.Node) {
+	walkMappings(root,
+		func(m *yaml.Node) bool { return mappingHas(m, "oneOf") },
+		func(path string, m *yaml.Node) {
+			if isTopLevelSchema(path) {
+				transformOneOf(m, root)
+			}
+		},
+	)
+}
+
+func transformOneOf(schema *yaml.Node, root *yaml.Node) {
+	oneOf := asSequence(mappingGet(schema, "oneOf"))
+	if oneOf == nil {
+		return
+	}
+	children := resolveSequenceRefs(oneOf, root, "oneOf")
+
+	if allHaveEnum(children) {
+		mergeEnums(schema, children, "oneOf")
+	} else {
+		transformOneOfProperties(schema, children, root)
+	}
+}
+
+func transformOneOfProperties(schema *yaml.Node, children []*yaml.Node, root *yaml.Node) {
+	discExt := buildDiscriminatorExtension(schema, root)
+
+	for _, child := range children {
+		props := asMapping(mappingGet(child, "properties"))
+		if props == nil {
+			props = syntheticPropsFromAllOf(child)
+			if props == nil {
+				typeStr := asString(mappingGet(child, "type"))
+				fmt.Fprintf(os.Stderr, "warning: skipping non-object oneOf variant (type: %s)\n", typeStr)
+				continue
+			}
+			mappingSet(child, "properties", props)
+		}
+		mergeChildPropertiesIntoParent(schema, props)
+	}
+
+	if discExt != nil {
+		mappingSet(schema, "x-xgen-discriminator", discExt)
+	}
+	mappingDelete(schema, "discriminator")
+	mappingDelete(schema, "oneOf")
+}
+
+// mergeChildPropertiesIntoParent merges child properties into the parent schema.
+// Type-mismatched properties are deleted (except ignored ones); remaining
+// properties use last-wins semantics, preserving the parent's description when
+// the child's description differs.
+func mergeChildPropertiesIntoParent(parent *yaml.Node, childProps *yaml.Node) {
+	childCopy := deepCopy(childProps)
+
+	parentProps := asMapping(mappingGet(parent, "properties"))
+	if parentProps != nil {
+		parentTypeOrRef := map[string]string{}
+		for i := 0; i < len(parentProps.Content)-1; i += 2 {
+			parentTypeOrRef[parentProps.Content[i].Value] = typeOrRef(asMapping(parentProps.Content[i+1]))
+		}
+
+		ignored := ignoredProperties()
+		var keysToDelete []string
+		for i := 0; i < len(childCopy.Content)-1; i += 2 {
+			k := childCopy.Content[i].Value
+			if pt, exists := parentTypeOrRef[k]; exists {
+				ct := typeOrRef(asMapping(childCopy.Content[i+1]))
+				if pt != ct && !ignored[k] {
+					keysToDelete = append(keysToDelete, k)
+				}
+			}
+		}
+		for _, k := range keysToDelete {
+			mappingDelete(childCopy, k)
+			mappingDelete(childProps, k)
+		}
+
+		for i := 0; i < len(childCopy.Content)-1; i += 2 {
+			k := childCopy.Content[i].Value
+			parentProp := asMapping(mappingGet(parentProps, k))
+			childProp := asMapping(childCopy.Content[i+1])
+			if parentProp == nil || childProp == nil {
+				continue
+			}
+			parentDesc := mappingGet(parentProp, "description")
+			if parentDesc == nil {
+				continue
+			}
+			if asString(mappingGet(childProp, "description")) != asString(parentDesc) {
+				mappingSet(childProp, "description", parentDesc)
+			}
+		}
+	}
+
+	if parentProps == nil {
+		parentProps = newMappingNode()
+		mappingSet(parent, "properties", parentProps)
+	}
+
+	for i := 0; i < len(childCopy.Content)-1; i += 2 {
+		mappingSet(parentProps, childCopy.Content[i].Value, childCopy.Content[i+1])
+	}
+}
+
+// buildDiscriminatorExtension builds the x-xgen-discriminator extension node.
+func buildDiscriminatorExtension(schema *yaml.Node, root *yaml.Node) *yaml.Node {
+	disc := asMapping(mappingGet(schema, "discriminator"))
+	if disc == nil {
+		return nil
+	}
+	propNameNode := mappingGet(disc, "propertyName")
+	mapping := asMapping(mappingGet(disc, "mapping"))
+	if propNameNode == nil || mapping == nil {
+		return nil
+	}
+	propertyName := asString(propNameNode)
+
+	baseProps := map[string]bool{}
+	if pp := asMapping(mappingGet(schema, "properties")); pp != nil {
+		for i := 0; i < len(pp.Content)-1; i += 2 {
+			baseProps[pp.Content[i].Value] = true
+		}
+	}
+
+	mappingNode := newMappingNode()
+	for i := 0; i < len(mapping.Content)-1; i += 2 {
+		discValue := mapping.Content[i].Value
+		ref := asString(mapping.Content[i+1])
+
+		_, child := resolveRef(root, ref)
+		if child == nil {
+			continue
+		}
+
+		allChildProps := collectAllProperties(child, root)
+		allChildRequired := collectAllRequired(child, root)
+
+		var typeSpecific []string
+		for j := 0; j < len(allChildProps.Content)-1; j += 2 {
+			k := allChildProps.Content[j].Value
+			if !baseProps[k] {
+				typeSpecific = append(typeSpecific, k)
+			}
+		}
+
+		var tsRequired []string
+		for _, p := range typeSpecific {
+			if p != propertyName && allChildRequired[p] {
+				tsRequired = append(tsRequired, p)
+			}
+		}
+
+		entry := newMappingNode()
+		propsSeq := newSequenceNode()
+		for _, p := range typeSpecific {
+			propsSeq.Content = append(propsSeq.Content, newStringNode(p))
+		}
+		mappingSet(entry, "properties", propsSeq)
+		if len(tsRequired) > 0 {
+			reqSeq := newSequenceNode()
+			for _, r := range tsRequired {
+				reqSeq.Content = append(reqSeq.Content, newStringNode(r))
+			}
+			mappingSet(entry, "required", reqSeq)
+		}
+		mappingSet(mappingNode, discValue, entry)
+	}
+
+	ext := newMappingNode()
+	mappingSet(ext, "propertyName", newStringNode(propertyName))
+	mappingSet(ext, "mapping", mappingNode)
+	return ext
+}
+
+func collectAllProperties(child *yaml.Node, root *yaml.Node) *yaml.Node {
+	result := newMappingNode()
+	if props := asMapping(mappingGet(child, "properties")); props != nil {
+		for i := 0; i < len(props.Content)-1; i += 2 {
+			mappingSet(result, props.Content[i].Value, props.Content[i+1])
+		}
+	}
+	if allOf := asSequence(mappingGet(child, "allOf")); allOf != nil {
+		for _, item := range allOf.Content {
+			resolved := resolveOrInline(item, root)
+			if resolved == nil {
+				continue
+			}
+			if props := asMapping(mappingGet(resolved, "properties")); props != nil {
+				for i := 0; i < len(props.Content)-1; i += 2 {
+					mappingSet(result, props.Content[i].Value, props.Content[i+1])
+				}
+			}
+		}
+	}
+	return result
+}
+
+func collectAllRequired(child *yaml.Node, root *yaml.Node) map[string]bool {
+	result := map[string]bool{}
+	if req := asSequence(mappingGet(child, "required")); req != nil {
+		for _, v := range req.Content {
+			result[asString(v)] = true
+		}
+	}
+	if allOf := asSequence(mappingGet(child, "allOf")); allOf != nil {
+		for _, item := range allOf.Content {
+			resolved := resolveOrInline(item, root)
+			if resolved == nil {
+				continue
+			}
+			if req := asSequence(mappingGet(resolved, "required")); req != nil {
+				for _, v := range req.Content {
+					result[asString(v)] = true
+				}
+			}
+		}
+	}
+	return result
+}

--- a/tools/openapi2crd/pkg/flatten/quote.go
+++ b/tools/openapi2crd/pkg/flatten/quote.go
@@ -1,0 +1,73 @@
+package flatten
+
+import (
+	"regexp"
+	"strings"
+)
+
+// needsQuotingYAML12 reports whether a plain scalar value must be quoted when
+// targeting YAML 1.2 core schema.  A value that would be misinterpreted as
+// null, bool, or a number must be quoted to preserve its string identity.
+func needsQuotingYAML12(v string) bool {
+	if v == "" {
+		return true
+	}
+	switch strings.ToLower(v) {
+	case "null", "~", "true", "false":
+		return true
+	}
+	if isYAML12Number(v) {
+		return true
+	}
+	return containsYAMLSpecialChars(v)
+}
+
+// containsYAMLSpecialChars reports whether a plain scalar would be syntactically
+// invalid or ambiguous in YAML 1.2 block context.
+func containsYAMLSpecialChars(v string) bool {
+	if v == "" {
+		return true
+	}
+	switch v[0] {
+	case '#', '|', '>', '!', '%', '@', '`', '"', '\'':
+		return true
+	case '&', '*', '?':
+		return true
+	case '-':
+		if len(v) > 1 && v[1] == ' ' {
+			return true
+		}
+	case ':':
+		if len(v) == 1 || v[1] == ' ' {
+			return true
+		}
+	case '{', '}', '[', ']':
+		return true
+	}
+	if strings.Contains(v, ": ") || strings.Contains(v, " #") {
+		return true
+	}
+	if strings.HasSuffix(v, ":") {
+		return true
+	}
+	if strings.ContainsAny(v, "\n\r") {
+		return true
+	}
+	return false
+}
+
+// isYAML12Number reports whether v would be parsed as a numeric type under
+// the YAML 1.2 core schema.
+func isYAML12Number(v string) bool {
+	if v == ".inf" || v == "+.inf" || v == "-.inf" || v == ".nan" {
+		return true
+	}
+	return reYAML12Number.MatchString(v)
+}
+
+// reYAML12Number matches YAML 1.2 numeric literals.
+var reYAML12Number = regexp.MustCompile(
+	`^[-+]?(\.[0-9]+|[0-9]+(\.[0-9]*)?)([eE][-+]?[0-9]+)?$` +
+		`|^[-+]?0o[0-7]+$` +
+		`|^[-+]?0x[0-9a-fA-F]+$`,
+)

--- a/tools/openapi2crd/pkg/flatten/quote_test.go
+++ b/tools/openapi2crd/pkg/flatten/quote_test.go
@@ -1,0 +1,116 @@
+package flatten
+
+import "testing"
+
+func TestNeedsQuotingYAML12(t *testing.T) {
+	tests := []struct {
+		value string
+		want  bool
+	}{
+		{"", true},
+
+		{"true", true},
+		{"True", true},
+		{"TRUE", true},
+		{"false", true},
+		{"False", true},
+
+		{"null", true},
+		{"Null", true},
+		{"NULL", true},
+		{"~", true},
+
+		{"yes", false},
+		{"no", false},
+		{"on", false},
+		{"off", false},
+
+		{"0", true},
+		{"42", true},
+		{"-1", true},
+		{"+1", true},
+		{"3.14", true},
+		{".5", true},
+		{"1e10", true},
+		{"1.5e-3", true},
+		{"0x1F", true},
+		{"0o17", true},
+		{".inf", true},
+		{"+.inf", true},
+		{"-.inf", true},
+		{".nan", true},
+
+		{"hello", false},
+		{"hello world", false},
+		{"snake_case", false},
+		{"camelCase", false},
+		{"v1", false},
+		{"application/json", false},
+		{"#/components/schemas/Foo", true},
+
+		{"#comment", true},
+		{"|literal", true},
+		{">folded", true},
+		{"!tag", true},
+		{"%directive", true},
+		{"@at", true},
+		{"`backtick", true},
+		{`"quoted`, true},
+		{"'single", true},
+		{"&anchor", true},
+		{"*alias", true},
+		{"?key", true},
+		{"{flow", true},
+		{"}flow", true},
+		{"[seq", true},
+		{"]seq", true},
+
+		{":", true},
+		{": ", true},
+		{"key: value", true},
+		{"key:", true},
+		{"key:value", false},
+		{"http://example.com", false},
+
+		{"- item", true},
+		{"-item", false},
+
+		{"foo #bar", true},
+
+		{"line1\nline2", true},
+		{"line1\rline2", true},
+	}
+
+	for _, tt := range tests {
+		got := needsQuotingYAML12(tt.value)
+		if got != tt.want {
+			t.Errorf("needsQuotingYAML12(%q) = %v, want %v", tt.value, got, tt.want)
+		}
+	}
+}
+
+func TestIsYAML12Number(t *testing.T) {
+	numbers := []string{
+		"0", "1", "42", "-1", "+1",
+		"3.14", ".5", "1.", "-3.14",
+		"1e10", "1.5e-3", "1E+10",
+		"0x1F", "0xdeadbeef", "0xDEAD",
+		"0o17", "0o777",
+		".inf", "+.inf", "-.inf", ".nan",
+	}
+	for _, v := range numbers {
+		if !isYAML12Number(v) {
+			t.Errorf("isYAML12Number(%q) = false, want true", v)
+		}
+	}
+
+	nonNumbers := []string{
+		"", "hello", "true", "false", "null",
+		"1.2.3", "0b1010", "yes", "no",
+	}
+	for _, v := range nonNumbers {
+		if isYAML12Number(v) {
+			t.Errorf("isYAML12Number(%q) = true, want false", v)
+		}
+	}
+}

--- a/tools/openapi2crd/pkg/flatten/schema.go
+++ b/tools/openapi2crd/pkg/flatten/schema.go
@@ -1,0 +1,148 @@
+package flatten
+
+import (
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+// resolveSequenceRefs resolves the refs/inline items in a oneOf/anyOf sequence
+// into concrete MappingNodes, logging warnings for unresolvable refs.
+func resolveSequenceRefs(seq *yaml.Node, root *yaml.Node, kind string) []*yaml.Node {
+	var result []*yaml.Node
+	for _, item := range seq.Content {
+		m := asMapping(item)
+		if m == nil {
+			continue
+		}
+		if ref := asString(mappingGet(m, "$ref")); ref != "" {
+			_, child := resolveRef(root, ref)
+			if child == nil {
+				fmt.Fprintf(os.Stderr, "warning: could not resolve %s reference: %s\n", kind, ref)
+				continue
+			}
+			result = append(result, child)
+		} else if mappingHas(m, "type") || mappingHas(m, "properties") {
+			result = append(result, m)
+		}
+	}
+	return result
+}
+
+// resolveOrInline resolves a $ref or returns the node as-is if it is inline.
+func resolveOrInline(item *yaml.Node, root *yaml.Node) *yaml.Node {
+	m := asMapping(item)
+	if m == nil {
+		return nil
+	}
+	if ref := asString(mappingGet(m, "$ref")); ref != "" {
+		_, resolved := resolveRef(root, ref)
+		return resolved
+	}
+	return m
+}
+
+// allHaveEnum reports whether every mapping in the list has an "enum" key.
+func allHaveEnum(children []*yaml.Node) bool {
+	for _, c := range children {
+		if !mappingHas(c, "enum") {
+			return false
+		}
+	}
+	return true
+}
+
+// mergeEnums merges enum values from children into schema, then deletes
+// discriminator and the given composition key (oneOf or anyOf).
+func mergeEnums(schema *yaml.Node, children []*yaml.Node, compositionKey string) {
+	seen := map[string]bool{}
+	var vals []*yaml.Node
+
+	if existing := asSequence(mappingGet(schema, "enum")); existing != nil {
+		for _, v := range existing.Content {
+			if s := asString(v); s != "" {
+				seen[s] = true
+				vals = append(vals, v)
+			}
+		}
+	}
+
+	var lastType *yaml.Node
+	for _, child := range children {
+		childEnum := asSequence(mappingGet(child, "enum"))
+		if childEnum == nil {
+			continue
+		}
+		for _, v := range childEnum.Content {
+			if s := asString(v); s != "" && !seen[s] {
+				seen[s] = true
+				vals = append(vals, v)
+			}
+		}
+		if t := mappingGet(child, "type"); t != nil {
+			lastType = t
+		}
+	}
+
+	enumNode := newSequenceNode()
+	enumNode.Content = vals
+	mappingSet(schema, "enum", enumNode)
+	if lastType != nil {
+		mappingSet(schema, "type", lastType)
+	}
+	mappingDelete(schema, "discriminator")
+	mappingDelete(schema, compositionKey)
+}
+
+// syntheticPropsFromAllOf builds a synthetic properties MappingNode from
+// inline (non-$ref) allOf entries that have a properties key.
+// Returns nil if there are no such entries.
+func syntheticPropsFromAllOf(child *yaml.Node) *yaml.Node {
+	allOf := asSequence(mappingGet(child, "allOf"))
+	if allOf == nil {
+		return nil
+	}
+	synth := newMappingNode()
+	for _, item := range allOf.Content {
+		m := asMapping(item)
+		if m == nil || mappingHas(m, "$ref") {
+			continue
+		}
+		if props := asMapping(mappingGet(m, "properties")); props != nil {
+			for i := 0; i < len(props.Content)-1; i += 2 {
+				mappingSet(synth, props.Content[i].Value, props.Content[i+1])
+			}
+		}
+	}
+	if len(synth.Content) == 0 {
+		return nil
+	}
+	return synth
+}
+
+// typeOrRef returns the "type" or "$ref" value of a property schema node,
+// used for mismatch detection.
+func typeOrRef(node *yaml.Node) string {
+	if node == nil {
+		return ""
+	}
+	if t := asString(mappingGet(node, "type")); t != "" {
+		return t
+	}
+	return asString(mappingGet(node, "$ref"))
+}
+
+// ignoredProperties returns the set of property names exempt from
+// type-mismatch deletion (from the Atlas duplicate.ignore.json list).
+func ignoredProperties() map[string]bool {
+	return map[string]bool{
+		"units":           true,
+		"threshold":       true,
+		"eventTypeName":   true,
+		"currentValue":    true,
+		"metricThreshold": true,
+		"autoScaling":     true,
+		"featureId":       true,
+	}
+}

--- a/tools/openapi2crd/pkg/flatten/structural.go
+++ b/tools/openapi2crd/pkg/flatten/structural.go
@@ -1,0 +1,161 @@
+package flatten
+
+import "gopkg.in/yaml.v3"
+
+// applyStructuralTransformations cleans up the schema tree to be compatible
+// with Kubernetes structural schemas. It runs after the existing composition
+// transformations (oneOf/anyOf/allOf top-level handlers) to catch inline
+// compositions that remain in property schemas.
+//
+// Specifically it:
+//   - Flattens inline allOf by merging items' type/properties/required into the parent
+//   - Flattens inline oneOf/anyOf by merging all variants' properties into the parent
+//   - Removes additionalProperties when properties is non-empty (mutually exclusive in CRDs)
+//   - Ensures every array schema has an items sub-schema
+func applyStructuralTransformations(root *yaml.Node) {
+	flattenInlineAllOf(root)
+	flattenInlineCompositions(root, "oneOf")
+	flattenInlineCompositions(root, "anyOf")
+	fixAdditionalPropertiesConflict(root)
+	ensureArrayHasItems(root)
+}
+
+// flattenInlineAllOf walks every schema that has allOf, merges the items'
+// type/properties/required into the parent, then removes allOf.
+func flattenInlineAllOf(root *yaml.Node) {
+	walkMappings(root,
+		func(m *yaml.Node) bool { return mappingHas(m, "allOf") },
+		func(_ string, m *yaml.Node) {
+			mergeAllOfInto(m, root)
+		},
+	)
+}
+
+// mergeAllOfInto merges each allOf item into schema and removes the allOf key.
+func mergeAllOfInto(schema *yaml.Node, root *yaml.Node) {
+	allOf := asSequence(mappingGet(schema, "allOf"))
+	if allOf == nil {
+		return
+	}
+
+	for _, item := range allOf.Content {
+		resolved := resolveOrInline(item, root)
+		if resolved == nil {
+			continue
+		}
+		if mappingGet(schema, "type") == nil {
+			if t := mappingGet(resolved, "type"); t != nil {
+				mappingSet(schema, "type", deepCopy(t))
+			}
+		}
+		for _, meta := range []string{"description", "title"} {
+			if mappingGet(schema, meta) == nil {
+				if v := mappingGet(resolved, meta); v != nil {
+					mappingSet(schema, meta, deepCopy(v))
+				}
+			}
+		}
+		mergePropertiesAndRequired(schema, resolved)
+	}
+
+	mappingDelete(schema, "allOf")
+}
+
+// flattenInlineCompositions walks every schema that has the given composition
+// key (oneOf or anyOf), merges each variant's properties into the parent, then
+// removes the composition key. Enum-only compositions are left untouched.
+func flattenInlineCompositions(root *yaml.Node, key string) {
+	walkMappings(root,
+		func(m *yaml.Node) bool { return mappingHas(m, key) },
+		func(_ string, m *yaml.Node) {
+			seq := asSequence(mappingGet(m, key))
+			if seq == nil {
+				return
+			}
+			children := resolveSequenceRefs(seq, root, key)
+			if len(children) > 0 && allHaveEnum(children) {
+				return
+			}
+			for _, item := range seq.Content {
+				resolved := resolveOrInline(item, root)
+				if resolved == nil {
+					continue
+				}
+				mergePropertiesAndRequired(m, resolved)
+			}
+			mappingDelete(m, key)
+		},
+	)
+}
+
+// mergePropertiesAndRequired copies properties and required from src into dst,
+// without overwriting existing keys.
+func mergePropertiesAndRequired(dst, src *yaml.Node) {
+	if srcProps := asMapping(mappingGet(src, "properties")); srcProps != nil {
+		dstProps := asMapping(mappingGet(dst, "properties"))
+		if dstProps == nil {
+			dstProps = newMappingNode()
+			mappingSet(dst, "properties", dstProps)
+		}
+		for i := 0; i < len(srcProps.Content)-1; i += 2 {
+			k := srcProps.Content[i].Value
+			if mappingGet(dstProps, k) == nil {
+				mappingSet(dstProps, k, deepCopy(srcProps.Content[i+1]))
+			}
+		}
+	}
+
+	if srcReq := asSequence(mappingGet(src, "required")); srcReq != nil {
+		dstReq := asSequence(mappingGet(dst, "required"))
+		existing := map[string]bool{}
+		if dstReq != nil {
+			for _, v := range dstReq.Content {
+				existing[asString(v)] = true
+			}
+		} else {
+			dstReq = newSequenceNode()
+		}
+		added := false
+		for _, v := range srcReq.Content {
+			if s := asString(v); s != "" && !existing[s] {
+				dstReq.Content = append(dstReq.Content, newStringNode(s))
+				existing[s] = true
+				added = true
+			}
+		}
+		if added {
+			mappingSet(dst, "required", dstReq)
+		}
+	}
+}
+
+// fixAdditionalPropertiesConflict removes additionalProperties from any schema
+// that also has a non-empty properties map. In Kubernetes CRDs these two fields
+// are mutually exclusive.
+func fixAdditionalPropertiesConflict(root *yaml.Node) {
+	walkMappings(root,
+		func(m *yaml.Node) bool {
+			if !mappingHas(m, "additionalProperties") {
+				return false
+			}
+			props := asMapping(mappingGet(m, "properties"))
+			return props != nil && len(props.Content) > 0
+		},
+		func(_ string, m *yaml.Node) {
+			mappingDelete(m, "additionalProperties")
+		},
+	)
+}
+
+// ensureArrayHasItems adds an empty items schema ({}) to any array schema that
+// lacks one. Kubernetes requires every array to declare its items type.
+func ensureArrayHasItems(root *yaml.Node) {
+	walkMappings(root,
+		func(m *yaml.Node) bool {
+			return asString(mappingGet(m, "type")) == "array" && !mappingHas(m, "items")
+		},
+		func(_ string, m *yaml.Node) {
+			mappingSet(m, "items", newMappingNode())
+		},
+	)
+}

--- a/tools/openapi2crd/pkg/flatten/testdata/additional_properties/golden.yaml
+++ b/tools/openapi2crd/pkg/flatten/testdata/additional_properties/golden.yaml
@@ -1,0 +1,23 @@
+paths:
+  /config:
+    get:
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Config"
+components:
+  schemas:
+    Config:
+      type: object
+      properties:
+        name:
+          type: string
+        settings:
+          type: object
+          properties:
+            timeout:
+              type: integer
+            retries:
+              type: integer

--- a/tools/openapi2crd/pkg/flatten/testdata/additional_properties/input.yaml
+++ b/tools/openapi2crd/pkg/flatten/testdata/additional_properties/input.yaml
@@ -1,0 +1,25 @@
+paths:
+  /config:
+    get:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Config'
+components:
+  schemas:
+    Config:
+      type: object
+      properties:
+        name:
+          type: string
+        settings:
+          type: object
+          properties:
+            timeout:
+              type: integer
+            retries:
+              type: integer
+          additionalProperties:
+            type: string

--- a/tools/openapi2crd/pkg/flatten/testdata/allof/golden.yaml
+++ b/tools/openapi2crd/pkg/flatten/testdata/allof/golden.yaml
@@ -1,0 +1,18 @@
+paths:
+  /pets:
+    get:
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PetKind"
+components:
+  schemas:
+    PetKind:
+      type: string
+      enum:
+        - lion
+        - tiger
+        - cat
+        - dog

--- a/tools/openapi2crd/pkg/flatten/testdata/allof/input.yaml
+++ b/tools/openapi2crd/pkg/flatten/testdata/allof/input.yaml
@@ -1,0 +1,26 @@
+paths:
+  /pets:
+    get:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PetKind'
+components:
+  schemas:
+    PetKind:
+      type: string
+      oneOf:
+        - $ref: '#/components/schemas/LargePetKind'
+        - $ref: '#/components/schemas/SmallPetKind'
+    LargePetKind:
+      type: string
+      enum:
+        - lion
+        - tiger
+    SmallPetKind:
+      type: string
+      enum:
+        - cat
+        - dog

--- a/tools/openapi2crd/pkg/flatten/testdata/allof_inheritance/golden.yaml
+++ b/tools/openapi2crd/pkg/flatten/testdata/allof_inheritance/golden.yaml
@@ -1,0 +1,24 @@
+paths:
+  /shapes:
+    get:
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Shape"
+components:
+  schemas:
+    Shape:
+      type: object
+      properties:
+        color:
+          type: string
+        area:
+          type: number
+        radius:
+          type: number
+        side:
+          type: number
+      required:
+        - color

--- a/tools/openapi2crd/pkg/flatten/testdata/allof_inheritance/input.yaml
+++ b/tools/openapi2crd/pkg/flatten/testdata/allof_inheritance/input.yaml
@@ -1,0 +1,41 @@
+paths:
+  /shapes:
+    get:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Shape'
+components:
+  schemas:
+    Shape:
+      type: object
+      oneOf:
+        - $ref: '#/components/schemas/Circle'
+        - $ref: '#/components/schemas/Square'
+      properties:
+        color:
+          type: string
+        area:
+          type: number
+      required:
+        - color
+    Circle:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/Shape'
+      properties:
+        radius:
+          type: number
+      required:
+        - radius
+    Square:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/Shape'
+      properties:
+        side:
+          type: number
+      required:
+        - side

--- a/tools/openapi2crd/pkg/flatten/testdata/anyof/golden.yaml
+++ b/tools/openapi2crd/pkg/flatten/testdata/anyof/golden.yaml
@@ -1,0 +1,18 @@
+paths:
+  /pets:
+    get:
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pet"
+components:
+  schemas:
+    Pet:
+      type: object
+      properties:
+        indoor:
+          type: boolean
+        breed:
+          type: string

--- a/tools/openapi2crd/pkg/flatten/testdata/anyof/input.yaml
+++ b/tools/openapi2crd/pkg/flatten/testdata/anyof/input.yaml
@@ -1,0 +1,26 @@
+paths:
+  /pets:
+    get:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+components:
+  schemas:
+    Pet:
+      type: object
+      anyOf:
+        - $ref: '#/components/schemas/Cat'
+        - $ref: '#/components/schemas/Dog'
+    Cat:
+      type: object
+      properties:
+        indoor:
+          type: boolean
+    Dog:
+      type: object
+      properties:
+        breed:
+          type: string

--- a/tools/openapi2crd/pkg/flatten/testdata/array_items/golden.yaml
+++ b/tools/openapi2crd/pkg/flatten/testdata/array_items/golden.yaml
@@ -1,0 +1,27 @@
+paths:
+  /lists:
+    get:
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ListContainer"
+components:
+  schemas:
+    ListContainer:
+      type: object
+      properties:
+        tags:
+          type: array
+          items: {}
+        names:
+          type: array
+          items:
+            type: string
+        nested:
+          type: object
+          properties:
+            values:
+              type: array
+              items: {}

--- a/tools/openapi2crd/pkg/flatten/testdata/array_items/input.yaml
+++ b/tools/openapi2crd/pkg/flatten/testdata/array_items/input.yaml
@@ -1,0 +1,25 @@
+paths:
+  /lists:
+    get:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListContainer'
+components:
+  schemas:
+    ListContainer:
+      type: object
+      properties:
+        tags:
+          type: array
+        names:
+          type: array
+          items:
+            type: string
+        nested:
+          type: object
+          properties:
+            values:
+              type: array

--- a/tools/openapi2crd/pkg/flatten/testdata/discriminator/golden.yaml
+++ b/tools/openapi2crd/pkg/flatten/testdata/discriminator/golden.yaml
@@ -1,0 +1,31 @@
+paths:
+  /animals:
+    get:
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Animal"
+components:
+  schemas:
+    Animal:
+      type: object
+      properties:
+        animalType:
+          type: string
+        name:
+          type: string
+        indoor:
+          type: boolean
+        breed:
+          type: string
+      x-xgen-discriminator:
+        propertyName: animalType
+        mapping:
+          cat:
+            properties:
+              - indoor
+          dog:
+            properties:
+              - breed

--- a/tools/openapi2crd/pkg/flatten/testdata/discriminator/input.yaml
+++ b/tools/openapi2crd/pkg/flatten/testdata/discriminator/input.yaml
@@ -1,0 +1,35 @@
+paths:
+  /animals:
+    get:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Animal'
+components:
+  schemas:
+    Animal:
+      type: object
+      discriminator:
+        propertyName: animalType
+        mapping:
+          cat: '#/components/schemas/Cat'
+          dog: '#/components/schemas/Dog'
+      properties:
+        animalType:
+          type: string
+        name:
+          type: string
+    Cat:
+      allOf:
+        - $ref: '#/components/schemas/Animal'
+      properties:
+        indoor:
+          type: boolean
+    Dog:
+      allOf:
+        - $ref: '#/components/schemas/Animal'
+      properties:
+        breed:
+          type: string

--- a/tools/openapi2crd/pkg/flatten/testdata/inline_allof/golden.yaml
+++ b/tools/openapi2crd/pkg/flatten/testdata/inline_allof/golden.yaml
@@ -1,0 +1,29 @@
+paths:
+  /items:
+    get:
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Item"
+components:
+  schemas:
+    Item:
+      type: object
+      properties:
+        metadata:
+          type: object
+          description: Base metadata
+          properties:
+            id:
+              type: string
+            createdAt:
+              type: string
+            updatedAt:
+              type: string
+            version:
+              type: integer
+          required:
+            - id
+            - version

--- a/tools/openapi2crd/pkg/flatten/testdata/inline_allof/input.yaml
+++ b/tools/openapi2crd/pkg/flatten/testdata/inline_allof/input.yaml
@@ -1,0 +1,33 @@
+paths:
+  /items:
+    get:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Item'
+components:
+  schemas:
+    Item:
+      type: object
+      properties:
+        metadata:
+          allOf:
+            - type: object
+              description: Base metadata
+              properties:
+                id:
+                  type: string
+                createdAt:
+                  type: string
+              required:
+                - id
+            - type: object
+              properties:
+                updatedAt:
+                  type: string
+                version:
+                  type: integer
+              required:
+                - version

--- a/tools/openapi2crd/pkg/flatten/testdata/oneof/golden.yaml
+++ b/tools/openapi2crd/pkg/flatten/testdata/oneof/golden.yaml
@@ -1,0 +1,20 @@
+paths:
+  /pets:
+    get:
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pet"
+components:
+  schemas:
+    Pet:
+      type: object
+      properties:
+        name:
+          type: string
+        indoor:
+          type: boolean
+        breed:
+          type: string

--- a/tools/openapi2crd/pkg/flatten/testdata/oneof/input.yaml
+++ b/tools/openapi2crd/pkg/flatten/testdata/oneof/input.yaml
@@ -1,0 +1,29 @@
+paths:
+  /pets:
+    get:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+components:
+  schemas:
+    Pet:
+      type: object
+      oneOf:
+        - $ref: '#/components/schemas/Cat'
+        - $ref: '#/components/schemas/Dog'
+      properties:
+        name:
+          type: string
+    Cat:
+      type: object
+      properties:
+        indoor:
+          type: boolean
+    Dog:
+      type: object
+      properties:
+        breed:
+          type: string

--- a/tools/openapi2crd/pkg/flatten/testdata/synthetic_props/golden.yaml
+++ b/tools/openapi2crd/pkg/flatten/testdata/synthetic_props/golden.yaml
@@ -1,0 +1,24 @@
+paths:
+  /resources:
+    get:
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Resource"
+components:
+  schemas:
+    Resource:
+      type: object
+      properties:
+        name:
+          type: string
+        path:
+          type: string
+        size:
+          type: integer
+        url:
+          type: string
+        target:
+          type: string

--- a/tools/openapi2crd/pkg/flatten/testdata/synthetic_props/input.yaml
+++ b/tools/openapi2crd/pkg/flatten/testdata/synthetic_props/input.yaml
@@ -1,0 +1,37 @@
+paths:
+  /resources:
+    get:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Resource'
+components:
+  schemas:
+    Resource:
+      type: object
+      oneOf:
+        - $ref: '#/components/schemas/FileResource'
+        - $ref: '#/components/schemas/LinkResource'
+      properties:
+        name:
+          type: string
+    FileResource:
+      type: object
+      allOf:
+        - type: object
+          properties:
+            path:
+              type: string
+            size:
+              type: integer
+    LinkResource:
+      type: object
+      allOf:
+        - type: object
+          properties:
+            url:
+              type: string
+            target:
+              type: string

--- a/tools/openapi2crd/pkg/generator/generator.go
+++ b/tools/openapi2crd/pkg/generator/generator.go
@@ -83,17 +83,9 @@ func (g *Generator) Generate(ctx context.Context, crdConfig *v1alpha1.CRDConfig)
 		var openApiSpec *openapi3.T
 		var err error
 
-		switch def.Path {
-		case "":
-			openApiSpec, err = g.atlasLoader.Load(ctx, def.Package)
-			if err != nil {
-				return nil, fmt.Errorf("error loading Atlas OpenAPI package %q: %w", def.Package, err)
-			}
-		default:
-			openApiSpec, err = g.openapiLoader.Load(ctx, def.Path)
-			if err != nil {
-				return nil, fmt.Errorf("error loading spec: %w", err)
-			}
+		openApiSpec, err = loadOpenAPISpec(ctx, def, g.openapiLoader, g.atlasLoader)
+		if err != nil {
+			return nil, err
 		}
 
 		for _, p := range g.pluginSet.Mapping {
@@ -190,4 +182,42 @@ func clearPropertiesWithoutExtensions(schema *openapi3.Schema) bool {
 	}
 
 	return hasExtensions
+}
+
+func loadOpenAPISpec(ctx context.Context, def v1alpha1.OpenAPIDefinition, openapiLoader, atlasLoader config.Loader) (*openapi3.T, error) {
+	if def.Flatten {
+		return loadFlattenedSpec(ctx, def, openapiLoader, atlasLoader)
+	}
+
+	switch def.Path {
+	case "":
+		spec, err := atlasLoader.Load(ctx, def.Package)
+		if err != nil {
+			return nil, fmt.Errorf("error loading Atlas OpenAPI package %q: %w", def.Package, err)
+		}
+		return spec, nil
+	default:
+		spec, err := openapiLoader.Load(ctx, def.Path)
+		if err != nil {
+			return nil, fmt.Errorf("error loading spec: %w", err)
+		}
+		return spec, nil
+	}
+}
+
+func loadFlattenedSpec(ctx context.Context, def v1alpha1.OpenAPIDefinition, openapiLoader, atlasLoader config.Loader) (*openapi3.T, error) {
+	switch def.Path {
+	case "":
+		spec, err := atlasLoader.LoadFlattened(ctx, def.Package)
+		if err != nil {
+			return nil, fmt.Errorf("error loading and flattening Atlas OpenAPI package %q: %w", def.Package, err)
+		}
+		return spec, nil
+	default:
+		spec, err := openapiLoader.LoadFlattened(ctx, def.Path)
+		if err != nil {
+			return nil, fmt.Errorf("error loading and flattening spec %q: %w", def.Path, err)
+		}
+		return spec, nil
+	}
 }

--- a/tools/openapi2crd/pkg/generator/generator_test.go
+++ b/tools/openapi2crd/pkg/generator/generator_test.go
@@ -268,6 +268,54 @@ func TestGeneratorGenerate(t *testing.T) {
 	}
 }
 
+func TestLoadOpenAPISpec(t *testing.T) {
+	expected := &openapi3.T{OpenAPI: "3.0.0"}
+
+	t.Run("path without flatten calls Load", func(t *testing.T) {
+		loader := config.NewLoaderMock(t)
+		loader.EXPECT().Load(context.Background(), "spec.yaml").Return(expected, nil)
+		atlas := config.NewLoaderMock(t)
+
+		def := v1alpha1.OpenAPIDefinition{Name: "v1", Path: "spec.yaml"}
+		got, err := loadOpenAPISpec(context.Background(), def, loader, atlas)
+		assert.NoError(t, err)
+		assert.Equal(t, expected, got)
+	})
+
+	t.Run("package without flatten calls atlas Load", func(t *testing.T) {
+		loader := config.NewLoaderMock(t)
+		atlas := config.NewLoaderMock(t)
+		atlas.EXPECT().Load(context.Background(), "go.example.com/pkg").Return(expected, nil)
+
+		def := v1alpha1.OpenAPIDefinition{Name: "v1", Package: "go.example.com/pkg"}
+		got, err := loadOpenAPISpec(context.Background(), def, loader, atlas)
+		assert.NoError(t, err)
+		assert.Equal(t, expected, got)
+	})
+
+	t.Run("path with flatten calls LoadFlattened", func(t *testing.T) {
+		loader := config.NewLoaderMock(t)
+		loader.EXPECT().LoadFlattened(context.Background(), "spec.yaml").Return(expected, nil)
+		atlas := config.NewLoaderMock(t)
+
+		def := v1alpha1.OpenAPIDefinition{Name: "v1", Path: "spec.yaml", Flatten: true}
+		got, err := loadOpenAPISpec(context.Background(), def, loader, atlas)
+		assert.NoError(t, err)
+		assert.Equal(t, expected, got)
+	})
+
+	t.Run("package with flatten calls atlas LoadFlattened", func(t *testing.T) {
+		loader := config.NewLoaderMock(t)
+		atlas := config.NewLoaderMock(t)
+		atlas.EXPECT().LoadFlattened(context.Background(), "go.example.com/pkg").Return(expected, nil)
+
+		def := v1alpha1.OpenAPIDefinition{Name: "v1", Package: "go.example.com/pkg", Flatten: true}
+		got, err := loadOpenAPISpec(context.Background(), def, loader, atlas)
+		assert.NoError(t, err)
+		assert.Equal(t, expected, got)
+	})
+}
+
 func baseCRD(crd *apiextensions.CustomResourceDefinition) {
 	crd.ObjectMeta = v1.ObjectMeta{
 		Name: "examples.test.com",


### PR DESCRIPTION
# Summary

Adds an OpenAPI spec flattening pipeline to the `openapi2crd` tool. This resolves `oneOf`/`anyOf`/`allOf`/discriminator compositions in the Atlas OpenAPI spec into flat object schemas before CRD generation, producing cleaner and more Kubernetes-native CRD output.

Key changes:
- New `flatten` package (`tools/openapi2crd/pkg/flatten/`) that transforms composed OpenAPI schemas into flat structures
- `LoadFlattened` method on the `Loader` interface and `KinOpenAPI`/`Atlas` implementations, with singleflight caching
- `Flatten` config flag on `OpenAPIDefinition` to opt-in per spec
- Generator integration: uses `LoadFlattened` when the config flag is set
- Comprehensive test coverage with golden-file testdata for all composition patterns (allOf, anyOf, oneOf, discriminator, inline allOf, etc.)

## Proof of Work

- `make unit-test` passes
- Golden-file tests cover: allOf, anyOf, oneOf, discriminator, inline_allof, additional_properties, array_items, synthetic_props

## Checklist
- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you checked for release_note changes?
- [x] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?