### PR TITLE
Fix flexcluster test cleanup

### DIFF
--- a/test/e2e2/flexcluster_test.go
+++ b/test/e2e2/flexcluster_test.go
@@ -119,7 +119,7 @@ var _ = Describe("FlexCluster CRUD", Ordered, Label("flexcluster"), func() {
 				Eventually(func(g Gomega) error {
 					err := kubeClient.Get(ctx, client.ObjectKeyFromObject(testGroup), testGroup)
 					return err
-				}).WithContext(ctx).WithTimeout(5 * time.Minute).WithPolling(5 * time.Second).NotTo(Succeed())
+				}).WithContext(ctx).WithTimeout(10 * time.Minute).WithPolling(5 * time.Second).NotTo(Succeed())
 			}
 		})
 		By("Clean up shared group namespace", func() {
@@ -144,6 +144,21 @@ var _ = Describe("FlexCluster CRUD", Ordered, Label("flexcluster"), func() {
 	_ = AfterEach(func() {
 		if kubeClient == nil {
 			return
+		}
+		// Explicitly delete remaining FlexClusters before removing the namespace.
+		// The namespace deletion timeout is short; if a FlexCluster finalizer is still
+		// waiting on Atlas (cluster deletion can take several minutes), the namespace
+		// hangs and AfterAll then finds the Atlas group still occupied → 409 on group DELETE.
+		flexList := &apiv1.FlexClusterList{}
+		if err := kubeClient.List(ctx, flexList, client.InNamespace(testNamespace.Name)); err == nil {
+			for i := range flexList.Items {
+				_ = kubeClient.Delete(ctx, &flexList.Items[i])
+			}
+			Eventually(func(g Gomega) {
+				remaining := &apiv1.FlexClusterList{}
+				g.Expect(kubeClient.List(ctx, remaining, client.InNamespace(testNamespace.Name))).To(Succeed())
+				g.Expect(remaining.Items).To(BeEmpty())
+			}).WithContext(ctx).WithTimeout(10 * time.Minute).WithPolling(10 * time.Second).Should(Succeed())
 		}
 		Expect(
 			kubeClient.Delete(ctx, testNamespace),


### PR DESCRIPTION
# Summary

This should unblock CI tests when Cloud QA takes longer to remove flex clusters such as:
https://github.com/mongodb/mongodb-atlas-kubernetes/actions/runs/24698195002/job/72273240528

## Proof of Work

E2e2 should pass clean.

## Checklist
- [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?

