### PR TITLE
fix: stabilize private endpoint e2e test retries

### DIFF
--- a/test/e2e/privateendpoint_test.go
+++ b/test/e2e/privateendpoint_test.go
@@ -56,22 +56,7 @@ var _ = Describe("Private Endpoints", Label("private-endpoint"), FlakeAttempts(3
 		if CurrentSpecReport().Failed() {
 			Expect(actions.SaveProjectsToFile(testData.Context, testData.K8SClient, testData.Resources.Namespace)).Should(Succeed())
 		}
-		By("Delete private endpoints before project deletion", func() {
-			peList := &akov2.AtlasPrivateEndpointList{}
-			Expect(testData.K8SClient.List(testData.Context, peList, client.InNamespace(testData.Resources.Namespace))).To(Succeed())
-			for i := range peList.Items {
-				_ = testData.K8SClient.Delete(testData.Context, &peList.Items[i])
-			}
-			Eventually(func(g Gomega) {
-				pList := &akov2.AtlasPrivateEndpointList{}
-				g.Expect(testData.K8SClient.List(testData.Context, pList, client.InNamespace(testData.Resources.Namespace))).To(Succeed())
-				g.Expect(pList.Items).To(BeEmpty())
-			}).WithTimeout(15 * time.Minute).WithPolling(10 * time.Second).Should(Succeed())
-		})
-		By("Delete Project and cluster resources", func() {
-			actions.DeleteTestDataProject(testData)
-			actions.AfterEachFinalCleanup([]model.TestDataProvider{*testData})
-		})
+		deletePrivateEndpointsAndProject(testData)
 	})
 
 	DescribeTable(
@@ -285,10 +270,24 @@ var _ = Describe("Migrate private endpoints from sub-resources to separate custo
 		if CurrentSpecReport().Failed() {
 			Expect(actions.SaveProjectsToFile(testData.Context, testData.K8SClient, testData.Resources.Namespace)).Should(Succeed())
 		}
-		By("Delete Project and cluster resources", func() {
-			actions.DeleteTestDataProject(testData)
-			actions.AfterEachFinalCleanup([]model.TestDataProvider{*testData})
+		By("Clear project sub-resource private endpoints", func() {
+			Expect(testData.K8SClient.Get(testData.Context, client.ObjectKeyFromObject(testData.Project), testData.Project)).To(Succeed())
+			if len(testData.Project.Spec.PrivateEndpoints) > 0 {
+				// Resume reconciliation in case it was paused, and clear sub-resource PEs so the
+				// controller finishes deleting Atlas PE services before we delete the project.
+				// Without this, the project controller races: it fires Atlas DELETE on PE services
+				// then immediately tries to DELETE the group, which Atlas rejects with 409 until
+				// the PE services are fully terminated.
+				delete(testData.Project.Annotations, customresource.ReconciliationPolicyAnnotation)
+				testData.Project.Spec.PrivateEndpoints = nil
+				Expect(testData.K8SClient.Update(testData.Context, testData.Project)).To(Succeed())
+				Eventually(func(g Gomega) {
+					g.Expect(testData.K8SClient.Get(testData.Context, client.ObjectKeyFromObject(testData.Project), testData.Project)).To(Succeed())
+					g.Expect(testData.Project.Status.Conditions).To(ContainElement(conditions.MatchCondition(api.TrueCondition(api.ReadyType))))
+				}).WithTimeout(15 * time.Minute).WithPolling(10 * time.Second).Should(Succeed())
+			}
 		})
+		deletePrivateEndpointsAndProject(testData)
 	})
 
 	It("Should migrate a private endpoint configured in a project as sub-resource to a separate custom resource", func(ctx SpecContext) {
@@ -652,10 +651,7 @@ var _ = Describe("Independent resource should no conflict with sub-resource", La
 		if CurrentSpecReport().Failed() {
 			Expect(actions.SaveProjectsToFile(testData.Context, testData.K8SClient, testData.Resources.Namespace)).Should(Succeed())
 		}
-		By("Delete Project and cluster resources", func() {
-			actions.DeleteTestDataProject(testData)
-			actions.AfterEachFinalCleanup([]model.TestDataProvider{*testData})
-		})
+		deletePrivateEndpointsAndProject(testData)
 	})
 
 	It("Should migrate a private endpoint configured in a project as sub-resource to a separate custom resource", func(ctx SpecContext) {
@@ -749,6 +745,25 @@ var _ = Describe("Independent resource should no conflict with sub-resource", La
 		})
 	})
 })
+
+func deletePrivateEndpointsAndProject(data *model.TestDataProvider) {
+	By("Delete private endpoints before project deletion", func() {
+		peList := &akov2.AtlasPrivateEndpointList{}
+		Expect(data.K8SClient.List(data.Context, peList, client.InNamespace(data.Resources.Namespace))).To(Succeed())
+		for i := range peList.Items {
+			_ = data.K8SClient.Delete(data.Context, &peList.Items[i])
+		}
+		Eventually(func(g Gomega) {
+			pList := &akov2.AtlasPrivateEndpointList{}
+			g.Expect(data.K8SClient.List(data.Context, pList, client.InNamespace(data.Resources.Namespace))).To(Succeed())
+			g.Expect(pList.Items).To(BeEmpty())
+		}).WithTimeout(15 * time.Minute).WithPolling(10 * time.Second).Should(Succeed())
+	})
+	By("Delete Project and cluster resources", func() {
+		actions.DeleteTestDataProject(data)
+		actions.AfterEachFinalCleanup([]model.TestDataProvider{*data})
+	})
+}
 
 func statusForProvider(peStatus []status.ProjectPrivateEndpoint, providerName provider.ProviderName) *status.ProjectPrivateEndpoint {
 	for _, s := range peStatus {

--- a/test/e2e/privateendpoint_test.go
+++ b/test/e2e/privateendpoint_test.go
@@ -56,6 +56,18 @@ var _ = Describe("Private Endpoints", Label("private-endpoint"), FlakeAttempts(3
 		if CurrentSpecReport().Failed() {
 			Expect(actions.SaveProjectsToFile(testData.Context, testData.K8SClient, testData.Resources.Namespace)).Should(Succeed())
 		}
+		By("Delete private endpoints before project deletion", func() {
+			peList := &akov2.AtlasPrivateEndpointList{}
+			Expect(testData.K8SClient.List(testData.Context, peList, client.InNamespace(testData.Resources.Namespace))).To(Succeed())
+			for i := range peList.Items {
+				_ = testData.K8SClient.Delete(testData.Context, &peList.Items[i])
+			}
+			Eventually(func(g Gomega) {
+				pList := &akov2.AtlasPrivateEndpointList{}
+				g.Expect(testData.K8SClient.List(testData.Context, pList, client.InNamespace(testData.Resources.Namespace))).To(Succeed())
+				g.Expect(pList.Items).To(BeEmpty())
+			}).WithTimeout(15 * time.Minute).WithPolling(10 * time.Second).Should(Succeed())
+		})
 		By("Delete Project and cluster resources", func() {
 			actions.DeleteTestDataProject(testData)
 			actions.AfterEachFinalCleanup([]model.TestDataProvider{*testData})
@@ -71,7 +83,15 @@ var _ = Describe("Private Endpoints", Label("private-endpoint"), FlakeAttempts(3
 			actions.ProjectCreationFlow(testData)
 
 			By("Preparing private endpoint resource", func() {
+				// Reset the entire object to clear stale state from FlakeAttempts retries.
+				// The pe pointer is shared across attempts; Kubernetes populates fields like
+				// ResourceVersion on Create which would cause subsequent Create calls to fail.
+				name := pe.Name
+				providerName := pe.Spec.Provider
+				*pe = akov2.AtlasPrivateEndpoint{}
+				pe.Name = name
 				pe.Namespace = testData.Resources.Namespace
+				pe.Spec.Provider = providerName
 				pe.Spec.ProjectRef = &common.ResourceRefNamespaced{
 					Name:      testData.Project.Name,
 					Namespace: testData.Project.Namespace,


### PR DESCRIPTION
# Summary

The FlakeAttempts(3) retries were broken by two bugs in the test teardown and setup. First, AfterEach did not delete AtlasPrivateEndpoint resources before the project, causing DeleteTestDataProject to block for 15 minutes on every failed attempt (the project controller refuses deletion while PE dependencies exist). Second, the pe pointer in Entry(...) is shared across retry attempts; after Kubernetes populated ResourceVersion on the first Create, subsequent attempts failed immediately with "resourceVersion should not be set on objects to be created".

Fix by explicitly deleting all PEs in the namespace during AfterEach before project deletion, and resetting the pe object at the start of each attempt to clear stale Kubernetes metadata.

## Proof of Work

CI must pass including fixed e2e test.

## Checklist
- [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?

