### PR TITLE
Avoid the workflow dirs and associated permissions

### DIFF
--- a/scripts/release-redhat-certified.sh
+++ b/scripts/release-redhat-certified.sh
@@ -52,13 +52,7 @@ cleanup() {
 trap cleanup EXIT
 pushd "${RH_CERTIFIED_OPENSHIFT_REPO_PATH}"
 
-git fetch upstream main
-git checkout -B "mongodb-atlas-kubernetes-operator-${version}" upstream/main
-
-# Drop upstream CI workflows before pushing: GitHub refuses pushes that add/modify
-# .github/workflows/* when the token lacks `workflows` permission.
-git rm -rf .github/workflows > /dev/null 2>&1 && \
-  git commit -m "chore: drop upstream ci workflows" --signoff || true
+git checkout -B "mongodb-atlas-kubernetes-operator-${version}" origin/main
 
 mkdir -p "${REPO}/${version}"
 

--- a/scripts/release-redhat-certified.sh
+++ b/scripts/release-redhat-certified.sh
@@ -52,7 +52,9 @@ cleanup() {
 trap cleanup EXIT
 pushd "${RH_CERTIFIED_OPENSHIFT_REPO_PATH}"
 
-git checkout -B "mongodb-atlas-kubernetes-operator-${version}" origin/main
+git fetch upstream main
+git push -f origin upstream/main:main
+git checkout -B "mongodb-atlas-kubernetes-operator-${version}" upstream/main
 
 mkdir -p "${REPO}/${version}"
 

--- a/scripts/release-redhat-certified.sh
+++ b/scripts/release-redhat-certified.sh
@@ -55,6 +55,11 @@ pushd "${RH_CERTIFIED_OPENSHIFT_REPO_PATH}"
 git fetch upstream main
 git checkout -B "mongodb-atlas-kubernetes-operator-${version}" upstream/main
 
+# Drop upstream CI workflows before pushing: GitHub refuses pushes that add/modify
+# .github/workflows/* when the token lacks `workflows` permission.
+git rm -rf .github/workflows > /dev/null 2>&1 && \
+  git commit -m "chore: drop upstream ci workflows" --signoff || true
+
 mkdir -p "${REPO}/${version}"
 
 cp -r "${PROJECT_ROOT}/releases/v${version}/bundle.Dockerfile" \

--- a/scripts/release-redhat-openshift.sh
+++ b/scripts/release-redhat-openshift.sh
@@ -41,7 +41,9 @@ cleanup() {
 trap cleanup EXIT
 pushd "${RH_COMMUNITY_OPENSHIFT_REPO_PATH}"
 
-git checkout -B "mongodb-atlas-operator-community-${version}" origin/main
+git fetch upstream main
+git push -f origin upstream/main:main
+git checkout -B "mongodb-atlas-operator-community-${version}" upstream/main
 
 # Copy operator from community-operators repo
 # Remove destination if it exists to avoid nested directory structure

--- a/scripts/release-redhat-openshift.sh
+++ b/scripts/release-redhat-openshift.sh
@@ -41,13 +41,7 @@ cleanup() {
 trap cleanup EXIT
 pushd "${RH_COMMUNITY_OPENSHIFT_REPO_PATH}"
 
-git fetch upstream main
-git checkout -B "mongodb-atlas-operator-community-${version}" upstream/main
-
-# Drop upstream CI workflows before pushing: GitHub refuses pushes that add/modify
-# .github/workflows/* when the token lacks `workflows` permission.
-git rm -rf .github/workflows > /dev/null 2>&1 && \
-  git commit -m "chore: drop upstream ci workflows" --signoff || true
+git checkout -B "mongodb-atlas-operator-community-${version}" origin/main
 
 # Copy operator from community-operators repo
 # Remove destination if it exists to avoid nested directory structure

--- a/scripts/release-redhat-openshift.sh
+++ b/scripts/release-redhat-openshift.sh
@@ -44,6 +44,11 @@ pushd "${RH_COMMUNITY_OPENSHIFT_REPO_PATH}"
 git fetch upstream main
 git checkout -B "mongodb-atlas-operator-community-${version}" upstream/main
 
+# Drop upstream CI workflows before pushing: GitHub refuses pushes that add/modify
+# .github/workflows/* when the token lacks `workflows` permission.
+git rm -rf .github/workflows > /dev/null 2>&1 && \
+  git commit -m "chore: drop upstream ci workflows" --signoff || true
+
 # Copy operator from community-operators repo
 # Remove destination if it exists to avoid nested directory structure
 rm -rf "${openshift}"

--- a/scripts/release-redhat.sh
+++ b/scripts/release-redhat.sh
@@ -33,7 +33,9 @@ cleanup() {
 trap cleanup EXIT
 pushd "${RH_COMMUNITY_OPERATORHUB_REPO_PATH}"
 
-git checkout -B "mongodb-atlas-operator-community-${version}" origin/main
+git fetch upstream main
+git push -f origin upstream/main:main
+git checkout -B "mongodb-atlas-operator-community-${version}" upstream/main
 
 repo="${RH_COMMUNITY_OPERATORHUB_REPO_PATH}/operators/mongodb-atlas-kubernetes"
 mkdir -p "${repo}/${version}"

--- a/scripts/release-redhat.sh
+++ b/scripts/release-redhat.sh
@@ -33,13 +33,7 @@ cleanup() {
 trap cleanup EXIT
 pushd "${RH_COMMUNITY_OPERATORHUB_REPO_PATH}"
 
-git fetch upstream main
-git checkout -B "mongodb-atlas-operator-community-${version}" upstream/main
-
-# Drop upstream CI workflows before pushing: GitHub refuses pushes that add/modify
-# .github/workflows/* when the token lacks `workflows` permission.
-git rm -rf .github/workflows > /dev/null 2>&1 && \
-  git commit -m "chore: drop upstream ci workflows" --signoff || true
+git checkout -B "mongodb-atlas-operator-community-${version}" origin/main
 
 repo="${RH_COMMUNITY_OPERATORHUB_REPO_PATH}/operators/mongodb-atlas-kubernetes"
 mkdir -p "${repo}/${version}"

--- a/scripts/release-redhat.sh
+++ b/scripts/release-redhat.sh
@@ -36,6 +36,11 @@ pushd "${RH_COMMUNITY_OPERATORHUB_REPO_PATH}"
 git fetch upstream main
 git checkout -B "mongodb-atlas-operator-community-${version}" upstream/main
 
+# Drop upstream CI workflows before pushing: GitHub refuses pushes that add/modify
+# .github/workflows/* when the token lacks `workflows` permission.
+git rm -rf .github/workflows > /dev/null 2>&1 && \
+  git commit -m "chore: drop upstream ci workflows" --signoff || true
+
 repo="${RH_COMMUNITY_OPERATORHUB_REPO_PATH}/operators/mongodb-atlas-kubernetes"
 mkdir -p "${repo}/${version}"
 cp -r "${PROJECT_ROOT}/releases/v${version}/bundle.Dockerfile" \


### PR DESCRIPTION
# Summary

Fix Push to RedHat workflow by pulling from origin instead of upstream. That way the CI automation does not complain it lacks permissions to access workflows, which it does not want to touch anyways.

## Proof of Work

⚠️ Branch test

## Checklist
- [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?

