### PR TITLE
Fix daily rebuilds sign bug

### DIFF
--- a/.github/workflows/rebuild-released-images.yml
+++ b/.github/workflows/rebuild-released-images.yml
@@ -116,6 +116,11 @@ jobs:
           else
             echo "sign=false" >> $GITHUB_OUTPUT
           fi
+      - name: Update signing scripts from main
+        if: steps.check-signing-support.outputs.sign == 'true'
+        run: |
+          git fetch origin main --depth=1
+          git checkout origin/main -- scripts/sign.sh scripts/sign-multiarch.sh scripts/verify.sh
       - name: Check for devbox
         id: check-devbox
         run: |


### PR DESCRIPTION
# Summary

Should fix errors such as:
https://github.com/mongodb/mongodb-atlas-kubernetes/actions/runs/30320693917/job/90208293860
`Unable to find image 'artifactory.corp.mongodb.com/release-tools-container-registry-local/garasign-cosign:latest' locally`

The artifactory repo has been discontinued by the DEVPROD team in favor of an AWS ECR. But the old rebuilt branches still used the signing script tied to artifactory. This fix updates the scripts in-place to allow siging to work again, using the new ECR now to pull the garasing container.

## Proof of Work

✅ [Test daily build using this branch](https://github.com/mongodb/mongodb-atlas-kubernetes/actions/runs/30343674251)

## Checklist
- [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?

