### PR TITLE
Re-request flex cluster deletion when Atlas returns non-DELETING state

### DIFF
--- a/internal/generated/controller/flexcluster/handler_v20250312.go
+++ b/internal/generated/controller/flexcluster/handler_v20250312.go
@@ -187,14 +187,22 @@ func (h *Handlerv20250312) HandleDeleting(ctx context.Context, flexcluster *akov
 		return result.Error(state.StateDeleting, fmt.Errorf("failed to translate flex api params: %w", err))
 	}
 
-	_, _, err = h.atlasClient.FlexClustersApi.GetFlexClusterWithParams(ctx, params).Execute()
+	atlasFlexCluster, _, err := h.atlasClient.FlexClustersApi.GetFlexClusterWithParams(ctx, params).Execute()
 	switch {
 	case v20250312sdk.IsErrorCode(err, "CLUSTER_NOT_FOUND"):
 		return result.NextState(state.StateDeleted, "Deleted")
 	case err != nil:
-		return result.Error(state.StateDeletionRequested, fmt.Errorf("failed to delete flexcluster: %w", err))
+		return result.Error(state.StateDeletionRequested, fmt.Errorf("failed to get flex cluster status: %w", err))
 	}
-	return result.NextState(state.StateDeleting, "Deleting Flex Cluster.")
+
+	if atlasFlexCluster.GetStateName() == "DELETING" {
+		return result.NextState(state.StateDeleting, "Deleting Flex Cluster.")
+	}
+
+	// Atlas returned the cluster in a non-deleting state. This can happen when Atlas silently
+	// ignores the deletion request. Re-request deletion so the DELETE is retried.
+	return result.NextState(state.StateDeletionRequested,
+		fmt.Sprintf("Flex cluster is in %q state instead of DELETING, re-requesting deletion.", atlasFlexCluster.GetStateName()))
 }
 
 // For returns the resource and predicates for the controller

--- a/internal/generated/controller/flexcluster/handler_v20250312_test.go
+++ b/internal/generated/controller/flexcluster/handler_v20250312_test.go
@@ -883,6 +883,20 @@ func TestHandleDeleting(t *testing.T) {
 			want: reenqueueResult(state.StateDeleting, "Deleting Flex Cluster."),
 		},
 		{
+			title:       "cluster in unexpected state after deletion — re-request deletion",
+			flexCluster: setGroupRef(defaultTestFlexCluster(testClusterName, testNamespace), testGroupName),
+			kubeObjects: []client.Object{
+				defaultTestGroup(testGroupName, testNamespace, new(testGroupID)),
+			},
+			atlasGetFlexClusterFunc: func() (*v20250312sdk.FlexClusterDescription20241113, *http.Response, error) {
+				return &v20250312sdk.FlexClusterDescription20241113{
+					Id:        new(testClusterID),
+					StateName: new("IDLE"),
+				}, nil, nil
+			},
+			want: reenqueueResult(state.StateDeletionRequested, `Flex cluster is in "IDLE" state instead of DELETING, re-requesting deletion.`),
+		},
+		{
 			title:       "get cluster fails",
 			flexCluster: setGroupRef(defaultTestFlexCluster(testClusterName, testNamespace), testGroupName),
 			kubeObjects: []client.Object{
@@ -892,7 +906,7 @@ func TestHandleDeleting(t *testing.T) {
 				return nil, nil, fmt.Errorf("get failed")
 			},
 			want:    errorResult(state.StateDeletionRequested),
-			wantErr: "failed to delete flexcluster",
+			wantErr: "failed to get flex cluster status",
 		},
 		{
 			title:       "get dependencies fails",

--- a/internal/generated/experimental/controller/flexcluster/handler_v20250312.go
+++ b/internal/generated/experimental/controller/flexcluster/handler_v20250312.go
@@ -176,14 +176,22 @@ func (h *Handlerv20250312) HandleDeleting(ctx context.Context, flexcluster *akov
 		return result.Error(state.StateDeleting, fmt.Errorf("failed to translate flex api params: %w", err))
 	}
 
-	_, _, err = h.atlasClient.FlexClustersApi.GetFlexClusterWithParams(ctx, params).Execute()
+	atlasFlexCluster, _, err := h.atlasClient.FlexClustersApi.GetFlexClusterWithParams(ctx, params).Execute()
 	switch {
 	case v20250312sdk.IsErrorCode(err, "CLUSTER_NOT_FOUND"):
 		return result.NextState(state.StateDeleted, "Deleted")
 	case err != nil:
-		return result.Error(state.StateDeletionRequested, fmt.Errorf("failed to delete flexcluster: %w", err))
+		return result.Error(state.StateDeletionRequested, fmt.Errorf("failed to get flex cluster status: %w", err))
 	}
-	return result.NextState(state.StateDeleting, "Deleting Flex Cluster.")
+
+	if atlasFlexCluster.GetStateName() == "DELETING" {
+		return result.NextState(state.StateDeleting, "Deleting Flex Cluster.")
+	}
+
+	// Atlas returned the cluster in a non-deleting state. This can happen when Atlas silently
+	// ignores the deletion request. Re-request deletion so the DELETE is retried.
+	return result.NextState(state.StateDeletionRequested,
+		fmt.Sprintf("Flex cluster is in %q state instead of DELETING, re-requesting deletion.", atlasFlexCluster.GetStateName()))
 }
 
 // For returns the resource and predicates for the controller

--- a/internal/generated/experimental/controller/flexcluster/handler_v20250312_test.go
+++ b/internal/generated/experimental/controller/flexcluster/handler_v20250312_test.go
@@ -883,6 +883,20 @@ func TestHandleDeleting(t *testing.T) {
 			want: reenqueueResult(state.StateDeleting, "Deleting Flex Cluster."),
 		},
 		{
+			title:       "cluster in unexpected state after deletion — re-request deletion",
+			flexCluster: setGroupRef(defaultTestFlexCluster(testClusterName, testNamespace), testGroupName),
+			kubeObjects: []client.Object{
+				defaultTestGroup(testGroupName, testNamespace, new(testGroupID)),
+			},
+			atlasGetFlexClusterFunc: func() (*v20250312sdk.FlexClusterDescription20241113, *http.Response, error) {
+				return &v20250312sdk.FlexClusterDescription20241113{
+					Id:        new(testClusterID),
+					StateName: new("IDLE"),
+				}, nil, nil
+			},
+			want: reenqueueResult(state.StateDeletionRequested, `Flex cluster is in "IDLE" state instead of DELETING, re-requesting deletion.`),
+		},
+		{
 			title:       "get cluster fails",
 			flexCluster: setGroupRef(defaultTestFlexCluster(testClusterName, testNamespace), testGroupName),
 			kubeObjects: []client.Object{
@@ -892,7 +906,7 @@ func TestHandleDeleting(t *testing.T) {
 				return nil, nil, fmt.Errorf("get failed")
 			},
 			want:    errorResult(state.StateDeletionRequested),
-			wantErr: "failed to delete flexcluster",
+			wantErr: "failed to get flex cluster status",
 		},
 		{
 			title:       "get dependencies fails",

--- a/test/e2e2/flexcluster_test.go
+++ b/test/e2e2/flexcluster_test.go
@@ -20,6 +20,7 @@ import (
 	k8s "github.com/crd2go/crd2go/k8s"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"go.mongodb.org/atlas-sdk/v20250312018/admin"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -56,8 +57,8 @@ var _ = Describe("FlexCluster CRUD", Ordered, Label("flexcluster"), func() {
 	var ctx = suiteCtx
 
 	_ = BeforeAll(func() {
-		deletionProtectionOff := false
-		ako = runTestAKO(DefaultGlobalCredentials, control.MustEnvVar("OPERATOR_NAMESPACE"), deletionProtectionOff)
+		deletionProtection := true
+		ako = runTestAKO(DefaultGlobalCredentials, control.MustEnvVar("OPERATOR_NAMESPACE"), deletionProtection)
 		ako.Start(ctx, GinkgoT())
 
 		// Register cleanup - this should even when the process is interrupted with Ctrl+C
@@ -164,6 +165,10 @@ var _ = Describe("FlexCluster CRUD", Ordered, Label("flexcluster"), func() {
 			// Track created objects for cleanup
 			var createdObjects []client.Object
 			var cluster *apiv1.FlexCluster
+			// Atlas coordinates for post-test cleanup (set during create / group-ready steps)
+			var atlasCleanupGroupID string
+			var atlasCleanupClusterName string
+			var atlasDeleteProject bool // true when the project was created by this test (groupRef case)
 
 			By("Copy credentials secret to test namespace", func() {
 				Expect(resources.CopyCredentialsToNamespace(ctx, kubeClient, DefaultGlobalCredentials, control.MustEnvVar("OPERATOR_NAMESPACE"), testNamespace.Name, GinkGoFieldOwner)).To(Succeed())
@@ -176,6 +181,12 @@ var _ = Describe("FlexCluster CRUD", Ordered, Label("flexcluster"), func() {
 				cluster = createMutation(objs, testParams)
 				Expect(cluster).NotTo(BeNil())
 
+				// Cluster name and direct groupId (if set) are fixed at create time
+				atlasCleanupClusterName = cluster.Spec.V20250312.Entry.Name
+				if cluster.Spec.V20250312.GroupId != nil {
+					atlasCleanupGroupID = *cluster.Spec.V20250312.GroupId
+				}
+
 				// Apply all objects to namespace
 				var err error
 				createdObjects, err = resources.ApplyObjectsToNamespace(ctx, kubeClient, objs, testNamespace.Name, GinkGoFieldOwner)
@@ -185,7 +196,6 @@ var _ = Describe("FlexCluster CRUD", Ordered, Label("flexcluster"), func() {
 			})
 
 			By("Wait for Group to be Ready (if using groupRef)", func() {
-				// Check if any Group objects were created
 				for _, obj := range createdObjects {
 					if group, ok := obj.(*apiv1.Group); ok {
 						groupObj := &apiv1.Group{
@@ -194,6 +204,11 @@ var _ = Describe("FlexCluster CRUD", Ordered, Label("flexcluster"), func() {
 						Eventually(func(g Gomega) {
 							g.Expect(resources.CheckResourceReady(ctx, kubeClient, groupObj)).To(Succeed())
 						}).WithContext(ctx).WithTimeout(5 * time.Minute).WithPolling(5 * time.Second).Should(Succeed())
+						// Capture Atlas project ID — this project was created by the test and must be cleaned up
+						Expect(groupObj.Status.V20250312).NotTo(BeNil())
+						Expect(groupObj.Status.V20250312.Id).NotTo(BeNil())
+						atlasCleanupGroupID = *groupObj.Status.V20250312.Id
+						atlasDeleteProject = true
 					}
 				}
 			})
@@ -237,7 +252,31 @@ var _ = Describe("FlexCluster CRUD", Ordered, Label("flexcluster"), func() {
 				for _, obj := range createdObjects {
 					Eventually(func(g Gomega) {
 						g.Expect(resources.CheckResourceDeleted(ctx, kubeClient, obj)).To(Succeed())
-					}).WithContext(ctx).WithTimeout(15 * time.Minute).WithPolling(10 * time.Second).Should(Succeed())
+					}).WithContext(ctx).WithTimeout(2 * time.Minute).WithPolling(5 * time.Second).Should(Succeed())
+				}
+			})
+
+			By("Delete Atlas resources (best-effort cleanup)", func() {
+				if atlasCleanupGroupID == "" || atlasCleanupClusterName == "" {
+					return
+				}
+				atlasClient, _ := newTestAtlasClient()
+				_, err := atlasClient.FlexClustersApi.DeleteFlexCluster(ctx, atlasCleanupGroupID, atlasCleanupClusterName).Execute()
+				if !admin.IsErrorCode(err, "CLUSTER_NOT_FOUND") {
+					Expect(err).NotTo(HaveOccurred())
+				}
+				deadline := time.Now().Add(3 * time.Minute)
+				for time.Now().Before(deadline) {
+					time.Sleep(10 * time.Second)
+					_, _, err = atlasClient.FlexClustersApi.GetFlexCluster(ctx, atlasCleanupGroupID, atlasCleanupClusterName).Execute()
+					if admin.IsErrorCode(err, "CLUSTER_NOT_FOUND") {
+						break
+					}
+				}
+				if atlasDeleteProject {
+					if _, err := atlasClient.ProjectsApi.DeleteGroup(ctx, atlasCleanupGroupID).Execute(); err != nil {
+						GinkgoWriter.Printf("WARNING: failed to delete Atlas project %s: %v\n", atlasCleanupGroupID, err)
+					}
 				}
 			})
 		},


### PR DESCRIPTION
# Summary

When Atlas accepts a DeleteFlexCluster call but subsequently returns the cluster as IDLE (instead of DELETING), the operator was silently looping in StateDeleting indefinitely. This appears to be an Atlas-side issue where the deletion is not actually queued despite a successful response.

HandleDeleting now checks the stateName returned by GetFlexCluster:
- "DELETING" -> continue polling in StateDeleting (expected path)
- anything else -> transition back to StateDeletionRequested so the DELETE is re-issued on the next reconcile cycle

Also fixes the misleading error message in the GET-failure path ("failed to delete flexcluster" -> "failed to get flex cluster status").

## Proof of Work

CI must pass, specially flex cluster tests

## Checklist
- [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
