### PR TITLE
CLOUDP-403318: Centralize external-id annotation lookup across import handlers

### DIFF
--- a/internal/generated/controller/cluster/handler_v20250312.go
+++ b/internal/generated/controller/cluster/handler_v20250312.go
@@ -16,7 +16,6 @@ package cluster
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	v20250312sdk "go.mongodb.org/atlas-sdk/v20250312018/admin"
@@ -97,9 +96,9 @@ func (h *Handlerv20250312) HandleInitial(ctx context.Context, cluster *akov2gene
 
 // HandleImportRequested handles the importrequested state for version v20250312
 func (h *Handlerv20250312) HandleImportRequested(ctx context.Context, cluster *akov2generated.Cluster) (ctrlstate.Result, error) {
-	id, ok := cluster.GetAnnotations()["mongodb.com/external-id"]
-	if !ok {
-		return result.Error(state.StateImportRequested, errors.New("missing annotation mongodb.com/external-id"))
+	id, err := ctrlstate.GetExternalID(cluster)
+	if err != nil {
+		return result.Error(state.StateImportRequested, err)
 	}
 
 	deps, err := h.getDependencies(ctx, cluster)

--- a/internal/generated/controller/databaseuser/handler_v20250312.go
+++ b/internal/generated/controller/databaseuser/handler_v20250312.go
@@ -16,7 +16,6 @@ package databaseuser
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -85,9 +84,9 @@ func (h *Handlerv20250312) HandleInitial(ctx context.Context, databaseuser *akov
 // HandleImportRequested handles the importrequested state for version v20250312.
 // The annotation mongodb.com/external-id must be set to "groupId:databaseName:username".
 func (h *Handlerv20250312) HandleImportRequested(ctx context.Context, databaseuser *akov2generated.DatabaseUser) (ctrlstate.Result, error) {
-	externalID, ok := databaseuser.GetAnnotations()["mongodb.com/external-id"]
-	if !ok {
-		return result.Error(state.StateImportRequested, errors.New("missing annotation mongodb.com/external-id"))
+	externalID, err := ctrlstate.GetExternalID(databaseuser)
+	if err != nil {
+		return result.Error(state.StateImportRequested, err)
 	}
 
 	databaseName, username, err := parseExternalID(externalID)

--- a/internal/generated/controller/flexcluster/handler_v20250312.go
+++ b/internal/generated/controller/flexcluster/handler_v20250312.go
@@ -16,7 +16,6 @@ package flexcluster
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	v20250312sdk "go.mongodb.org/atlas-sdk/v20250312018/admin"
@@ -88,9 +87,9 @@ func (h *Handlerv20250312) HandleInitial(ctx context.Context, flexcluster *akov2
 
 // HandleImportRequested handles the importrequested state for version v20250312
 func (h *Handlerv20250312) HandleImportRequested(ctx context.Context, flexcluster *akov2generated.FlexCluster) (ctrlstate.Result, error) {
-	id, ok := flexcluster.GetAnnotations()["mongodb.com/external-id"]
-	if !ok {
-		return result.Error(state.StateImportRequested, errors.New("missing annotation mongodb.com/external-id"))
+	id, err := ctrlstate.GetExternalID(flexcluster)
+	if err != nil {
+		return result.Error(state.StateImportRequested, err)
 	}
 
 	deps, err := h.getDependencies(ctx, flexcluster)

--- a/internal/generated/controller/group/handler_v20250312.go
+++ b/internal/generated/controller/group/handler_v20250312.go
@@ -16,7 +16,6 @@ package group
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	v20250312sdk "go.mongodb.org/atlas-sdk/v20250312018/admin"
@@ -81,9 +80,9 @@ func (h *Handlerv20250312) HandleInitial(ctx context.Context, group *akov2genera
 
 // HandleImportRequested handles the importrequested state for version v20250312
 func (h *Handlerv20250312) HandleImportRequested(ctx context.Context, group *akov2generated.Group) (ctrlstate.Result, error) {
-	id, ok := group.GetAnnotations()["mongodb.com/external-id"]
-	if !ok {
-		return result.Error(state.StateImportRequested, errors.New("missing annotation mongodb.com/external-id"))
+	id, err := ctrlstate.GetExternalID(group)
+	if err != nil {
+		return result.Error(state.StateImportRequested, err)
 	}
 
 	response, _, err := h.atlasClient.ProjectsApi.GetGroup(ctx, id).Execute()

--- a/internal/generated/controller/ipaccesslistentry/handler_v20250312.go
+++ b/internal/generated/controller/ipaccesslistentry/handler_v20250312.go
@@ -85,9 +85,9 @@ func (h *Handlerv20250312) HandleInitial(ctx context.Context, ipaccesslistentry 
 // HandleImportRequested imports an existing Atlas IP access list entry.
 // The annotation mongodb.com/external-id must be set to the entry value (IP address, CIDR block or AWS security group)
 func (h *Handlerv20250312) HandleImportRequested(ctx context.Context, ipaccesslistentry *akov2generated.IPAccessListEntry) (ctrlstate.Result, error) {
-	entryValue, ok := ipaccesslistentry.GetAnnotations()["mongodb.com/external-id"]
-	if !ok || entryValue == "" {
-		return result.Error(state.StateImportRequested, errors.New("missing annotation mongodb.com/external-id: set it to the entry value (IP, CIDR, or AWS SG)"))
+	entryValue, err := ctrlstate.GetExternalID(ipaccesslistentry)
+	if err != nil {
+		return result.Error(state.StateImportRequested, err)
 	}
 
 	groupID, err := h.resolveGroupID(ctx, ipaccesslistentry)

--- a/pkg/controller/state/externalid.go
+++ b/pkg/controller/state/externalid.go
@@ -14,12 +14,19 @@
 
 package state
 
-import "strings"
+import (
+	"fmt"
 
-const (
-	AnnotationReapplyTimestamp = "mongodb.internal.com/reapply-timestamp"
-	AnnotationStateTracker     = "mongodb.internal.com/state-tracker"
-	AnnotationExternalID       = "mongodb.com/external-id"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var jsonPatchReplacer = strings.NewReplacer("/", "~1", "~", "~0")
+// GetExternalID reads the AnnotationExternalID annotation from obj.
+// Returns an error if the annotation is absent or empty.
+func GetExternalID(obj metav1.Object) (string, error) {
+	id, ok := obj.GetAnnotations()[AnnotationExternalID]
+	if !ok || id == "" {
+		return "", fmt.Errorf("missing annotation %s", AnnotationExternalID)
+	}
+
+	return id, nil
+}

--- a/pkg/controller/state/externalid_test.go
+++ b/pkg/controller/state/externalid_test.go
@@ -1,0 +1,62 @@
+// Copyright 2025 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package state_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	ctrlstate "github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/controller/state"
+)
+
+func TestGetExternalID(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		wantID      string
+		wantErrMsg  string
+	}{
+		{
+			name:        "returns id when annotation is present",
+			annotations: map[string]string{ctrlstate.AnnotationExternalID: "abc123"},
+			wantID:      "abc123",
+		},
+		{
+			name:       "returns error when annotation is missing",
+			wantErrMsg: ctrlstate.AnnotationExternalID,
+		},
+		{
+			name:        "returns error when annotation value is empty",
+			annotations: map[string]string{ctrlstate.AnnotationExternalID: ""},
+			wantErrMsg:  ctrlstate.AnnotationExternalID,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			obj := &metav1.ObjectMeta{Annotations: tc.annotations}
+			id, err := ctrlstate.GetExternalID(obj)
+			if tc.wantErrMsg != "" {
+				require.ErrorContains(t, err, tc.wantErrMsg)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantID, id)
+		})
+	}
+}


### PR DESCRIPTION
# Summary

The mongodb.com/external-id annotation key was hardcoded as a string literal in five separate HandleImportRequested methods across the generated controllers (group, cluster, flexcluster, databaseuser, ipaccesslistentry). Each handler duplicated the same fetch-and-validate pattern inline, with no shared constant and inconsistent empty-value handling.

## Proof of Work

CI Pass

## Checklist
- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you checked for release_note changes?
- [x] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?

