### PR TITLE
Fix create-github-app-token args

### DIFF
--- a/.github/workflows/devbox-update.yml
+++ b/.github/workflows/devbox-update.yml
@@ -20,7 +20,7 @@ jobs:
       id: generate_token
       uses: actions/create-github-app-token@v3
       with:
-        app-id: ${{ secrets.AKO_RELEASER_APP_ID }}
+        client-id: ${{ secrets.AKO_RELEASER_CLIENT_ID }}
         private-key: ${{ secrets.AKO_RELEASER_RSA_KEY }}
         owner: ${{ github.repository_owner }}
         repositories: mongodb-atlas-kubernetes

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -158,7 +158,7 @@ jobs:
         id: generate_token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.AKO_RELEASER_APP_ID }}
+          client-id: ${{ secrets.AKO_RELEASER_CLIENT_ID }}
           private-key: ${{ secrets.AKO_RELEASER_RSA_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: |

--- a/.github/workflows/release-rh.yml
+++ b/.github/workflows/release-rh.yml
@@ -37,7 +37,7 @@ jobs:
       id: generate_token
       uses: actions/create-github-app-token@v3
       with:
-        app-id: ${{ secrets.AKO_RELEASER_APP_ID }}
+        client-id: ${{ secrets.AKO_RELEASER_CLIENT_ID }}
         private-key: ${{ secrets.AKO_RELEASER_RSA_KEY }}
         owner: mongodb-forks
         repositories: >-

--- a/.github/workflows/sync-helm-charts.yml
+++ b/.github/workflows/sync-helm-charts.yml
@@ -31,7 +31,7 @@ jobs:
         id: generate_token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.AKO_RELEASER_APP_ID }}
+          client-id: ${{ secrets.AKO_RELEASER_CLIENT_ID }}
           private-key: ${{ secrets.AKO_RELEASER_RSA_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: |

--- a/.github/workflows/update-helm.yml
+++ b/.github/workflows/update-helm.yml
@@ -26,7 +26,7 @@ jobs:
         id: generate_token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.AKO_RELEASER_APP_ID }}
+          client-id: ${{ secrets.AKO_RELEASER_CLIENT_ID }}
           private-key: ${{ secrets.AKO_RELEASER_RSA_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: |

--- a/.github/workflows/update-sdk.yml
+++ b/.github/workflows/update-sdk.yml
@@ -20,7 +20,7 @@ jobs:
         id: generate_token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.AKO_RELEASER_APP_ID }}
+          client-id: ${{ secrets.AKO_RELEASER_CLIENT_ID }}
           private-key: ${{ secrets.AKO_RELEASER_RSA_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: mongodb-atlas-kubernetes


### PR DESCRIPTION
# Summary

Fix errors like this:
https://github.com/mongodb/mongodb-atlas-kubernetes/actions/runs/30278024076/job/90019600031
`Warning: Input 'app-id' has been deprecated with message: Use 'client-id' instead.`

After we recently bumped to `actions/create-github-app-token@v3`

## Proof of Work

✅ [Sync workflow passes in this branch](https://github.com/mongodb/mongodb-atlas-kubernetes/actions/runs/30278027732)

## Checklist
- [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?

