### PR TITLE
CLOUDP-407347: Recover from DUPLICATE_CLUSTER_NAME

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,6 +85,24 @@ Do not:
 - Add new dependencies without running `make lint` and `make unit-test` to verify compatibility.
 - Introduce e2e tests when unit or integration tests suffice. E2e tests are expensive and slow CI.
 
+## Git commits
+
+When writing a `git commit` command:
+
+- Use multiple `-m` flags instead of a heredoc — one flag for the title, one per summary paragraph.
+- Title: 50 chars soft limit, 72 chars hard limit.
+- Body lines: no hard limit, but prefer wrapping around 72 chars for readability.
+- Each `-m` after the title becomes a paragraph separated by a blank line.
+
+Example:
+
+```sh
+git commit \
+  -m "fix: short imperative title under 50 chars" \
+  -m "First paragraph explaining the why of the change." \
+  -m "Optional second paragraph with extra context."
+```
+
 ## Verification
 
 After making changes, run `make ci` to execute all unit tests and linting checks before considering the work done. This is the same gate that CI enforces on pull requests.

--- a/internal/generated/controller/flexcluster/handler_v20250312.go
+++ b/internal/generated/controller/flexcluster/handler_v20250312.go
@@ -70,7 +70,23 @@ func (h *Handlerv20250312) HandleInitial(ctx context.Context, flexcluster *akov2
 	}
 
 	atlasFlexCluster, _, err := h.atlasClient.FlexClustersApi.CreateFlexClusterWithParams(ctx, params).Execute()
-	if err != nil {
+	if v20250312sdk.IsErrorCode(err, "DUPLICATE_CLUSTER_NAME") {
+		// Only recover if a previous reconcile already wrote the Atlas ID to status — confirming we
+		// own this cluster. If status has no ID, the name conflict is either genuine (a pre-existing
+		// Atlas resource we must not hijack) or the cache is too stale to confirm ownership; return
+		// an error so the next retry (after backoff) reads the updated cache and decides correctly.
+		if flexcluster.Status.V20250312 == nil || flexcluster.Status.V20250312.Id == nil {
+			return result.Error(state.StateInitial, fmt.Errorf("failed to create flex cluster: %w", err))
+		}
+		getParams := &v20250312sdk.GetFlexClusterApiParams{}
+		if translateErr := h.translator.ToAPI(getParams, flexcluster, deps...); translateErr != nil {
+			return result.Error(state.StateInitial, fmt.Errorf("failed to translate get params for existing cluster: %w", translateErr))
+		}
+		atlasFlexCluster, _, err = h.atlasClient.FlexClustersApi.GetFlexClusterWithParams(ctx, getParams).Execute()
+		if err != nil {
+			return result.Error(state.StateInitial, fmt.Errorf("failed to get existing flex cluster: %w", err))
+		}
+	} else if err != nil {
 		return result.Error(state.StateInitial, fmt.Errorf("failed to create flex cluster: %w", err))
 	}
 	newFlexCluster := flexcluster.DeepCopy()

--- a/internal/generated/controller/flexcluster/handler_v20250312_test.go
+++ b/internal/generated/controller/flexcluster/handler_v20250312_test.go
@@ -66,6 +66,7 @@ func TestHandleInitial(t *testing.T) {
 		flexCluster                *akov2generated.FlexCluster
 		kubeObjects                []client.Object
 		atlasCreateFlexClusterFunc func() (*v20250312sdk.FlexClusterDescription20241113, *http.Response, error)
+		atlasGetFlexClusterFunc    func() (*v20250312sdk.FlexClusterDescription20241113, *http.Response, error)
 		interceptorFuncs           *interceptor.Funcs
 		want                       ctrlstate.Result
 		wantErr                    string
@@ -146,6 +147,62 @@ func TestHandleInitial(t *testing.T) {
 			want:    ctrlstate.Result{NextState: state.StateInitial},
 			wantErr: "failed to patch flex cluster status",
 		},
+		{
+			title: "duplicate cluster name - recovers when id already in status",
+			flexCluster: withStatusID(
+				setGroupRef(defaultTestFlexCluster(testClusterName, testNamespace), testGroupName),
+				testClusterID,
+			),
+			kubeObjects: []client.Object{
+				defaultTestGroup(testGroupName, testNamespace, new(testGroupID)),
+			},
+			atlasCreateFlexClusterFunc: func() (*v20250312sdk.FlexClusterDescription20241113, *http.Response, error) {
+				apiErr := &v20250312sdk.GenericOpenAPIError{}
+				apiErr.SetModel(v20250312sdk.ApiError{ErrorCode: "DUPLICATE_CLUSTER_NAME"})
+				return nil, nil, apiErr
+			},
+			atlasGetFlexClusterFunc: func() (*v20250312sdk.FlexClusterDescription20241113, *http.Response, error) {
+				return &v20250312sdk.FlexClusterDescription20241113{
+					Id:        new(testClusterID),
+					StateName: new("CREATING"),
+				}, nil, nil
+			},
+			want: reenqueueResult(state.StateCreating, "Creating Flex Cluster."),
+		},
+		{
+			title: "duplicate cluster name - get existing cluster fails when id in status",
+			flexCluster: withStatusID(
+				setGroupRef(defaultTestFlexCluster(testClusterName, testNamespace), testGroupName),
+				testClusterID,
+			),
+			kubeObjects: []client.Object{
+				defaultTestGroup(testGroupName, testNamespace, new(testGroupID)),
+			},
+			atlasCreateFlexClusterFunc: func() (*v20250312sdk.FlexClusterDescription20241113, *http.Response, error) {
+				apiErr := &v20250312sdk.GenericOpenAPIError{}
+				apiErr.SetModel(v20250312sdk.ApiError{ErrorCode: "DUPLICATE_CLUSTER_NAME"})
+				return nil, nil, apiErr
+			},
+			atlasGetFlexClusterFunc: func() (*v20250312sdk.FlexClusterDescription20241113, *http.Response, error) {
+				return nil, nil, fmt.Errorf("get cluster failed")
+			},
+			want:    ctrlstate.Result{NextState: state.StateInitial},
+			wantErr: "failed to get existing flex cluster",
+		},
+		{
+			title:       "duplicate cluster name - no id in status - no recovery",
+			flexCluster: setGroupRef(defaultTestFlexCluster(testClusterName, testNamespace), testGroupName),
+			kubeObjects: []client.Object{
+				defaultTestGroup(testGroupName, testNamespace, new(testGroupID)),
+			},
+			atlasCreateFlexClusterFunc: func() (*v20250312sdk.FlexClusterDescription20241113, *http.Response, error) {
+				apiErr := &v20250312sdk.GenericOpenAPIError{}
+				apiErr.SetModel(v20250312sdk.ApiError{ErrorCode: "DUPLICATE_CLUSTER_NAME"})
+				return nil, nil, apiErr
+			},
+			want:    ctrlstate.Result{NextState: state.StateInitial},
+			wantErr: "failed to create flex cluster",
+		},
 	} {
 		t.Run(tc.title, func(t *testing.T) {
 			fakeClient := fixture.buildFakeClient(tc.flexCluster, tc.kubeObjects, tc.interceptorFuncs)
@@ -156,6 +213,12 @@ func TestHandleInitial(t *testing.T) {
 				req := admin.CreateFlexClusterApiRequest{ApiService: flexAPI}
 				flexAPI.EXPECT().CreateFlexClusterWithParams(mock.Anything, mock.Anything).Return(req)
 				flexAPI.EXPECT().CreateFlexClusterExecute(req).Return(cluster, rsp, err)
+			}
+			if tc.atlasGetFlexClusterFunc != nil {
+				cluster, rsp, err := tc.atlasGetFlexClusterFunc()
+				req := admin.GetFlexClusterApiRequest{ApiService: flexAPI}
+				flexAPI.EXPECT().GetFlexClusterWithParams(mock.Anything, mock.Anything).Return(req)
+				flexAPI.EXPECT().GetFlexClusterExecute(req).Return(cluster, rsp, err)
 			}
 
 			atlasClient := buildAtlasClient(flexAPI)
@@ -1140,6 +1203,15 @@ func assertError(t *testing.T, err error, wantErr string) {
 func withStatus(flexCluster *akov2generated.FlexCluster) *akov2generated.FlexCluster {
 	flexCluster.Status = akov2generated.FlexClusterStatus{
 		V20250312: &akov2generated.FlexClusterStatusV20250312{},
+	}
+	return flexCluster
+}
+
+// withStatusID creates a FlexCluster with a status ID, simulating a resource whose Atlas cluster
+// was already created in a previous reconcile.
+func withStatusID(flexCluster *akov2generated.FlexCluster, id string) *akov2generated.FlexCluster {
+	flexCluster.Status = akov2generated.FlexClusterStatus{
+		V20250312: &akov2generated.FlexClusterStatusV20250312{Id: &id},
 	}
 	return flexCluster
 }

--- a/internal/generated/experimental/controller/flexcluster/handler_v20250312.go
+++ b/internal/generated/experimental/controller/flexcluster/handler_v20250312.go
@@ -71,7 +71,23 @@ func (h *Handlerv20250312) HandleInitial(ctx context.Context, flexcluster *akov2
 	}
 
 	atlasFlexCluster, _, err := h.atlasClient.FlexClustersApi.CreateFlexClusterWithParams(ctx, params).Execute()
-	if err != nil {
+	if v20250312sdk.IsErrorCode(err, "DUPLICATE_CLUSTER_NAME") {
+		// Only recover if a previous reconcile already wrote the Atlas ID to status — confirming we
+		// own this cluster. If status has no ID, the name conflict is either genuine (a pre-existing
+		// Atlas resource we must not hijack) or the cache is too stale to confirm ownership; return
+		// an error so the next retry (after backoff) reads the updated cache and decides correctly.
+		if flexcluster.Status.V20250312 == nil || flexcluster.Status.V20250312.Id == nil {
+			return result.Error(state.StateInitial, fmt.Errorf("failed to create flex cluster: %w", err))
+		}
+		getParams := &v20250312sdk.GetFlexClusterApiParams{}
+		if translateErr := h.translator.ToAPI(getParams, flexcluster, deps...); translateErr != nil {
+			return result.Error(state.StateInitial, fmt.Errorf("failed to translate get params for existing cluster: %w", translateErr))
+		}
+		atlasFlexCluster, _, err = h.atlasClient.FlexClustersApi.GetFlexClusterWithParams(ctx, getParams).Execute()
+		if err != nil {
+			return result.Error(state.StateInitial, fmt.Errorf("failed to get existing flex cluster: %w", err))
+		}
+	} else if err != nil {
 		return result.Error(state.StateInitial, fmt.Errorf("failed to create flex cluster: %w", err))
 	}
 	newFlexCluster := flexcluster.DeepCopy()

--- a/internal/generated/experimental/controller/flexcluster/handler_v20250312_test.go
+++ b/internal/generated/experimental/controller/flexcluster/handler_v20250312_test.go
@@ -66,6 +66,7 @@ func TestHandleInitial(t *testing.T) {
 		flexCluster                *akov2generated.FlexCluster
 		kubeObjects                []client.Object
 		atlasCreateFlexClusterFunc func() (*v20250312sdk.FlexClusterDescription20241113, *http.Response, error)
+		atlasGetFlexClusterFunc    func() (*v20250312sdk.FlexClusterDescription20241113, *http.Response, error)
 		interceptorFuncs           *interceptor.Funcs
 		want                       ctrlstate.Result
 		wantErr                    string
@@ -146,6 +147,62 @@ func TestHandleInitial(t *testing.T) {
 			want:    ctrlstate.Result{NextState: state.StateInitial},
 			wantErr: "failed to patch flex cluster status",
 		},
+		{
+			title: "duplicate cluster name - recovers when id already in status",
+			flexCluster: withStatusID(
+				setGroupRef(defaultTestFlexCluster(testClusterName, testNamespace), testGroupName),
+				testClusterID,
+			),
+			kubeObjects: []client.Object{
+				defaultTestGroup(testGroupName, testNamespace, new(testGroupID)),
+			},
+			atlasCreateFlexClusterFunc: func() (*v20250312sdk.FlexClusterDescription20241113, *http.Response, error) {
+				apiErr := &v20250312sdk.GenericOpenAPIError{}
+				apiErr.SetModel(v20250312sdk.ApiError{ErrorCode: "DUPLICATE_CLUSTER_NAME"})
+				return nil, nil, apiErr
+			},
+			atlasGetFlexClusterFunc: func() (*v20250312sdk.FlexClusterDescription20241113, *http.Response, error) {
+				return &v20250312sdk.FlexClusterDescription20241113{
+					Id:        new(testClusterID),
+					StateName: new("CREATING"),
+				}, nil, nil
+			},
+			want: reenqueueResult(state.StateCreating, "Creating Flex Cluster."),
+		},
+		{
+			title: "duplicate cluster name - get existing cluster fails when id in status",
+			flexCluster: withStatusID(
+				setGroupRef(defaultTestFlexCluster(testClusterName, testNamespace), testGroupName),
+				testClusterID,
+			),
+			kubeObjects: []client.Object{
+				defaultTestGroup(testGroupName, testNamespace, new(testGroupID)),
+			},
+			atlasCreateFlexClusterFunc: func() (*v20250312sdk.FlexClusterDescription20241113, *http.Response, error) {
+				apiErr := &v20250312sdk.GenericOpenAPIError{}
+				apiErr.SetModel(v20250312sdk.ApiError{ErrorCode: "DUPLICATE_CLUSTER_NAME"})
+				return nil, nil, apiErr
+			},
+			atlasGetFlexClusterFunc: func() (*v20250312sdk.FlexClusterDescription20241113, *http.Response, error) {
+				return nil, nil, fmt.Errorf("get cluster failed")
+			},
+			want:    ctrlstate.Result{NextState: state.StateInitial},
+			wantErr: "failed to get existing flex cluster",
+		},
+		{
+			title:       "duplicate cluster name - no id in status - no recovery",
+			flexCluster: setGroupRef(defaultTestFlexCluster(testClusterName, testNamespace), testGroupName),
+			kubeObjects: []client.Object{
+				defaultTestGroup(testGroupName, testNamespace, new(testGroupID)),
+			},
+			atlasCreateFlexClusterFunc: func() (*v20250312sdk.FlexClusterDescription20241113, *http.Response, error) {
+				apiErr := &v20250312sdk.GenericOpenAPIError{}
+				apiErr.SetModel(v20250312sdk.ApiError{ErrorCode: "DUPLICATE_CLUSTER_NAME"})
+				return nil, nil, apiErr
+			},
+			want:    ctrlstate.Result{NextState: state.StateInitial},
+			wantErr: "failed to create flex cluster",
+		},
 	} {
 		t.Run(tc.title, func(t *testing.T) {
 			fakeClient := fixture.buildFakeClient(tc.flexCluster, tc.kubeObjects, tc.interceptorFuncs)
@@ -156,6 +213,12 @@ func TestHandleInitial(t *testing.T) {
 				req := admin.CreateFlexClusterApiRequest{ApiService: flexAPI}
 				flexAPI.EXPECT().CreateFlexClusterWithParams(mock.Anything, mock.Anything).Return(req)
 				flexAPI.EXPECT().CreateFlexClusterExecute(req).Return(cluster, rsp, err)
+			}
+			if tc.atlasGetFlexClusterFunc != nil {
+				cluster, rsp, err := tc.atlasGetFlexClusterFunc()
+				req := admin.GetFlexClusterApiRequest{ApiService: flexAPI}
+				flexAPI.EXPECT().GetFlexClusterWithParams(mock.Anything, mock.Anything).Return(req)
+				flexAPI.EXPECT().GetFlexClusterExecute(req).Return(cluster, rsp, err)
 			}
 
 			atlasClient := buildAtlasClient(flexAPI)
@@ -1140,6 +1203,15 @@ func assertError(t *testing.T, err error, wantErr string) {
 func withStatus(flexCluster *akov2generated.FlexCluster) *akov2generated.FlexCluster {
 	flexCluster.Status = akov2generated.FlexClusterStatus{
 		V20250312: &akov2generated.FlexClusterStatusV20250312{},
+	}
+	return flexCluster
+}
+
+// withStatusID creates a FlexCluster with a status ID, simulating a resource whose Atlas cluster
+// was already created in a previous reconcile.
+func withStatusID(flexCluster *akov2generated.FlexCluster, id string) *akov2generated.FlexCluster {
+	flexCluster.Status = akov2generated.FlexClusterStatus{
+		V20250312: &akov2generated.FlexClusterStatusV20250312{Id: &id},
 	}
 	return flexCluster
 }


### PR DESCRIPTION
# Summary

Only recover when flex cluster status already has an Atlas ID, confirming a prior reconcile created it. Without an ID the conflict may be a pre-existing Atlas resource; return an error so the operator retries after backoff rather than hijacking it.

## Proof of Work

CI must ass, including specially e2e2 tests.

## Checklist
- [X] Have you linked a jira ticket and/or is the ticket in the title?
- [X] Have you checked whether your jira ticket required DOCSP changes?
- [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?

