### PR TITLE
CLOUDP-405629: Removed K8S validations on Role field for the AtlasFederatedAuth CR

### DIFF
--- a/api/v1/atlasfederatedauth_types.go
+++ b/api/v1/atlasfederatedauth_types.go
@@ -129,8 +129,7 @@ type RoleMapping struct {
 type RoleAssignment struct {
 	// The Atlas project in the same org in which the role should be given.
 	ProjectName string `json:"projectName,omitempty"`
-	// The role in Atlas that should be given to group members.
-	// +kubebuilder:validation:Enum=ORG_MEMBER;ORG_READ_ONLY;ORG_BILLING_ADMIN;ORG_GROUP_CREATOR;ORG_OWNER;ORG_BILLING_READ_ONLY;GROUP_OWNER;GROUP_READ_ONLY;GROUP_DATA_ACCESS_ADMIN;GROUP_DATA_ACCESS_READ_ONLY;GROUP_DATA_ACCESS_READ_WRITE;GROUP_CLUSTER_MANAGER;GROUP_SEARCH_INDEX_EDITOR;GROUP_DATABASE_ACCESS_ADMIN;GROUP_BACKUP_MANAGER;GROUP_STREAM_PROCESSING_OWNER;ORG_STREAM_PROCESSING_ADMIN;GROUP_OBSERVABILITY_VIEWER
+	// The role in Atlas that should be given to group members. See https://www.mongodb.com/docs/atlas/reference/user-roles/ for allowed values
 	Role string `json:"role,omitempty"`
 }
 

--- a/docs/api-docs.md
+++ b/docs/api-docs.md
@@ -5563,11 +5563,9 @@ RoleMapping maps an external group from an identity provider to roles within Atl
         <td>false</td>
       </tr><tr>
         <td><b>role</b></td>
-        <td>enum</td>
+        <td>string</td>
         <td>
-          The role in Atlas that should be given to group members.<br/>
-          <br/>
-            <i>Enum</i>: ORG_MEMBER, ORG_READ_ONLY, ORG_BILLING_ADMIN, ORG_GROUP_CREATOR, ORG_OWNER, ORG_BILLING_READ_ONLY, GROUP_OWNER, GROUP_READ_ONLY, GROUP_DATA_ACCESS_ADMIN, GROUP_DATA_ACCESS_READ_ONLY, GROUP_DATA_ACCESS_READ_WRITE, GROUP_CLUSTER_MANAGER, GROUP_SEARCH_INDEX_EDITOR, GROUP_DATABASE_ACCESS_ADMIN, GROUP_BACKUP_MANAGER, GROUP_STREAM_PROCESSING_OWNER, ORG_STREAM_PROCESSING_ADMIN, GROUP_OBSERVABILITY_VIEWER<br/>
+          The role in Atlas that should be given to group members. See https://www.mongodb.com/docs/atlas/reference/user-roles/ for allowed values<br/>
         </td>
         <td>false</td>
       </tr></tbody>


### PR DESCRIPTION
# Summary

Removed K8S validaitons on Role field for the AtlasFederatedAuth CR

## Checklist
- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you checked for release_note changes?
- [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?

## Reminder (Please remove this when merging)
- Please try to Approve or Reject Changes the PR, keep PRs in review as short as possible
- Remember the following Communication Standards - use comment prefixes for clarity:
  * **blocking**: Must be addressed before approval.
  * **follow-up**: Can be addressed in a later PR or ticket.
  * **q**: Clarifying question.
  * **nit**: Non-blocking suggestions.
  * **note**: Side-note, non-actionable. Example: Praise 
  * --> no prefix is considered a question

