### PR TITLE
fix: retry AtlasDatabaseUser reconcile when scope not ready

### DIFF
--- a/internal/controller/atlasdatabaseuser/databaseuser.go
+++ b/internal/controller/atlasdatabaseuser/databaseuser.go
@@ -103,7 +103,7 @@ func (r *AtlasDatabaseUserReconciler) dbuLifeCycle(ctx *workflow.Context, dbUser
 		return r.terminate(ctx, atlasDatabaseUser, api.DatabaseUserReadyType, workflow.DatabaseUserInvalidSpec, false, err)
 	}
 	if !scopesAreValid {
-		return r.terminate(ctx, atlasDatabaseUser, api.DatabaseUserReadyType, workflow.DatabaseUserInvalidSpec, false, errors.New("\"scopes\" field refer to one or more deployments that don't exist"))
+		return r.terminate(ctx, atlasDatabaseUser, api.DatabaseUserReadyType, workflow.DatabaseUserInvalidSpec, true, errors.New("\"scopes\" field refer to one or more deployments that don't exist"))
 	}
 
 	dbUserExists := databaseUserInAtlas != nil

--- a/internal/controller/atlasdatabaseuser/databaseuser_test.go
+++ b/internal/controller/atlasdatabaseuser/databaseuser_test.go
@@ -592,6 +592,7 @@ func TestDbuLifeCycle(t *testing.T) {
 				return service
 			},
 			expectedResult: ctrl.Result{},
+			wantErr:        true,
 			expectedConditions: []api.Condition{
 				api.FalseCondition(api.DatabaseUserReadyType).
 					WithReason(string(workflow.DatabaseUserInvalidSpec)).


### PR DESCRIPTION
## Summary

Fixes [HELP-95382](https://jira.mongodb.org/browse/HELP-95382) — *Atlas Kubernetes Operator takes too long to reconcile*.

When an `AtlasDatabaseUser` is created alongside an `AtlasDeployment` and references that deployment in `spec.scopes`, the user fails to create initially because the deployment isn't ready yet. `areDeploymentScopesValid` returns `false` (the scoped cluster doesn't exist yet), and `dbuLifeCycle` terminated the reconcile with `retry=false`. That clears the error and sets `requeueAfter=-1`, so the user is only re-reconciled on the next watch event or the global resync (~3h) — making user creation appear stuck behind a misleading "scopes not ready" message.

## Change

`internal/controller/atlasdatabaseuser/databaseuser.go` — flip the retry flag to `true` on the scope-invalid termination. With `retry=true` the error is preserved, so `ReconcileResult()` returns `reconcile.Result{}, err` and controller-runtime requeues with rate-limited backoff. The user then reconciles as soon as the scoped deployment becomes ready, instead of waiting for the resync.

## Tests

- Updated `TestDbuLifeCycle/deployment scope is invalid` to expect an error (requeue) instead of a silent terminate. Verified red before the source change, green after (TDD).
- Full `internal/controller/atlasdatabaseuser/...` package + `go vet` pass.

## Release note (draft, for release author)

- Fixed `AtlasDatabaseUser` resources that reference a not-yet-ready deployment in `scopes` getting stuck for hours; the user now retries promptly and becomes ready as soon as the scoped deployment is available.

## Related / out of scope

The adjacent termination for a genuine API error from `ClusterExists` (`databaseuser.go:103`) also uses `retry=false` with reason `DatabaseUserInvalidSpec`, which is arguably wrong for a transient API failure. Left unchanged here to keep the fix focused on the reported issue.