### PR TITLE
DEVPROD-34208: use DevProd ECR for container images instead of Artifactory

### DIFF
--- a/.github/workflows/rebuild-released-images.yml
+++ b/.github/workflows/rebuild-released-images.yml
@@ -56,6 +56,9 @@ jobs:
   build-and-publish-image:
     environment: release
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     needs:
       - read-versions
     env:
@@ -210,13 +213,17 @@ jobs:
             ${{ env.IMAGE_REPOSITORY }}:${{ matrix.version }}
             quay.io/${{ env.IMAGE_REPOSITORY }}:${{ steps.daily-tag.outputs.daily-tag }}
             quay.io/${{ env.IMAGE_REPOSITORY }}:${{ matrix.version }}
-      - name: Login to artifactory.corp.mongodb.com
+      - name: Configure AWS credentials for DevProd Platforms ECR
+        if: steps.check-signing-support.outputs.sign == 'true'
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.DEVPROD_PLATFORMS_ECR_ROLE_ARN }}
+          aws-region: us-east-1
+      - name: Login to DevProd Platforms ECR
         if: steps.check-signing-support.outputs.sign == 'true'
         uses: docker/login-action@v4
         with:
-          registry: artifactory.corp.mongodb.com
-          username: ${{ secrets.MDB_ARTIFACTORY_USERNAME }}
-          password: ${{ secrets.MDB_ARTIFACTORY_PASSWORD }}
+          registry: 901841024863.dkr.ecr.us-east-1.amazonaws.com
       - name: Sign images (Non Devbox)
         if: steps.check-signing-support.outputs.sign == 'true' && steps.check-devbox.outputs.devbox-build == 'false'
         env:

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -122,6 +122,10 @@ jobs:
     name: Release images
     runs-on: ubuntu-latest
     environment: release
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
     needs:
     - image2commit
     - compute-repo
@@ -175,12 +179,16 @@ jobs:
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}
 
-      - name: Log in to Artifactory
+      - name: Configure AWS credentials for DevProd Platforms ECR
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.DEVPROD_PLATFORMS_ECR_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Log in to DevProd Platforms ECR
         uses: docker/login-action@v4
         with:
-          registry: artifactory.corp.mongodb.com
-          username: ${{ secrets.MDB_ARTIFACTORY_USERNAME }}
-          password: ${{ secrets.MDB_ARTIFACTORY_PASSWORD }}
+          registry: 901841024863.dkr.ecr.us-east-1.amazonaws.com
 
       # Prepare release PR: checkout branch, build artifacts, and create PR
       # This combines: prepare-released-branch + build-release-pr + create-release-pr

--- a/.github/workflows/send-sboms.yml
+++ b/.github/workflows/send-sboms.yml
@@ -15,6 +15,9 @@ jobs:
   send-sboms:
     runs-on: ubuntu-latest
     environment: release
+    permissions:
+      contents: read
+      id-token: write
     steps:
     - name: Checkout code
       uses: actions/checkout@v7
@@ -25,6 +28,17 @@ jobs:
       uses: jetify-com/devbox-install-action@v0.15.0
       with:
         enable-cache: 'true'
+
+    - name: Configure AWS credentials for DevProd Platforms ECR
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: ${{ secrets.DEVPROD_PLATFORMS_ECR_ROLE_ARN }}
+        aws-region: us-east-1
+
+    - name: Log in to DevProd Platforms ECR
+      uses: docker/login-action@v4
+      with:
+        registry: 901841024863.dkr.ecr.us-east-1.amazonaws.com
 
     - name: Send SBOMs to Kondukto
       env:

--- a/scripts/augment-sbom.sh
+++ b/scripts/augment-sbom.sh
@@ -30,7 +30,7 @@ set -euo pipefail
 ###
 
 # Constants
-registry=artifactory.corp.mongodb.com/release-tools-container-registry-public-local
+registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/release-infrastructure
 silkbomb_img="${registry}/silkbomb:2.0"
 docker_platform="linux/amd64"
 
@@ -51,6 +51,13 @@ target="${target_dir}/linux-${arch}.sbom.augmented.json"
 target_name=$(basename "${target}")
 
 echo "Computed Kondukto branch: ${kondukto_branch}"
+
+# In CI the workflow already authenticates to ECR via OIDC; locally we log in ourselves.
+if [ "${CI:-}" != "true" ]; then
+  profile="${DEVPROD_PLATFORMS_ECR_AWS_PROFILE:-ECRScopedAccess-901841024863}"
+  aws ecr get-login-password --region us-east-1 --profile "${profile}" |
+    docker login --username AWS --password-stdin 901841024863.dkr.ecr.us-east-1.amazonaws.com
+fi
 
 # Download
 docker run --platform="${docker_platform}" --rm -v "${target_dir}":/tmp \

--- a/scripts/sign.sh
+++ b/scripts/sign.sh
@@ -38,6 +38,13 @@ SIGNING_ENVFILE="${TMPDIR}/signing-envfile"
   echo "COSIGN_REPOSITORY=${SIGNATURE_REPO}";
 }  > "${SIGNING_ENVFILE}"
 
+# In CI the workflow already authenticates to ECR via OIDC; locally we log in ourselves.
+if [ "${CI:-}" != "true" ]; then
+  profile="${DEVPROD_PLATFORMS_ECR_AWS_PROFILE:-ECRScopedAccess-901841024863}"
+  aws ecr get-login-password --region us-east-1 --profile "${profile}" |
+    docker login --username AWS --password-stdin 901841024863.dkr.ecr.us-east-1.amazonaws.com
+fi
+
 docker run \
   --platform linux/amd64 \
   --env-file="${SIGNING_ENVFILE}" \
@@ -45,7 +52,7 @@ docker run \
   --rm \
   -v "$(pwd):$(pwd)" \
   -w "$(pwd)" \
-  artifactory.corp.mongodb.com/release-tools-container-registry-local/garasign-cosign \
+  901841024863.dkr.ecr.us-east-1.amazonaws.com/release-infrastructure/garasign-cosign \
   cosign sign --key "${PKCS11_URI}" \
   --tlog-upload=false --use-signing-config=false --new-bundle-format=false "${img}" && \
   echo "✍️  Signed"

--- a/scripts/upload-to-kondukto.sh
+++ b/scripts/upload-to-kondukto.sh
@@ -29,7 +29,7 @@ set -euo pipefail
 ###
 
 # Constants
-registry=artifactory.corp.mongodb.com/release-tools-container-registry-public-local
+registry=901841024863.dkr.ecr.us-east-1.amazonaws.com/release-infrastructure
 silkbomb_img="${registry}/silkbomb:2.0"
 docker_platform="linux/amd64"
 
@@ -47,6 +47,13 @@ arch=$(jq -r < "${sbom_lite_json}" '.components[0].properties[] | select( .name 
 kondukto_branch="${kondukto_branch_prefix}-linux-${arch}"
 
 echo "Computed Kondukto branch: ${kondukto_branch}"
+
+# In CI the workflow already authenticates to ECR via OIDC; locally we log in ourselves.
+if [ "${CI:-}" != "true" ]; then
+  profile="${DEVPROD_PLATFORMS_ECR_AWS_PROFILE:-ECRScopedAccess-901841024863}"
+  aws ecr get-login-password --region us-east-1 --profile "${profile}" |
+    docker login --username AWS --password-stdin 901841024863.dkr.ecr.us-east-1.amazonaws.com
+fi
 
 # Upload
 docker run --platform="${docker_platform}" --rm -v "${PWD}":/pwd \


### PR DESCRIPTION
# Summary

MongoDB Artifactory will be deprecated soon, so I am updating the source for the DevProd container images to use ECR instead.

## Proof of Work

- **Send SBOMs to Kondukto**: https://github.com/mongodb/mongodb-atlas-kubernetes/actions/runs/30276074704/job/90010367388

## Checklist
- [x] Have you linked a jira ticket and/or is the ticket in the title?
- [x] Have you checked whether your jira ticket required DOCSP changes?
- [x] Have you checked for release_note changes?
- [x] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
