### PR TITLE
CLOUDP-410427: Updated AtlasPrivateEndpoint CR to the latest Atlas Go SDK

### DIFF
--- a/api/v1/atlasprivateendpoint_types.go
+++ b/api/v1/atlasprivateendpoint_types.go
@@ -42,6 +42,13 @@ type AtlasPrivateEndpointSpec struct {
 	// Region of the chosen cloud provider in which you want to create the private endpoint service.
 	// +kubebuilder:validation:Required
 	Region string `json:"region"`
+	// SupportedRegions is the list of regions from which AWS Private Link traffic is forwarded to this endpoint. AWS only.
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:MaxItems=35
+	SupportedRegions []string `json:"supportedRegions,omitempty"`
+	// PortMappingEnabled indicates whether this endpoint service uses PSC port-mapping. GCP only.
+	// +kubebuilder:validation:Optional
+	PortMappingEnabled bool `json:"portMappingEnabled,omitempty"`
 	// AWSConfiguration is the specific AWS settings for the private endpoint.
 	// +listType=map
 	// +listMapKey=id

--- a/api/v1/status/atlasprivateendpoint.go
+++ b/api/v1/status/atlasprivateendpoint.go
@@ -35,6 +35,8 @@ type AtlasPrivateEndpointStatus struct {
 	ServiceAttachmentNames []string `json:"serviceAttachmentNames,omitempty"`
 	// SupportedRegions is the list of regions from which AWS Private Link traffic is forwarded. AWS only.
 	SupportedRegions []string `json:"supportedRegions,omitempty"`
+	// PortMappingEnabled indicates whether the GCP endpoint service uses PSC port-mapping. GCP only.
+	PortMappingEnabled bool `json:"portMappingEnabled,omitempty"`
 	// Endpoints are the status of the endpoints connected to the service
 	Endpoints []EndpointInterfaceStatus `json:"endpoints,omitempty"`
 }

--- a/api/v1/status/atlasprivateendpoint.go
+++ b/api/v1/status/atlasprivateendpoint.go
@@ -33,6 +33,8 @@ type AtlasPrivateEndpointStatus struct {
 	ResourceID string `json:"resourceId,omitempty"`
 	// ServiceAttachmentNames is the list of URLs that identifies endpoints that Atlas can use to access one service across the private connection
 	ServiceAttachmentNames []string `json:"serviceAttachmentNames,omitempty"`
+	// SupportedRegions is the list of regions from which AWS Private Link traffic is forwarded. AWS only.
+	SupportedRegions []string `json:"supportedRegions,omitempty"`
 	// Endpoints are the status of the endpoints connected to the service
 	Endpoints []EndpointInterfaceStatus `json:"endpoints,omitempty"`
 }

--- a/api/v1/status/zz_generated.deepcopy.go
+++ b/api/v1/status/zz_generated.deepcopy.go
@@ -292,6 +292,11 @@ func (in *AtlasPrivateEndpointStatus) DeepCopyInto(out *AtlasPrivateEndpointStat
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.SupportedRegions != nil {
+		in, out := &in.SupportedRegions, &out.SupportedRegions
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.Endpoints != nil {
 		in, out := &in.Endpoints, &out.Endpoints
 		*out = make([]EndpointInterfaceStatus, len(*in))

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -1502,6 +1502,11 @@ func (in *AtlasPrivateEndpointList) DeepCopyObject() runtime.Object {
 func (in *AtlasPrivateEndpointSpec) DeepCopyInto(out *AtlasPrivateEndpointSpec) {
 	*out = *in
 	in.ProjectDualReference.DeepCopyInto(&out.ProjectDualReference)
+	if in.SupportedRegions != nil {
+		in, out := &in.SupportedRegions, &out.SupportedRegions
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.AWSConfiguration != nil {
 		in, out := &in.AWSConfiguration, &out.AWSConfiguration
 		*out = make([]AWSPrivateEndpointConfiguration, len(*in))

--- a/docs/api-docs.md
+++ b/docs/api-docs.md
@@ -7726,6 +7726,13 @@ The Atlas Operator updates this field to the value of 'metadata.generation' as s
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>portMappingEnabled</b></td>
+        <td>boolean</td>
+        <td>
+          PortMappingEnabled indicates whether the GCP endpoint service uses PSC port-mapping. GCP only.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>resourceId</b></td>
         <td>string</td>
         <td>

--- a/docs/api-docs.md
+++ b/docs/api-docs.md
@@ -7426,11 +7426,25 @@ Mutually exclusive with the "projectRef" field.<br/>
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>portMappingEnabled</b></td>
+        <td>boolean</td>
+        <td>
+          PortMappingEnabled indicates whether this endpoint service uses PSC port-mapping. GCP only.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b><a href="#atlasprivateendpointspecprojectref">projectRef</a></b></td>
         <td>object</td>
         <td>
           projectRef is a reference to the parent AtlasProject resource.
 Mutually exclusive with the "externalProjectRef" field.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>supportedRegions</b></td>
+        <td>[]string</td>
+        <td>
+          SupportedRegions is the list of regions from which AWS Private Link traffic is forwarded to this endpoint. AWS only.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -7744,6 +7758,13 @@ The Atlas Operator updates this field to the value of 'metadata.generation' as s
         <td>string</td>
         <td>
           ServiceStatus is the state of the private endpoint service<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>supportedRegions</b></td>
+        <td>[]string</td>
+        <td>
+          SupportedRegions is the list of regions from which AWS Private Link traffic is forwarded. AWS only.<br/>
         </td>
         <td>false</td>
       </tr></tbody>

--- a/internal/controller/atlasprivateendpoint/privateendpoint.go
+++ b/internal/controller/atlasprivateendpoint/privateendpoint.go
@@ -17,6 +17,7 @@ package atlasprivateendpoint
 import (
 	"context"
 	"errors"
+	"slices"
 
 	ctrl "sigs.k8s.io/controller-runtime"
 
@@ -110,6 +111,14 @@ func (r *AtlasPrivateEndpointReconciler) watchServiceState(
 
 	ctx.SetConditionTrue(api.PrivateEndpointServiceReady)
 	r.EventRecorder.Event(akoPrivateEndpoint, "Normal", string(workflow.PrivateEndpointServiceCreated), "Private Endpoint Service is available")
+
+	if serviceNeedsUpdate(akoPEService, atlasPEService) {
+		updatedService, err := privateEndpointService.UpdatePrivateEndpointService(ctx.Context, projectID, atlasPEService.ServiceID(), akoPEService)
+		if err != nil {
+			return r.terminate(ctx, akoPrivateEndpoint, atlasPEService, api.PrivateEndpointServiceReady, workflow.PrivateEndpointServiceFailedToConfigure, err)
+		}
+		atlasPEService = updatedService
+	}
 
 	return r.handlePrivateEndpointInterface(ctx, privateEndpointService, projectID, akoPrivateEndpoint, akoPEService, atlasPEService)
 }
@@ -264,6 +273,20 @@ func hasInterfaceFailed(ep privateendpoint.EndpointInterface) bool {
 	status := ep.Status()
 
 	return status == privateendpoint.StatusFailed || status == privateendpoint.StatusRejected
+}
+
+// Only AWS supportedRegions are mutable after creation. portMappingEnabled (GCP) is immutable
+func serviceNeedsUpdate(ako, atlas privateendpoint.EndpointService) bool {
+	akoAWS, akoOK := ako.(*privateendpoint.AWSService)
+	atlasAWS, atlasOK := atlas.(*privateendpoint.AWSService)
+	if !akoOK || !atlasOK {
+		return false
+	}
+	akoRegions := slices.Clone(akoAWS.SupportedRegions)
+	atlasRegions := slices.Clone(atlasAWS.SupportedRegions)
+	slices.Sort(akoRegions)
+	slices.Sort(atlasRegions)
+	return !slices.Equal(akoRegions, atlasRegions)
 }
 
 func getGCPProjectID(akoPrivateEndpoint *akov2.AtlasPrivateEndpoint, interfaceID string) string {

--- a/internal/controller/atlasprivateendpoint/privateendpoint_test.go
+++ b/internal/controller/atlasprivateendpoint/privateendpoint_test.go
@@ -423,6 +423,114 @@ func TestHandlePrivateEndpointService(t *testing.T) {
 					WithMessageRegexp("Private Endpoint is being deleted"),
 			},
 		},
+		"update AWS supported regions": {
+			atlasPrivateEndpoint: &akov2.AtlasPrivateEndpoint{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pe1",
+					Namespace: "default",
+				},
+				Spec: akov2.AtlasPrivateEndpointSpec{
+					ProjectDualReference: akov2.ProjectDualReference{
+						ExternalProjectRef: &akov2.ExternalProjectReference{
+							ID: projectID,
+						},
+						ConnectionSecret: &api.LocalObjectReference{},
+					},
+					Provider:         "AWS",
+					Region:           "US_EAST_1",
+					SupportedRegions: []string{"US_WEST_1", "EU_WEST_1"},
+				},
+				Status: status.AtlasPrivateEndpointStatus{
+					ServiceID:     "pe-service-id",
+					ServiceStatus: "AVAILABLE",
+				},
+			},
+			peClient: func() privateendpoint.PrivateEndpointService {
+				atlasService := &privateendpoint.AWSService{
+					CommonEndpointService: privateendpoint.CommonEndpointService{
+						ID:            "pe-service-id",
+						CloudRegion:   "US_EAST_1",
+						ServiceStatus: "AVAILABLE",
+						Interfaces:    privateendpoint.EndpointInterfaces{},
+					},
+				}
+				updatedService := &privateendpoint.AWSService{
+					CommonEndpointService: privateendpoint.CommonEndpointService{
+						ID:            "pe-service-id",
+						CloudRegion:   "US_EAST_1",
+						ServiceStatus: "AVAILABLE",
+						Interfaces:    privateendpoint.EndpointInterfaces{},
+					},
+					SupportedRegions: []string{"US_WEST_1", "EU_WEST_1"},
+				}
+
+				c := translation.NewPrivateEndpointServiceMock(t)
+				c.EXPECT().GetPrivateEndpoint(ctx, projectID, "AWS", "pe-service-id").
+					Return(atlasService, nil)
+				c.EXPECT().UpdatePrivateEndpointService(ctx, projectID, "pe-service-id", mock.AnythingOfType("*privateendpoint.AWSService")).
+					Return(updatedService, nil)
+
+				return c
+			},
+			expectedResult: reconcile.Result{},
+			expectedConditions: []api.Condition{
+				api.TrueCondition(api.PrivateEndpointServiceReady),
+				api.FalseCondition(api.ReadyType),
+				api.FalseCondition(api.PrivateEndpointReady).
+					WithReason(string(workflow.PrivateEndpointConfigurationPending)).
+					WithMessageRegexp("waiting for private endpoint configuration from customer side"),
+			},
+		},
+		"fail to update AWS supported regions": {
+			wantErr: true,
+			atlasPrivateEndpoint: &akov2.AtlasPrivateEndpoint{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pe1",
+					Namespace: "default",
+				},
+				Spec: akov2.AtlasPrivateEndpointSpec{
+					ProjectDualReference: akov2.ProjectDualReference{
+						ExternalProjectRef: &akov2.ExternalProjectReference{
+							ID: projectID,
+						},
+						ConnectionSecret: &api.LocalObjectReference{},
+					},
+					Provider:         "AWS",
+					Region:           "US_EAST_1",
+					SupportedRegions: []string{"US_WEST_1"},
+				},
+				Status: status.AtlasPrivateEndpointStatus{
+					ServiceID:     "pe-service-id",
+					ServiceStatus: "AVAILABLE",
+				},
+			},
+			peClient: func() privateendpoint.PrivateEndpointService {
+				atlasService := &privateendpoint.AWSService{
+					CommonEndpointService: privateendpoint.CommonEndpointService{
+						ID:            "pe-service-id",
+						CloudRegion:   "US_EAST_1",
+						ServiceStatus: "AVAILABLE",
+						Interfaces:    privateendpoint.EndpointInterfaces{},
+					},
+				}
+
+				c := translation.NewPrivateEndpointServiceMock(t)
+				c.EXPECT().GetPrivateEndpoint(ctx, projectID, "AWS", "pe-service-id").
+					Return(atlasService, nil)
+				c.EXPECT().UpdatePrivateEndpointService(ctx, projectID, "pe-service-id", mock.AnythingOfType("*privateendpoint.AWSService")).
+					Return(nil, errors.New("failed to update"))
+
+				return c
+			},
+			// SetConditionTrue(PrivateEndpointServiceReady) is called before terminate, so it occupies
+			// position 0; terminate then adds ReadyType at position 1 and updates PrivateEndpointServiceReady in place.
+			expectedConditions: []api.Condition{
+				api.FalseCondition(api.PrivateEndpointServiceReady).
+					WithReason(string(workflow.PrivateEndpointServiceFailedToConfigure)).
+					WithMessageRegexp("failed to update"),
+				api.FalseCondition(api.ReadyType),
+			},
+		},
 		"private endpoint service is available": {
 			atlasPrivateEndpoint: &akov2.AtlasPrivateEndpoint{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1333,6 +1441,50 @@ func TestDeletePrivateEndpoint(t *testing.T) {
 
 			_, err := r.deletePrivateEndpoint(ctx, tt.peClient(), projectID, tt.peService)
 			assert.Equal(t, tt.expectedErr, err)
+		})
+	}
+}
+
+func TestServiceNeedsUpdate(t *testing.T) {
+	tests := map[string]struct {
+		ako    privateendpoint.EndpointService
+		atlas  privateendpoint.EndpointService
+		expect bool
+	}{
+		"both empty": {
+			ako:    &privateendpoint.AWSService{},
+			atlas:  &privateendpoint.AWSService{},
+			expect: false,
+		},
+		"same supported regions": {
+			ako:    &privateendpoint.AWSService{SupportedRegions: []string{"US_EAST_1", "US_WEST_1"}},
+			atlas:  &privateendpoint.AWSService{SupportedRegions: []string{"US_WEST_1", "US_EAST_1"}},
+			expect: false,
+		},
+		"different supported regions": {
+			ako:    &privateendpoint.AWSService{SupportedRegions: []string{"US_EAST_1", "EU_WEST_1"}},
+			atlas:  &privateendpoint.AWSService{SupportedRegions: []string{"US_EAST_1"}},
+			expect: true,
+		},
+		"ako adds regions where atlas has none": {
+			ako:    &privateendpoint.AWSService{SupportedRegions: []string{"US_WEST_1"}},
+			atlas:  &privateendpoint.AWSService{},
+			expect: true,
+		},
+		"non-AWS provider never needs update": {
+			ako:    &privateendpoint.GCPService{},
+			atlas:  &privateendpoint.GCPService{},
+			expect: false,
+		},
+		"mixed provider types": {
+			ako:    &privateendpoint.AWSService{SupportedRegions: []string{"US_EAST_1"}},
+			atlas:  &privateendpoint.GCPService{},
+			expect: false,
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tt.expect, serviceNeedsUpdate(tt.ako, tt.atlas))
 		})
 	}
 }

--- a/internal/mocks/translation/private_endpoint_service.go
+++ b/internal/mocks/translation/private_endpoint_service.go
@@ -481,6 +481,67 @@ func (_c *PrivateEndpointServiceMock_ToggleRegionalizedPrivateEndpointMode_Call)
 	return _c
 }
 
+// UpdatePrivateEndpointService provides a mock function with given fields: ctx, projectID, serviceID, peService
+func (_m *PrivateEndpointServiceMock) UpdatePrivateEndpointService(ctx context.Context, projectID string, serviceID string, peService privateendpoint.EndpointService) (privateendpoint.EndpointService, error) {
+	ret := _m.Called(ctx, projectID, serviceID, peService)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdatePrivateEndpointService")
+	}
+
+	var r0 privateendpoint.EndpointService
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, privateendpoint.EndpointService) (privateendpoint.EndpointService, error)); ok {
+		return rf(ctx, projectID, serviceID, peService)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, privateendpoint.EndpointService) privateendpoint.EndpointService); ok {
+		r0 = rf(ctx, projectID, serviceID, peService)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(privateendpoint.EndpointService)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, privateendpoint.EndpointService) error); ok {
+		r1 = rf(ctx, projectID, serviceID, peService)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// PrivateEndpointServiceMock_UpdatePrivateEndpointService_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdatePrivateEndpointService'
+type PrivateEndpointServiceMock_UpdatePrivateEndpointService_Call struct {
+	*mock.Call
+}
+
+// UpdatePrivateEndpointService is a helper method to define mock.On call
+//   - ctx context.Context
+//   - projectID string
+//   - serviceID string
+//   - peService privateendpoint.EndpointService
+func (_e *PrivateEndpointServiceMock_Expecter) UpdatePrivateEndpointService(ctx interface{}, projectID interface{}, serviceID interface{}, peService interface{}) *PrivateEndpointServiceMock_UpdatePrivateEndpointService_Call {
+	return &PrivateEndpointServiceMock_UpdatePrivateEndpointService_Call{Call: _e.mock.On("UpdatePrivateEndpointService", ctx, projectID, serviceID, peService)}
+}
+
+func (_c *PrivateEndpointServiceMock_UpdatePrivateEndpointService_Call) Run(run func(ctx context.Context, projectID string, serviceID string, peService privateendpoint.EndpointService)) *PrivateEndpointServiceMock_UpdatePrivateEndpointService_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(privateendpoint.EndpointService))
+	})
+	return _c
+}
+
+func (_c *PrivateEndpointServiceMock_UpdatePrivateEndpointService_Call) Return(_a0 privateendpoint.EndpointService, _a1 error) *PrivateEndpointServiceMock_UpdatePrivateEndpointService_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *PrivateEndpointServiceMock_UpdatePrivateEndpointService_Call) RunAndReturn(run func(context.Context, string, string, privateendpoint.EndpointService) (privateendpoint.EndpointService, error)) *PrivateEndpointServiceMock_UpdatePrivateEndpointService_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // NewPrivateEndpointServiceMock creates a new instance of PrivateEndpointServiceMock. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func NewPrivateEndpointServiceMock(t interface {

--- a/internal/translation/privateendpoint/conversion.go
+++ b/internal/translation/privateendpoint/conversion.go
@@ -79,7 +79,8 @@ func (s *CommonEndpointService) ErrorMessage() string {
 type AWSService struct {
 	CommonEndpointService
 
-	ServiceName string
+	ServiceName      string
+	SupportedRegions []string
 }
 
 func (s *AWSService) Provider() string {
@@ -98,7 +99,8 @@ func (s *AzureService) Provider() string {
 
 type GCPService struct {
 	CommonEndpointService
-	AttachmentNames []string
+	AttachmentNames    []string
+	PortMappingEnabled bool
 }
 
 func (s *GCPService) Provider() string {
@@ -177,7 +179,8 @@ func NewPrivateEndpoint(akoPrivateEndpoint *akov2.AtlasPrivateEndpoint) Endpoint
 				Error:         akoPrivateEndpoint.Status.Error,
 				Interfaces:    newPrivateEndpointInterface(akoPrivateEndpoint),
 			},
-			ServiceName: akoPrivateEndpoint.Status.ServiceName,
+			ServiceName:      akoPrivateEndpoint.Status.ServiceName,
+			SupportedRegions: akoPrivateEndpoint.Spec.SupportedRegions,
 		}
 	case ProviderAzure:
 		return &AzureService{
@@ -200,7 +203,8 @@ func NewPrivateEndpoint(akoPrivateEndpoint *akov2.AtlasPrivateEndpoint) Endpoint
 				Error:         akoPrivateEndpoint.Status.Error,
 				Interfaces:    newPrivateEndpointInterface(akoPrivateEndpoint),
 			},
-			AttachmentNames: akoPrivateEndpoint.Status.ServiceAttachmentNames,
+			AttachmentNames:    akoPrivateEndpoint.Status.ServiceAttachmentNames,
+			PortMappingEnabled: akoPrivateEndpoint.Spec.PortMappingEnabled,
 		}
 	}
 
@@ -249,6 +253,7 @@ func NewPrivateEndpointStatus(peService EndpointService) status.AtlasPrivateEndp
 		switch pe := peService.(type) {
 		case *AWSService:
 			s.ServiceName = pe.ServiceName
+			s.SupportedRegions = pe.SupportedRegions
 		case *AzureService:
 			s.ServiceName = pe.ServiceName
 			s.ResourceID = pe.ResourceID
@@ -355,7 +360,8 @@ func serviceFromAtlas(peService *admin.EndpointService, endpoints EndpointInterf
 				Error:         peService.GetErrorMessage(),
 				Interfaces:    endpoints,
 			},
-			ServiceName: peService.GetEndpointServiceName(),
+			ServiceName:      peService.GetEndpointServiceName(),
+			SupportedRegions: peService.GetSupportedRemoteRegions(),
 		}
 	case ProviderAzure:
 		return &AzureService{
@@ -378,7 +384,8 @@ func serviceFromAtlas(peService *admin.EndpointService, endpoints EndpointInterf
 				Error:         peService.GetErrorMessage(),
 				Interfaces:    endpoints,
 			},
-			AttachmentNames: peService.GetServiceAttachmentNames(),
+			AttachmentNames:    peService.GetServiceAttachmentNames(),
+			PortMappingEnabled: peService.GetPortMappingEnabled(),
 		}
 	}
 
@@ -386,10 +393,27 @@ func serviceFromAtlas(peService *admin.EndpointService, endpoints EndpointInterf
 }
 
 func serviceCreateToAtlas(peService EndpointService) *admin.CloudProviderEndpointServiceRequest {
-	return &admin.CloudProviderEndpointServiceRequest{
+	req := &admin.CloudProviderEndpointServiceRequest{
 		ProviderName: peService.Provider(),
 		Region:       peService.Region(),
 	}
+	if awsSvc, ok := peService.(*AWSService); ok && len(awsSvc.SupportedRegions) > 0 {
+		req.SupportedRemoteRegions = &awsSvc.SupportedRegions
+	}
+	if gcpSvc, ok := peService.(*GCPService); ok && gcpSvc.PortMappingEnabled {
+		req.PortMappingEnabled = new(gcpSvc.PortMappingEnabled)
+	}
+	return req
+}
+
+func serviceUpdateToAtlas(peService EndpointService) *admin.ApiAtlasModifyEndpointServiceRequest {
+	req := &admin.ApiAtlasModifyEndpointServiceRequest{
+		CloudProvider: peService.Provider(),
+	}
+	if awsSvc, ok := peService.(*AWSService); ok {
+		req.SupportedRemoteRegions = &awsSvc.SupportedRegions
+	}
+	return req
 }
 
 func interfaceFromAtlas(peInterface *admin.PrivateLinkEndpoint) EndpointInterface {

--- a/internal/translation/privateendpoint/conversion.go
+++ b/internal/translation/privateendpoint/conversion.go
@@ -259,6 +259,7 @@ func NewPrivateEndpointStatus(peService EndpointService) status.AtlasPrivateEndp
 			s.ResourceID = pe.ResourceID
 		case *GCPService:
 			s.ServiceAttachmentNames = pe.AttachmentNames
+			s.PortMappingEnabled = pe.PortMappingEnabled
 		}
 	}
 }
@@ -411,7 +412,11 @@ func serviceUpdateToAtlas(peService EndpointService) *admin.ApiAtlasModifyEndpoi
 		CloudProvider: peService.Provider(),
 	}
 	if awsSvc, ok := peService.(*AWSService); ok {
-		req.SupportedRemoteRegions = &awsSvc.SupportedRegions
+		regions := awsSvc.SupportedRegions
+		if regions == nil {
+			regions = []string{}
+		}
+		req.SupportedRemoteRegions = &regions
 	}
 	return req
 }

--- a/internal/translation/privateendpoint/privateendpoint.go
+++ b/internal/translation/privateendpoint/privateendpoint.go
@@ -31,6 +31,7 @@ type PrivateEndpointService interface {
 	ListPrivateEndpoints(ctx context.Context, projectID, provider string) ([]EndpointService, error)
 	GetPrivateEndpoint(ctx context.Context, projectID, provider, ID string) (EndpointService, error)
 	CreatePrivateEndpointService(ctx context.Context, projectID string, peService EndpointService) (EndpointService, error)
+	UpdatePrivateEndpointService(ctx context.Context, projectID, serviceID string, peService EndpointService) (EndpointService, error)
 	DeleteEndpointService(ctx context.Context, projectID, provider, ID string) error
 	CreatePrivateEndpointInterface(ctx context.Context, projectID, provider, serviceID, gcpProjectID string, peInterface EndpointInterface) (EndpointInterface, error)
 	DeleteEndpointInterface(ctx context.Context, projectID, provider, serviceID, ID string) error
@@ -118,6 +119,16 @@ func (pe *PrivateEndpoint) CreatePrivateEndpointService(ctx context.Context, pro
 	}
 
 	return serviceFromAtlas(service, []EndpointInterface{}), nil
+}
+
+func (pe *PrivateEndpoint) UpdatePrivateEndpointService(ctx context.Context, projectID, serviceID string, peService EndpointService) (EndpointService, error) {
+	service, _, err := pe.api.UpdatePrivateEndpointService(ctx, projectID, serviceID, serviceUpdateToAtlas(peService)).
+		Execute()
+	if err != nil {
+		return nil, fmt.Errorf("failed to update the private endpoint service: %w", err)
+	}
+
+	return serviceFromAtlas(service, peService.EndpointInterfaces()), nil
 }
 
 func (pe *PrivateEndpoint) DeleteEndpointService(ctx context.Context, projectID, provider, ID string) error {

--- a/internal/translation/privateendpoint/privateendpoint_test.go
+++ b/internal/translation/privateendpoint/privateendpoint_test.go
@@ -626,3 +626,124 @@ func TestDeletePrivateEndpointInterface(t *testing.T) {
 		})
 	}
 }
+
+func TestUpdatePrivateEndpointService(t *testing.T) {
+	tests := map[string]struct {
+		service              EndpointService
+		mockUpdateReturnFunc func() (*admin.EndpointService, *http.Response, error)
+		expectedPE           EndpointService
+		expectedErr          error
+	}{
+		"failed to update the service": {
+			service: &AWSService{
+				CommonEndpointService: CommonEndpointService{
+					ID:          "pe-service-ID",
+					CloudRegion: "US_EAST_1",
+				},
+				SupportedRegions: []string{"US_WEST_1"},
+			},
+			mockUpdateReturnFunc: func() (*admin.EndpointService, *http.Response, error) {
+				return nil, &http.Response{}, errors.New("atlas failed to update")
+			},
+			expectedErr: fmt.Errorf("failed to update the private endpoint service: %w", errors.New("atlas failed to update")),
+		},
+		"update AWS supported regions": {
+			service: &AWSService{
+				CommonEndpointService: CommonEndpointService{
+					ID:          "pe-service-ID",
+					CloudRegion: "US_EAST_1",
+				},
+				SupportedRegions: []string{"US_WEST_1", "EU_WEST_1"},
+			},
+			mockUpdateReturnFunc: func() (*admin.EndpointService, *http.Response, error) {
+				return &admin.EndpointService{
+					CloudProvider:          "AWS",
+					Id:                     new("pe-service-ID"),
+					RegionName:             new("US_EAST_1"),
+					Status:                 new("AVAILABLE"),
+					SupportedRemoteRegions: &[]string{"US_WEST_1", "EU_WEST_1"},
+				}, &http.Response{}, nil
+			},
+			expectedPE: &AWSService{
+				CommonEndpointService: CommonEndpointService{
+					ID:            "pe-service-ID",
+					CloudRegion:   "US_EAST_1",
+					ServiceStatus: "AVAILABLE",
+				},
+				SupportedRegions: []string{"US_WEST_1", "EU_WEST_1"},
+			},
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctx := context.Background()
+			projectID := "project-ID"
+			serviceID := "pe-service-ID"
+			api := mockadmin.NewPrivateEndpointServicesApi(t)
+			api.EXPECT().UpdatePrivateEndpointService(ctx, projectID, serviceID, mock.AnythingOfType("*admin.ApiAtlasModifyEndpointServiceRequest")).
+				Return(admin.UpdatePrivateEndpointServiceApiRequest{ApiService: api})
+			api.EXPECT().UpdatePrivateEndpointServiceExecute(mock.AnythingOfType("admin.UpdatePrivateEndpointServiceApiRequest")).
+				Return(tt.mockUpdateReturnFunc())
+
+			pe := &PrivateEndpoint{api: api}
+
+			result, err := pe.UpdatePrivateEndpointService(ctx, projectID, serviceID, tt.service)
+			assert.Equal(t, tt.expectedErr, err)
+			assert.Equal(t, tt.expectedPE, result)
+		})
+	}
+}
+
+func TestServiceCreateToAtlas(t *testing.T) {
+	tests := map[string]struct {
+		service  EndpointService
+		expected *admin.CloudProviderEndpointServiceRequest
+	}{
+		"AWS without cross-region": {
+			service: &AWSService{
+				CommonEndpointService: CommonEndpointService{CloudRegion: "US_EAST_1"},
+			},
+			expected: &admin.CloudProviderEndpointServiceRequest{
+				ProviderName: "AWS",
+				Region:       "US_EAST_1",
+			},
+		},
+		"AWS with cross-region": {
+			service: &AWSService{
+				CommonEndpointService: CommonEndpointService{CloudRegion: "US_EAST_1"},
+				SupportedRegions:      []string{"US_WEST_1", "EU_WEST_1"},
+			},
+			expected: &admin.CloudProviderEndpointServiceRequest{
+				ProviderName:           "AWS",
+				Region:                 "US_EAST_1",
+				SupportedRemoteRegions: &[]string{"US_WEST_1", "EU_WEST_1"},
+			},
+		},
+		"GCP without port mapping": {
+			service: &GCPService{
+				CommonEndpointService: CommonEndpointService{CloudRegion: "EUROPE_WEST_3"},
+			},
+			expected: &admin.CloudProviderEndpointServiceRequest{
+				ProviderName: "GCP",
+				Region:       "EUROPE_WEST_3",
+			},
+		},
+		"GCP with port mapping": {
+			service: &GCPService{
+				CommonEndpointService: CommonEndpointService{CloudRegion: "EUROPE_WEST_3"},
+				PortMappingEnabled:    true,
+			},
+			expected: &admin.CloudProviderEndpointServiceRequest{
+				ProviderName:       "GCP",
+				Region:             "EUROPE_WEST_3",
+				PortMappingEnabled: new(true),
+			},
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := serviceCreateToAtlas(tt.service)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}

--- a/internal/translation/privateendpoint/privateendpoint_test.go
+++ b/internal/translation/privateendpoint/privateendpoint_test.go
@@ -747,3 +747,46 @@ func TestServiceCreateToAtlas(t *testing.T) {
 		})
 	}
 }
+
+func TestServiceUpdateToAtlas(t *testing.T) {
+	emptyRegions := []string{}
+	tests := map[string]struct {
+		service  EndpointService
+		expected *admin.ApiAtlasModifyEndpointServiceRequest
+	}{
+		"AWS nil regions sends empty slice not null": {
+			service: &AWSService{
+				CommonEndpointService: CommonEndpointService{},
+				SupportedRegions:      nil,
+			},
+			expected: &admin.ApiAtlasModifyEndpointServiceRequest{
+				CloudProvider:          "AWS",
+				SupportedRemoteRegions: &emptyRegions,
+			},
+		},
+		"AWS with regions sends them": {
+			service: &AWSService{
+				CommonEndpointService: CommonEndpointService{},
+				SupportedRegions:      []string{"US_WEST_1", "EU_WEST_1"},
+			},
+			expected: &admin.ApiAtlasModifyEndpointServiceRequest{
+				CloudProvider:          "AWS",
+				SupportedRemoteRegions: &[]string{"US_WEST_1", "EU_WEST_1"},
+			},
+		},
+		"non-AWS provider sends no regions": {
+			service: &AzureService{
+				CommonEndpointService: CommonEndpointService{},
+			},
+			expected: &admin.ApiAtlasModifyEndpointServiceRequest{
+				CloudProvider: "AZURE",
+			},
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := serviceUpdateToAtlas(tt.service)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}


### PR DESCRIPTION
# Summary

Updated AtlasPrivateEndpoint CR to the latest Atlas Go SDK. Added two missing fields: `portMappingEnabled` (GCP) and `supportedRegions` (AWS)