### PR TITLE
openapi2crd/flatten: fix nested enum oneOf not being merged

### DIFF
--- a/tools/openapi2crd/pkg/flatten/structural.go
+++ b/tools/openapi2crd/pkg/flatten/structural.go
@@ -74,6 +74,7 @@ func flattenInlineCompositions(root *yaml.Node, key string) {
 			}
 			children := resolveSequenceRefs(seq, root, key)
 			if len(children) > 0 && allHaveEnum(children) {
+				mergeEnums(m, children, key)
 				return
 			}
 			for _, item := range seq.Content {

--- a/tools/openapi2crd/pkg/flatten/testdata/inline_enum_oneof/golden.yaml
+++ b/tools/openapi2crd/pkg/flatten/testdata/inline_enum_oneof/golden.yaml
@@ -1,0 +1,24 @@
+paths:
+  /clusters:
+    get:
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RegionConfig"
+components:
+  schemas:
+    RegionConfig:
+      type: object
+      properties:
+        regionName:
+          description: Cloud provider region name.
+          enum:
+            - US_EAST_1
+            - US_WEST_2
+            - US_CENTRAL
+            - US_EAST
+            - US_EAST1
+            - US_WEST1
+          type: string

--- a/tools/openapi2crd/pkg/flatten/testdata/inline_enum_oneof/input.yaml
+++ b/tools/openapi2crd/pkg/flatten/testdata/inline_enum_oneof/input.yaml
@@ -1,0 +1,35 @@
+paths:
+  /clusters:
+    get:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RegionConfig'
+components:
+  schemas:
+    RegionConfig:
+      type: object
+      properties:
+        regionName:
+          description: Cloud provider region name.
+          oneOf:
+            - description: AWS Regions.
+              title: AWS Regions
+              type: string
+              enum:
+                - US_EAST_1
+                - US_WEST_2
+            - description: Azure Regions.
+              title: Azure Regions
+              type: string
+              enum:
+                - US_CENTRAL
+                - US_EAST
+            - description: GCP Regions.
+              title: GCP Regions
+              type: string
+              enum:
+                - US_EAST1
+                - US_WEST1


### PR DESCRIPTION
# Summary

Fix a bug in `flattenInlineCompositions` where inline oneOf/anyOf compositions with enum-only children (e.g. cloud provider region lists split by provider) were detected but not merged. The early return skipped the `mergeEnums` call, leaving the oneOf intact instead of collapsing the enum variants into a single unified list.

This pattern appears in the Atlas OpenAPI spec for region name fields, where each cloud provider's regions are a separate oneOf variant.

## Proof of Work

- `cd tools/openapi2crd && go test ./...` passes
- Golden-file test case `inline_enum_oneof` added, reproducing the Atlas region pattern

## Checklist
- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you checked for release_note changes?
- [x] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?