### PR TITLE
Bump Go to avoid vulnerabilities

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mongodb/mongodb-atlas-kubernetes/v2
 
-go 1.26.2
+go 1.26.3
 
 require (
 	cloud.google.com/go/kms v1.30.0

--- a/test/app/go.mod
+++ b/test/app/go.mod
@@ -1,6 +1,6 @@
 module github.com/mongodb/mongodb-atlas-kubernetes/test/app
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/gorilla/mux v1.8.0

--- a/tools/clean/go.mod
+++ b/tools/clean/go.mod
@@ -1,6 +1,6 @@
 module tools/clean
 
-go 1.26.2
+go 1.26.3
 
 require (
 	cloud.google.com/go/compute v1.61.0

--- a/tools/githubjobs/go.mod
+++ b/tools/githubjobs/go.mod
@@ -1,6 +1,6 @@
 module tools/githubjobs
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/google/go-github/v57 v57.0.0

--- a/tools/makejwt/go.mod
+++ b/tools/makejwt/go.mod
@@ -1,5 +1,5 @@
 module tools/makejwt
 
-go 1.26.2
+go 1.26.3
 
 require github.com/golang-jwt/jwt/v5 v5.3.1

--- a/tools/openapi2crd/go.mod
+++ b/tools/openapi2crd/go.mod
@@ -1,6 +1,6 @@
 module github.com/mongodb/mongodb-atlas-kubernetes/tools/openapi2crd
 
-go 1.26.2
+go 1.26.3
 
 tool (
 	github.com/daixiang0/gci

--- a/tools/openapi2crd/hack/tools/go.mod
+++ b/tools/openapi2crd/hack/tools/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/kind/hack/tools
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/golangci/golangci-lint v1.64.8

--- a/tools/scaffolder/go.mod
+++ b/tools/scaffolder/go.mod
@@ -1,6 +1,6 @@
 module github.com/mongodb/mongodb-atlas-kubernetes/tools/scaffolder
 
-go 1.26.2
+go 1.26.3
 
 // replace github.com/josvazg/crd2go => ../crd2go
 

--- a/tools/scandeprecation/go.mod
+++ b/tools/scandeprecation/go.mod
@@ -1,6 +1,6 @@
 module tools/scandeprecations
 
-go 1.26.2
+go 1.26.3
 
 require go.uber.org/zap v1.27.0
 

--- a/tools/toolbox/go.mod
+++ b/tools/toolbox/go.mod
@@ -1,6 +1,6 @@
 module toolbox
 
-go 1.26.2
+go 1.26.3
 
 tool (
 	fybrik.io/crdoc


### PR DESCRIPTION
# Summary

Bump go to avoid:
```
govulncheck found 4 non ignored vulnerabilities
Vulnerability #1: GO-2026-4982
Vulnerability #2: GO-2026-4980
Vulnerability #3: GO-2026-4971
Vulnerability #4: GO-2026-4918
```

## Proof of Work

CI works

## Checklist
- [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
