### PR TITLE
Fix main linting after devbox update

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -37,6 +37,9 @@ linters:
     gosec:
       excludes:
         - G117 # Exported struct field name matching secret pattern - field names are not secrets, only values matter
+    govet:
+      disable:
+      - inline
   exclusions:
     generated: lax
     rules:


### PR DESCRIPTION
# Summary

Devbox update [broke linting with a very niche complain](https://github.com/mongodb/mongodb-atlas-kubernetes/actions/runs/27126413894/job/80059674299). This PR ignores that new `govet` check.

## Proof of Work

CI passes again.

## Checklist
- [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
