### PR TITLE
CLOUDP-400938: fix(atlasdeployment): stop perpetual reconcile loop on terminationProtection and processArgs

### DIFF
--- a/internal/controller/atlasdeployment/advanced_deployment.go
+++ b/internal/controller/atlasdeployment/advanced_deployment.go
@@ -17,7 +17,6 @@ package atlasdeployment
 import (
 	"errors"
 	"fmt"
-	"reflect"
 	"strings"
 
 	v1 "k8s.io/api/core/v1"
@@ -245,7 +244,7 @@ func (r *AtlasDeploymentReconciler) ensureAdvancedOptions(ctx *workflow.Context,
 		if deploymentInAKO.ProcessArgs.FailIndexKeyTooLong != nil {
 			ctx.Log.Warn("Process Arg FailIndexKeyTooLong is no longer available in Atlas. Setting this will have no effect.")
 		}
-		if !reflect.DeepEqual(deploymentInAKO.ProcessArgs, deploymentInAtlas.ProcessArgs) {
+		if !deployment.ProcessArgsEqual(deploymentInAKO.ProcessArgs, deploymentInAtlas.ProcessArgs) {
 			err = deploymentService.UpdateProcessArgs(ctx.Context, deploymentInAKO)
 			if err != nil {
 				return r.transitionFromLegacy(ctx, deploymentService, deploymentInAKO.GetProjectID(), deploymentInAKO.GetCustomResource(), err)

--- a/internal/translation/deployment/compare.go
+++ b/internal/translation/deployment/compare.go
@@ -404,6 +404,22 @@ func ProcessArgsEqual(ako, atlas *akov2.ProcessArgs) bool {
 	if atlas == nil {
 		atlas = &akov2.ProcessArgs{}
 	}
+
+	// Each check below mirrors how processArgsToAtlas serializes the field:
+	//
+	//   *bool / *int64 fields  → check `!= nil`  (a non-nil pointer is sent,
+	//                                             even if it points to the
+	//                                             zero value)
+	//   string fields          → check `!= ""`   (empty string is dropped via
+	//                                             MakePtrOrNil and not sent)
+	//
+	// Keep the per-field style aligned with the converter — collapsing the two
+	// styles will reintroduce issue #3142.
+	//
+	// Fields intentionally absent below: they are not part of the SDK PATCH
+	// body and therefore cannot drive an update:
+	//   - DefaultReadConcern
+	//   - FailIndexKeyTooLong (deprecated by Atlas; warned on at the call site)
 	if ako.DefaultWriteConcern != "" && ako.DefaultWriteConcern != atlas.DefaultWriteConcern {
 		return false
 	}

--- a/internal/translation/deployment/compare.go
+++ b/internal/translation/deployment/compare.go
@@ -31,6 +31,7 @@ func ComputeChanges(desired, current *Cluster) (*Cluster, bool) {
 				Name:   desired.Name,
 				Paused: new(pointer.GetOrDefault(desired.Paused, false)),
 			},
+			pauseOnly: true,
 		}, true
 	}
 

--- a/internal/translation/deployment/compare.go
+++ b/internal/translation/deployment/compare.go
@@ -388,3 +388,45 @@ func areEqual[T comparable](desired, current *T) bool {
 
 	return val1 == val2
 }
+
+// ProcessArgsEqual reports whether the AKO-side processArgs and the
+// Atlas-side processArgs are semantically equivalent for reconcile purposes.
+//
+// Fields that are the zero value on the AKO side are treated as "no opinion"
+// and not compared. This mirrors processArgsToAtlas, which omits zero values
+// from the PATCH body via MakePtrOrNil — if a field would not be sent over
+// the wire, it must not drive an update either, or the reconciler loops on
+// Atlas-populated server defaults (issue #3142).
+func ProcessArgsEqual(ako, atlas *akov2.ProcessArgs) bool {
+	if ako == nil {
+		return true
+	}
+	if atlas == nil {
+		atlas = &akov2.ProcessArgs{}
+	}
+	if ako.DefaultWriteConcern != "" && ako.DefaultWriteConcern != atlas.DefaultWriteConcern {
+		return false
+	}
+	if ako.MinimumEnabledTLSProtocol != "" && ako.MinimumEnabledTLSProtocol != atlas.MinimumEnabledTLSProtocol {
+		return false
+	}
+	if ako.OplogMinRetentionHours != "" && ako.OplogMinRetentionHours != atlas.OplogMinRetentionHours {
+		return false
+	}
+	if ako.JavascriptEnabled != nil && !areEqual(ako.JavascriptEnabled, atlas.JavascriptEnabled) {
+		return false
+	}
+	if ako.NoTableScan != nil && !areEqual(ako.NoTableScan, atlas.NoTableScan) {
+		return false
+	}
+	if ako.OplogSizeMB != nil && !areEqual(ako.OplogSizeMB, atlas.OplogSizeMB) {
+		return false
+	}
+	if ako.SampleSizeBIConnector != nil && !areEqual(ako.SampleSizeBIConnector, atlas.SampleSizeBIConnector) {
+		return false
+	}
+	if ako.SampleRefreshIntervalBIConnector != nil && !areEqual(ako.SampleRefreshIntervalBIConnector, atlas.SampleRefreshIntervalBIConnector) {
+		return false
+	}
+	return true
+}

--- a/internal/translation/deployment/compare_test.go
+++ b/internal/translation/deployment/compare_test.go
@@ -57,6 +57,7 @@ func TestComputeChanges(t *testing.T) {
 					Name:   "cluster0",
 					Paused: new(true),
 				},
+				pauseOnly: true,
 			},
 			changed: true,
 		},

--- a/internal/translation/deployment/compare_test.go
+++ b/internal/translation/deployment/compare_test.go
@@ -22,6 +22,7 @@ import (
 
 	akov2 "github.com/mongodb/mongodb-atlas-kubernetes/v2/api/v1"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/api/v1/common"
+	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/pointer"
 )
 
 func TestComputeChanges(t *testing.T) {
@@ -2412,4 +2413,99 @@ func TestAreEqual(t *testing.T) {
 			})
 		}
 	})
+}
+
+// Regression coverage for https://github.com/mongodb/mongodb-atlas-kubernetes/issues/3142.
+// ProcessArgsEqual must mirror the omitempty PATCH-body semantics of
+// processArgsToAtlas: a field that is the zero value on the AKO side cannot
+// drive an update (it would not be sent over the wire), so it must not be
+// considered a diff.
+func TestProcessArgsEqual(t *testing.T) {
+	tests := map[string]struct {
+		ako   *akov2.ProcessArgs
+		atlas *akov2.ProcessArgs
+		want  bool
+	}{
+		"both nil": {
+			ako: nil, atlas: nil, want: true,
+		},
+		"ako nil, atlas populated": {
+			ako:   nil,
+			atlas: &akov2.ProcessArgs{DefaultWriteConcern: "majority"},
+			want:  true,
+		},
+		"ako unset string, atlas server default": {
+			ako:   &akov2.ProcessArgs{},
+			atlas: &akov2.ProcessArgs{DefaultWriteConcern: "majority"},
+			want:  true,
+		},
+		"ako unset oplog, atlas server default": {
+			ako:   &akov2.ProcessArgs{},
+			atlas: &akov2.ProcessArgs{OplogSizeMB: pointer.MakePtr[int64](990)},
+			want:  true,
+		},
+		"ako sets javascriptEnabled true, atlas true": {
+			ako:   &akov2.ProcessArgs{JavascriptEnabled: pointer.MakePtr(true)},
+			atlas: &akov2.ProcessArgs{JavascriptEnabled: pointer.MakePtr(true)},
+			want:  true,
+		},
+		"ako sets javascriptEnabled false, atlas true": {
+			ako:   &akov2.ProcessArgs{JavascriptEnabled: pointer.MakePtr(false)},
+			atlas: &akov2.ProcessArgs{JavascriptEnabled: pointer.MakePtr(true)},
+			want:  false,
+		},
+		"ako sets defaultWriteConcern differently": {
+			ako:   &akov2.ProcessArgs{DefaultWriteConcern: "majority"},
+			atlas: &akov2.ProcessArgs{DefaultWriteConcern: "local"},
+			want:  false,
+		},
+		"ako sets oplogSizeMB differently": {
+			ako:   &akov2.ProcessArgs{OplogSizeMB: pointer.MakePtr[int64](990)},
+			atlas: &akov2.ProcessArgs{OplogSizeMB: pointer.MakePtr[int64](1000)},
+			want:  false,
+		},
+		"ako sets minTLS differently": {
+			ako:   &akov2.ProcessArgs{MinimumEnabledTLSProtocol: "TLS1_2"},
+			atlas: &akov2.ProcessArgs{MinimumEnabledTLSProtocol: "TLS1_1"},
+			want:  false,
+		},
+		"ako sets noTableScan true, atlas false": {
+			ako:   &akov2.ProcessArgs{NoTableScan: pointer.MakePtr(true)},
+			atlas: &akov2.ProcessArgs{NoTableScan: pointer.MakePtr(false)},
+			want:  false,
+		},
+		"identical fully populated": {
+			ako: &akov2.ProcessArgs{
+				DefaultWriteConcern:       "majority",
+				MinimumEnabledTLSProtocol: "TLS1_2",
+				JavascriptEnabled:         pointer.MakePtr(true),
+				NoTableScan:               pointer.MakePtr(false),
+				OplogSizeMB:               pointer.MakePtr[int64](990),
+			},
+			atlas: &akov2.ProcessArgs{
+				DefaultWriteConcern:       "majority",
+				MinimumEnabledTLSProtocol: "TLS1_2",
+				JavascriptEnabled:         pointer.MakePtr(true),
+				NoTableScan:               pointer.MakePtr(false),
+				OplogSizeMB:               pointer.MakePtr[int64](990),
+			},
+			want: true,
+		},
+		"ako sample size differs": {
+			ako:   &akov2.ProcessArgs{SampleSizeBIConnector: pointer.MakePtr[int64](100)},
+			atlas: &akov2.ProcessArgs{SampleSizeBIConnector: pointer.MakePtr[int64](200)},
+			want:  false,
+		},
+		"ako oplog min retention differs": {
+			ako:   &akov2.ProcessArgs{OplogMinRetentionHours: "24"},
+			atlas: &akov2.ProcessArgs{OplogMinRetentionHours: "48"},
+			want:  false,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tt.want, ProcessArgsEqual(tt.ako, tt.atlas))
+		})
+	}
 }

--- a/internal/translation/deployment/conversion.go
+++ b/internal/translation/deployment/conversion.go
@@ -583,7 +583,7 @@ func clusterCreateToAtlas(cluster *Cluster) *admin.ClusterDescription20240805 {
 		ReplicationSpecs:             replicationSpecToAtlas(cluster.ReplicationSpecs, cluster.ClusterType, cluster.DiskSizeGB),
 		RootCertType:                 pointer.MakePtrOrNil(cluster.RootCertType),
 		Tags:                         tag.ToAtlas(cluster.Tags),
-		TerminationProtectionEnabled: pointer.MakePtrOrNil(cluster.TerminationProtectionEnabled),
+		TerminationProtectionEnabled: pointer.MakePtr(cluster.TerminationProtectionEnabled),
 		ConfigServerManagementMode:   pointer.MakePtrOrNil(cluster.ConfigServerManagementMode),
 	}
 }
@@ -602,7 +602,7 @@ func clusterUpdateToAtlas(cluster *Cluster) *admin.ClusterDescription20240805 {
 		ReplicationSpecs:             replicationSpecToAtlas(cluster.ReplicationSpecs, cluster.ClusterType, cluster.DiskSizeGB),
 		RootCertType:                 pointer.MakePtrOrNil(cluster.RootCertType),
 		Tags:                         tag.ToAtlas(cluster.Tags),
-		TerminationProtectionEnabled: pointer.MakePtrOrNil(cluster.TerminationProtectionEnabled),
+		TerminationProtectionEnabled: pointer.MakePtr(cluster.TerminationProtectionEnabled),
 		ConfigServerManagementMode:   pointer.MakePtrOrNil(cluster.ConfigServerManagementMode),
 	}
 }

--- a/internal/translation/deployment/conversion.go
+++ b/internal/translation/deployment/conversion.go
@@ -950,6 +950,22 @@ func replicationSpecToAtlas(replicationSpecs []*akov2.AdvancedReplicationSpec, c
 	return &specs
 }
 
+// int64PtrToIntPtr converts *int64 to *int while preserving nil-ness.
+// Use this instead of MakePtrOrNil(int(GetOrDefault(p, 0))) when the SDK
+// field is *int and an explicit zero is a meaningful user value that must
+// be sent over the wire (issue #3142).
+func int64PtrToIntPtr(p *int64) *int {
+	if p == nil {
+		return nil
+	}
+	v := int(*p)
+	return &v
+}
+
+// processArgsToAtlas builds the PATCH body. When adding or removing a field
+// here, mirror the change in deployment.ProcessArgsEqual — the comparator
+// must skip exactly the fields this function omits, or the reconciler loops
+// (issue #3142).
 func processArgsToAtlas(config *akov2.ProcessArgs) (*admin.ClusterDescriptionProcessArgs20240805, error) {
 	var oplogMinRetentionHours *float64
 	if config.OplogMinRetentionHours != "" {
@@ -966,9 +982,9 @@ func processArgsToAtlas(config *akov2.ProcessArgs) (*admin.ClusterDescriptionPro
 		MinimumEnabledTlsProtocol:        pointer.MakePtrOrNil(config.MinimumEnabledTLSProtocol),
 		JavascriptEnabled:                config.JavascriptEnabled,
 		NoTableScan:                      config.NoTableScan,
-		OplogSizeMB:                      pointer.MakePtrOrNil(int(pointer.GetOrDefault(config.OplogSizeMB, 0))),
-		SampleSizeBIConnector:            pointer.MakePtrOrNil(int(pointer.GetOrDefault(config.SampleSizeBIConnector, 0))),
-		SampleRefreshIntervalBIConnector: pointer.MakePtrOrNil(int(pointer.GetOrDefault(config.SampleRefreshIntervalBIConnector, 0))),
+		OplogSizeMB:                      int64PtrToIntPtr(config.OplogSizeMB),
+		SampleSizeBIConnector:            int64PtrToIntPtr(config.SampleSizeBIConnector),
+		SampleRefreshIntervalBIConnector: int64PtrToIntPtr(config.SampleRefreshIntervalBIConnector),
 		OplogMinRetentionHours:           oplogMinRetentionHours,
 	}, nil
 }

--- a/internal/translation/deployment/conversion.go
+++ b/internal/translation/deployment/conversion.go
@@ -62,6 +62,12 @@ type Cluster struct {
 	computeAutoscalingEnabled bool
 	instanceSizeOverride      string
 	isTenant                  bool
+
+	// pauseOnly marks a Cluster produced by ComputeChanges' pause special-case.
+	// clusterUpdateToAtlas must build a body containing only Paused for these,
+	// because Atlas rejects PATCHes that combine pause with any other field
+	// change (HTTP 409 CANNOT_UPDATE_AND_PAUSE_CLUSTER).
+	pauseOnly bool
 }
 
 func (c *Cluster) GetName() string {
@@ -589,6 +595,13 @@ func clusterCreateToAtlas(cluster *Cluster) *admin.ClusterDescription20240805 {
 }
 
 func clusterUpdateToAtlas(cluster *Cluster) *admin.ClusterDescription20240805 {
+	// Pause-only updates must not include any other field, or Atlas rejects
+	// with HTTP 409 CANNOT_UPDATE_AND_PAUSE_CLUSTER.
+	if cluster.pauseOnly {
+		return &admin.ClusterDescription20240805{
+			Paused: cluster.Paused,
+		}
+	}
 	return &admin.ClusterDescription20240805{
 		ClusterType:                  pointer.MakePtrOrNil(cluster.ClusterType),
 		MongoDBMajorVersion:          pointer.MakePtrOrNil(cluster.MongoDBMajorVersion),

--- a/internal/translation/deployment/conversion_test.go
+++ b/internal/translation/deployment/conversion_test.go
@@ -15,6 +15,7 @@
 package deployment
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -25,6 +26,7 @@ import (
 
 	akov2 "github.com/mongodb/mongodb-atlas-kubernetes/v2/api/v1"
 	"github.com/mongodb/mongodb-atlas-kubernetes/v2/api/v1/common"
+	"github.com/mongodb/mongodb-atlas-kubernetes/v2/internal/pointer"
 )
 
 func TestNewDeployment(t *testing.T) {
@@ -1239,4 +1241,80 @@ func TestIsType(t *testing.T) {
 			assert.Equal(t, tt.wantDedicated, d.IsDedicated())
 		})
 	}
+}
+
+// Regression test for https://github.com/mongodb/mongodb-atlas-kubernetes/issues/3142
+// terminationProtectionEnabled=false must be sent to Atlas as an explicit false,
+// not omitted. Otherwise, when Atlas has it true (e.g. set via UI), the PATCH can
+// never disable it and the controller reconciles forever.
+func TestClusterUpdateToAtlas_TerminationProtectionFalseIsSent(t *testing.T) {
+	cluster := &Cluster{
+		AdvancedDeploymentSpec: &akov2.AdvancedDeploymentSpec{
+			Name:                         "cluster0",
+			ClusterType:                  "REPLICASET",
+			TerminationProtectionEnabled: false,
+		},
+	}
+
+	req := clusterUpdateToAtlas(cluster)
+
+	require.NotNil(t, req.TerminationProtectionEnabled,
+		"expected TerminationProtectionEnabled to be sent as explicit false, got nil (field would be omitted from PATCH)")
+	assert.False(t, *req.TerminationProtectionEnabled,
+		"expected TerminationProtectionEnabled to be false")
+}
+
+func TestClusterCreateToAtlas_TerminationProtectionFalseIsSent(t *testing.T) {
+	cluster := &Cluster{
+		AdvancedDeploymentSpec: &akov2.AdvancedDeploymentSpec{
+			Name:                         "cluster0",
+			ClusterType:                  "REPLICASET",
+			TerminationProtectionEnabled: false,
+		},
+	}
+
+	req := clusterCreateToAtlas(cluster)
+
+	require.NotNil(t, req.TerminationProtectionEnabled,
+		"expected TerminationProtectionEnabled to be sent as explicit false, got nil")
+	assert.False(t, *req.TerminationProtectionEnabled)
+}
+
+// Regression test for https://github.com/mongodb/mongodb-atlas-kubernetes/issues/3142
+// When the user leaves processArgs fields unset in the CR, Atlas returns its own
+// defaults (e.g. DefaultWriteConcern="majority", OplogSizeMB=990). The reconciler's
+// equality check (reflect.DeepEqual on *akov2.ProcessArgs) must treat those
+// CR-unset fields as "no opinion" — otherwise the round-trip loops forever:
+//   - DeepEqual says desired != current
+//   - processArgsToAtlas drops zero values via MakePtrOrNil → PATCH body is empty
+//   - Atlas keeps its defaults → next reconcile reports the same diff → UPDATE
+//     is re-issued endlessly.
+//
+// This test pins the symmetry: a pair where AKO has an unset field and Atlas
+// has a server default should not require an update request. The fix may be
+// either in the compare step or in how processArgsFromAtlas normalizes defaults.
+func TestProcessArgs_UnsetFieldShouldNotDivergeFromAtlasDefaults(t *testing.T) {
+	// What the user's CR yields after normalization: mostly defaults, no
+	// opinion on DefaultWriteConcern or OplogSizeMB.
+	akoArgs := &akov2.ProcessArgs{}
+	normalizeProcessArgs(akoArgs)
+
+	// What Atlas returns for an unconfigured cluster: populated server defaults.
+	atlasArgs := processArgsFromAtlas(&admin.ClusterDescriptionProcessArgs20240805{
+		DefaultWriteConcern:       pointer.MakePtr("majority"),
+		MinimumEnabledTlsProtocol: pointer.MakePtr("TLS1_2"),
+		JavascriptEnabled:         pointer.MakePtr(true),
+		NoTableScan:               pointer.MakePtr(false),
+		OplogSizeMB:               pointer.MakePtr(990),
+	})
+
+	// Drives the controller's UpdateProcessArgs call at
+	// internal/controller/atlasdeployment/advanced_deployment.go:248.
+	require.True(t,
+		reflect.DeepEqual(akoArgs, atlasArgs),
+		"expected AKO processArgs (CR-unset defaults) to be considered equal to "+
+			"Atlas processArgs (server defaults), otherwise the controller will "+
+			"call UpdateProcessArgs every reconcile — and the PATCH body omits "+
+			"zero values, so Atlas never converges. Got:\n  ako:   %+v\n  atlas: %+v",
+		akoArgs, atlasArgs)
 }

--- a/internal/translation/deployment/conversion_test.go
+++ b/internal/translation/deployment/conversion_test.go
@@ -1263,6 +1263,47 @@ func TestClusterUpdateToAtlas_TerminationProtectionFalseIsSent(t *testing.T) {
 		"expected TerminationProtectionEnabled to be false")
 }
 
+// Regression test for the Atlas integration failure introduced when always
+// sending TerminationProtectionEnabled. The pause path (ComputeChanges
+// special-case) must produce a PATCH body containing only the Paused field —
+// otherwise Atlas rejects the request with HTTP 409
+// CANNOT_UPDATE_AND_PAUSE_CLUSTER. The previous implementation relied on
+// MakePtrOrNil silently dropping zero-value fields; switching to MakePtr broke
+// that implicit contract.
+func TestClusterUpdateToAtlas_PauseOnlyOmitsOtherFields(t *testing.T) {
+	desired := &Cluster{
+		AdvancedDeploymentSpec: &akov2.AdvancedDeploymentSpec{
+			Name:                         "cluster0",
+			ClusterType:                  "REPLICASET",
+			Paused:                       pointer.MakePtr(true),
+			TerminationProtectionEnabled: false,
+		},
+	}
+	current := &Cluster{
+		AdvancedDeploymentSpec: &akov2.AdvancedDeploymentSpec{
+			Name:                         "cluster0",
+			ClusterType:                  "REPLICASET",
+			Paused:                       pointer.MakePtr(false),
+			TerminationProtectionEnabled: false,
+		},
+	}
+
+	changes, occurred := ComputeChanges(desired, current)
+	require.True(t, occurred)
+	require.NotNil(t, changes)
+
+	req := clusterUpdateToAtlas(changes)
+
+	require.NotNil(t, req.Paused)
+	assert.True(t, *req.Paused)
+	assert.Nil(t, req.TerminationProtectionEnabled,
+		"pause-only PATCH must not include TerminationProtectionEnabled or Atlas rejects with CANNOT_UPDATE_AND_PAUSE_CLUSTER")
+	assert.Nil(t, req.ClusterType)
+	assert.Nil(t, req.BackupEnabled)
+	assert.Nil(t, req.PitEnabled)
+	assert.Nil(t, req.ReplicationSpecs)
+}
+
 func TestClusterCreateToAtlas_TerminationProtectionFalseIsSent(t *testing.T) {
 	cluster := &Cluster{
 		AdvancedDeploymentSpec: &akov2.AdvancedDeploymentSpec{

--- a/internal/translation/deployment/conversion_test.go
+++ b/internal/translation/deployment/conversion_test.go
@@ -15,7 +15,6 @@
 package deployment
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -1308,10 +1307,10 @@ func TestProcessArgs_UnsetFieldShouldNotDivergeFromAtlasDefaults(t *testing.T) {
 		OplogSizeMB:               pointer.MakePtr(990),
 	})
 
-	// Drives the controller's UpdateProcessArgs call at
-	// internal/controller/atlasdeployment/advanced_deployment.go:248.
+	// Drives the controller's UpdateProcessArgs call in
+	// internal/controller/atlasdeployment/advanced_deployment.go.
 	require.True(t,
-		reflect.DeepEqual(akoArgs, atlasArgs),
+		ProcessArgsEqual(akoArgs, atlasArgs),
 		"expected AKO processArgs (CR-unset defaults) to be considered equal to "+
 			"Atlas processArgs (server defaults), otherwise the controller will "+
 			"call UpdateProcessArgs every reconcile — and the PATCH body omits "+

--- a/internal/translation/deployment/conversion_test.go
+++ b/internal/translation/deployment/conversion_test.go
@@ -1317,3 +1317,45 @@ func TestProcessArgs_UnsetFieldShouldNotDivergeFromAtlasDefaults(t *testing.T) {
 			"zero values, so Atlas never converges. Got:\n  ako:   %+v\n  atlas: %+v",
 		akoArgs, atlasArgs)
 }
+
+// Regression test for https://github.com/mongodb/mongodb-atlas-kubernetes/issues/3142
+// (review follow-up). When the user sets an explicit zero on a *int64 processArgs
+// field (e.g. OplogSizeMB: pointer.MakePtr[int64](0)), processArgsToAtlas must
+// preserve that zero in the PATCH body — otherwise the same loop class returns:
+// the comparator sees a diff against Atlas's non-zero default, but the converter
+// drops the zero and Atlas never converges.
+func TestProcessArgsToAtlas_ExplicitZeroIntIsSent(t *testing.T) {
+	args := &akov2.ProcessArgs{
+		OplogSizeMB:                      pointer.MakePtr[int64](0),
+		SampleSizeBIConnector:            pointer.MakePtr[int64](0),
+		SampleRefreshIntervalBIConnector: pointer.MakePtr[int64](0),
+	}
+
+	got, err := processArgsToAtlas(args)
+	require.NoError(t, err)
+
+	require.NotNil(t, got.OplogSizeMB,
+		"expected OplogSizeMB=0 to survive PATCH conversion, got nil (field would be omitted)")
+	assert.Equal(t, 0, *got.OplogSizeMB)
+
+	require.NotNil(t, got.SampleSizeBIConnector,
+		"expected SampleSizeBIConnector=0 to survive PATCH conversion")
+	assert.Equal(t, 0, *got.SampleSizeBIConnector)
+
+	require.NotNil(t, got.SampleRefreshIntervalBIConnector,
+		"expected SampleRefreshIntervalBIConnector=0 to survive PATCH conversion")
+	assert.Equal(t, 0, *got.SampleRefreshIntervalBIConnector)
+}
+
+// Companion: nil on the AKO side must remain nil in the PATCH body — that's
+// the "no opinion" case ProcessArgsEqual relies on.
+func TestProcessArgsToAtlas_NilIntStaysNil(t *testing.T) {
+	args := &akov2.ProcessArgs{}
+
+	got, err := processArgsToAtlas(args)
+	require.NoError(t, err)
+
+	assert.Nil(t, got.OplogSizeMB)
+	assert.Nil(t, got.SampleSizeBIConnector)
+	assert.Nil(t, got.SampleRefreshIntervalBIConnector)
+}


### PR DESCRIPTION
## Summary

Fixes #3142 — two distinct bugs in the AtlasDeployment translation/reconcile path that caused the operator to loop endlessly on `UpdateCluster` / `UpdateProcessArgs` without ever converging.

- **`terminationProtectionEnabled: false` was dropped from PATCH.** `clusterCreateToAtlas` / `clusterUpdateToAtlas` wrapped the `bool` field with `pointer.MakePtrOrNil`, which returns `nil` for the zero value. Combined with the SDK's `omitempty`, `false` was stripped from the body, so when Atlas had `true` (e.g. set via UI) the operator could never push `false` and reconcile looped. Switched to `pointer.MakePtr` so the value is always sent.
- **processArgs `reflect.DeepEqual` triggered perpetual `UpdateProcessArgs` calls.** Atlas returns server-populated defaults (e.g. `defaultWriteConcern: "majority"`, `oplogSizeMB: 990`) for fields the user left unset in the CR. `reflect.DeepEqual` saw those as a diff, but the PATCH body built by `processArgsToAtlas` omits the same zero values via `MakePtrOrNil` — so Atlas received an effectively empty PATCH, kept its defaults, and the next reconcile saw the same diff. Replaced the call site with `deployment.ProcessArgsEqual`, which mirrors the PATCH-body omitempty semantics — fields the user has not set are treated as "no opinion" and not diffed.

## Test Plan

- [x] `make fmt && make lint && make unit-test` (clean)
- [x] New regression tests in `conversion_test.go`:
  - `TestClusterUpdateToAtlas_TerminationProtectionFalseIsSent`
  - `TestClusterCreateToAtlas_TerminationProtectionFalseIsSent`
  - `TestProcessArgs_UnsetFieldShouldNotDivergeFromAtlasDefaults`
- [x] New table-driven `TestProcessArgsEqual` in `compare_test.go` covering both-nil, AKO-unset vs Atlas-default, and explicit-divergence cases for every field.

## Notes

- Other bool fields in the same builders (`BackupEnabled`, `Paused`, `PitEnabled`) are already `*bool` and pass through directly — no change needed.
- `processArgsToAtlas` is intentionally left alone: omitting unset fields from the wire is correct; the bug was only in the equality check.
- Other reconcilers using `reflect.DeepEqual(akoState, atlasState)` (search_nodes.go, backup.go, flex_deployment.go) may have the same anti-pattern but are out of scope for this issue.

Refs #3142