### PR TITLE
fix: grant missing permissions to reusable workflow calls in test.yml

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,8 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
+  packages: write
 
 jobs:
   run-tests:


### PR DESCRIPTION
# Summary

The security hardening commit (d2ecaff4) added top-level permissions blocks to all reusable workflows but only added `contents: read` to the caller (test.yml). Called workflows requesting `pull-requests: read` (cloud-tests- filter, tests-selectable, tests-e2e2) and `packages: write` (build-images) were being denied at validation time.

Added `pull-requests: read` and `packages: write` to test.yml so the token passed to all seven called workflows satisfies their declared permissions.

## Proof of Work

CI restored

## Checklist
- [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
