### PR TITLE
CLOUDP-410834: Allow Helm Chart to get CLI args as extraArgs

### DIFF
--- a/helm-charts/atlas-operator/templates/deployment.yaml
+++ b/helm-charts/atlas-operator/templates/deployment.yaml
@@ -38,6 +38,9 @@ spec:
             - --object-deletion-protection={{ .Values.objectDeletionProtection }}
             - --subobject-deletion-protection={{ .Values.subobjectDeletionProtection }}
             - "--leader-elect"
+            {{- with .Values.extraArgs }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           command:
             - /manager
           securityContext:

--- a/helm-charts/atlas-operator/values.yaml
+++ b/helm-charts/atlas-operator/values.yaml
@@ -93,6 +93,13 @@ securityContext:
   allowPrivilegeEscalation: false
 
 
+# extraArgs passes additional command-line arguments to the operator binary.
+# Use this to set flags not exposed as dedicated values, such as --log-level.
+# Example:
+#   extraArgs:
+#     - --log-level=debug
+extraArgs: []
+
 # configure extra environment variables
 # Extra environment variables are writen in kubernetes format and added "as is" to the pod's env variables
 # https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/


### PR DESCRIPTION
# Summary

Allow the Helm Chart to take extraArgs for the CLI.

## Proof of Work

CI must pass.

## Checklist
- [X] Have you linked a jira ticket and/or is the ticket in the title?
- [X] Have you checked whether your jira ticket required DOCSP changes?
- [X] Have you checked for release_note changes?
- [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
