### PR TITLE
CLOUDP-403040: Fix import flow for Databaseuser and FlexCLuster

### DIFF
--- a/internal/generated/controller/databaseuser/handler_v20250312.go
+++ b/internal/generated/controller/databaseuser/handler_v20250312.go
@@ -90,12 +90,26 @@ func (h *Handlerv20250312) HandleImportRequested(ctx context.Context, databaseus
 		return result.Error(state.StateImportRequested, errors.New("missing annotation mongodb.com/external-id"))
 	}
 
-	groupID, databaseName, username, err := parseExternalID(externalID)
+	databaseName, username, err := parseExternalID(externalID)
 	if err != nil {
 		return result.Error(state.StateImportRequested, err)
 	}
 
-	response, _, err := h.atlasClient.DatabaseUsersApi.GetDatabaseUser(ctx, groupID, databaseName, username).Execute()
+	deps, err := h.getDependencies(ctx, databaseuser)
+	if err != nil {
+		return result.Error(state.StateInitial, fmt.Errorf("failed to resolve Cluster dependencies: %w", err))
+	}
+
+	params := &v20250312sdk.GetDatabaseUserApiParams{
+		DatabaseName: databaseName,
+		Username:     username,
+	}
+	err = h.translator.ToAPI(params, databaseuser, deps...)
+	if err != nil {
+		return result.Error(state.StateImportRequested, fmt.Errorf("failed to translate cluster API parameters to Atlas: %w", err))
+	}
+
+	response, _, err := h.atlasClient.DatabaseUsersApi.GetDatabaseUserWithParams(ctx, params).Execute()
 	if err != nil {
 		return result.Error(state.StateImportRequested, fmt.Errorf("failed to get DatabaseUser %q: %w", externalID, err))
 	}
@@ -455,11 +469,11 @@ func checkExpiry(databaseuser *akov2generated.DatabaseUser) (bool, error) {
 }
 
 // parseExternalID parses the mongodb.com/external-id annotation value.
-// Expected format: "groupId:databaseName:username".
-func parseExternalID(externalID string) (groupID, databaseName, username string, err error) {
-	parts := strings.SplitN(externalID, ":", 3)
-	if len(parts) != 3 || parts[0] == "" || parts[1] == "" || parts[2] == "" {
-		return "", "", "", fmt.Errorf("invalid mongodb.com/external-id %q: expected format \"groupId:databaseName:username\"", externalID)
+// Expected format: "databaseName:username".
+func parseExternalID(externalID string) (databaseName, username string, err error) {
+	parts := strings.SplitN(externalID, ":", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", fmt.Errorf("invalid mongodb.com/external-id %q: expected format \"databaseName:username\"", externalID)
 	}
-	return parts[0], parts[1], parts[2], nil
+	return parts[0], parts[1], nil
 }

--- a/internal/generated/controller/flexcluster/handler_v20250312.go
+++ b/internal/generated/controller/flexcluster/handler_v20250312.go
@@ -88,22 +88,34 @@ func (h *Handlerv20250312) HandleInitial(ctx context.Context, flexcluster *akov2
 
 // HandleImportRequested handles the importrequested state for version v20250312
 func (h *Handlerv20250312) HandleImportRequested(ctx context.Context, flexcluster *akov2generated.FlexCluster) (ctrlstate.Result, error) {
-	externalName, ok := flexcluster.GetAnnotations()["mongodb.com/external-name"]
+	id, ok := flexcluster.GetAnnotations()["mongodb.com/external-id"]
 	if !ok {
-		return result.Error(state.StateImportRequested, errors.New("missing mongodb.com/external-name"))
+		return result.Error(state.StateImportRequested, errors.New("missing annotation mongodb.com/external-id"))
 	}
 
-	externalGroupID, ok := flexcluster.GetAnnotations()["mongodb.com/external-group-id"]
-	if !ok {
-		return result.Error(state.StateImportRequested, errors.New("missing mongodb.com/external-group-id"))
-	}
-	flexClusterCopy := flexcluster.DeepCopy()
-	flexClusterCopy.Spec.V20250312.Entry.Name = externalName
-	flexClusterCopy.Spec.V20250312.GroupId = &externalGroupID
-	_, err := h.patchStatus(ctx, flexClusterCopy)
+	deps, err := h.getDependencies(ctx, flexcluster)
 	if err != nil {
-		return result.Error(state.StateImportRequested, err)
+		return result.Error(state.StateImportRequested, fmt.Errorf("failed to resolve FlexCluster dependencies: %w", err))
 	}
+
+	params := &v20250312sdk.GetFlexClusterApiParams{
+		Name: id,
+	}
+	err = h.translator.ToAPI(params, flexcluster, deps...)
+	if err != nil {
+		return result.Error(state.StateImportRequested, fmt.Errorf("failed to translate FlexCluster API parameters to Atlas: %w", err))
+	}
+
+	_, _, err = h.atlasClient.FlexClustersApi.GetFlexClusterWithParams(ctx, params).Execute()
+	if err != nil {
+		return result.Error(state.StateImportRequested, fmt.Errorf("failed to get FlexCluster with id %s: %w", id, err))
+	}
+
+	_, err = h.patchStatus(ctx, flexcluster)
+	if err != nil {
+		return result.Error(state.StateImportRequested, fmt.Errorf("failed to patch FlexCluster status: %w", err))
+	}
+
 	return result.NextState(state.StateImported, "Imported Flex Cluster.")
 }
 


### PR DESCRIPTION
# Summary

Refactors the import-requested state handling for two CRD controllers, DatabaseUser and FlexCluster, to align with the translator pattern used elsewhere in the scaffolded controllers.

**DatabaseUser (handler_v20250312.go)**

- Changed the mongodb.com/external-id annotation format from "groupId:databaseName:username" to "databaseName:username". The group ID is no longer embedded in the annotation; it is now resolved via the translator from the resource's dependencies (e.g. groupRef).
 

**FlexCluster (handler_v20250312.go)**

- Replaced two separate annotations (mongodb.com/external-name + mongodb.com/external-group-id) with a single mongodb.com/external-id annotation.
- Added Atlas API verification (GetFlexClusterWithParams) before patching status, ensuring the resource actually exists in Atlas before transitioning to the Imported state.

## Proof of Work

CI Pass

## Checklist
- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you checked for release_note changes?
- [x] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?