### PR TITLE
HELP-95382: Let AKO continue to reconcile DBUser scopes if clusters aren't ready

### DIFF
--- a/internal/controller/atlasdatabaseuser/databaseuser.go
+++ b/internal/controller/atlasdatabaseuser/databaseuser.go
@@ -100,10 +100,10 @@ func (r *AtlasDatabaseUserReconciler) dbuLifeCycle(ctx *workflow.Context, dbUser
 
 	scopesAreValid, err := r.areDeploymentScopesValid(ctx, deploymentService, atlasProject.ID, atlasDatabaseUser)
 	if err != nil {
-		return r.terminate(ctx, atlasDatabaseUser, api.DatabaseUserReadyType, workflow.DatabaseUserInvalidSpec, false, err)
+		return r.terminate(ctx, atlasDatabaseUser, api.DatabaseUserReadyType, workflow.DatabaseUserInvalidSpec, true, err)
 	}
 	if !scopesAreValid {
-		return r.terminate(ctx, atlasDatabaseUser, api.DatabaseUserReadyType, workflow.DatabaseUserInvalidSpec, false, errors.New("\"scopes\" field refer to one or more deployments that don't exist"))
+		return r.terminate(ctx, atlasDatabaseUser, api.DatabaseUserReadyType, workflow.DatabaseUserInvalidSpec, true, errors.New("\"scopes\" field refer to one or more deployments that don't exist"))
 	}
 
 	dbUserExists := databaseUserInAtlas != nil

--- a/internal/controller/atlasdatabaseuser/databaseuser_test.go
+++ b/internal/controller/atlasdatabaseuser/databaseuser_test.go
@@ -536,6 +536,7 @@ func TestDbuLifeCycle(t *testing.T) {
 
 				return service
 			},
+			wantErr:        true,
 			expectedResult: ctrl.Result{},
 			expectedConditions: []api.Condition{
 				api.FalseCondition(api.DatabaseUserReadyType).
@@ -591,6 +592,7 @@ func TestDbuLifeCycle(t *testing.T) {
 
 				return service
 			},
+			wantErr:        true,
 			expectedResult: ctrl.Result{},
 			expectedConditions: []api.Condition{
 				api.FalseCondition(api.DatabaseUserReadyType).


### PR DESCRIPTION
# Summary

Let AKO continue to reconcile DBUser scopes if clusters aren't ready. When creating a new AtlasDeployment and AtlasDatabaseUser for the deployment the user will fail to create initially since the deployment is not yet ready and we will only retry after 3h which makes the user creation slow and misleading (if the user checks what’s going on after the deployment is up they will just see a message about scoped not being ready)
