### PR TITLE
KUBE-269: Fix syntax breking SDK automation workflow

### DIFF
--- a/.github/workflows/update-sdk.yml
+++ b/.github/workflows/update-sdk.yml
@@ -10,7 +10,7 @@ permissions:
   pull-requests: write
 
 jobs:
-  update-devbox:
+  update-sdk:
     runs-on: ubuntu-latest
     environment: release
     steps:
@@ -66,8 +66,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh pr create --head=${{ steps.generate_branch.outputs.BRANCH_NAME }} --title "Atlas SDK Dependency Update" \
-          --body "This PR contains the new updates to the Atlas Go SDK.
-
-If this PR does not merge cleanly (build/test failures) or the bump touches public API behavior, follow the runbook: https://github.com/mongodb/mongodb-atlas-kubernetes/blob/main/docs/dev/atlas-sdk-breaking-changes.md" \
+          --body $'This PR contains the new updates to the Atlas Go SDK.\n\nIf this PR does not merge cleanly (build/test failures) or the bump touches public API behavior, follow the runbook: https://github.com/mongodb/mongodb-atlas-kubernetes/blob/main/docs/dev/atlas-sdk-breaking-changes.md' \
           && echo "Pull request created"
 

--- a/scripts/update-sdk.sh
+++ b/scripts/update-sdk.sh
@@ -16,8 +16,9 @@
 
 set -euo pipefail
 
-CURRENT_SDK_TAG=$(go list -m all | grep go.mongodb.org/atlas-sdk | awk -F '/| ' '{print $4}')
-CURRENT_SDK_RELEASE=$(echo "${CURRENT_SDK_TAG}" | cut -d '.' -f 1)
+CURRENT_SDK_LINE=$(grep -E '^\s*go\.mongodb\.org/atlas-sdk/v[0-9]+ v[0-9.]+$' go.mod)
+CURRENT_SDK_TAG=$(awk '{print $2}' <<< "${CURRENT_SDK_LINE}")
+CURRENT_SDK_RELEASE=$(awk '{print $1}' <<< "${CURRENT_SDK_LINE}" | awk -F/ '{print $NF}')
 echo "CURRENT_SDK_TAG: $CURRENT_SDK_TAG"
 echo "CURRENT_SDK_RELEASE: $CURRENT_SDK_RELEASE"
 
@@ -39,7 +40,7 @@ CRD_CONFIGS_TO_UPDATE=(
 )
 for file in "${CRD_CONFIGS_TO_UPDATE[@]}"; do
 	echo "==> Updating ${file}..."
-	sed -i -e "s/${CURRENT_SDK_RELEASE}/${LATEST_SDK_RELEASE}/g" "${file}"
+	sed -i.bak -e "s/${CURRENT_SDK_RELEASE}/${LATEST_SDK_RELEASE}/g" "${file}" && rm -f "${file}.bak"
 done
 
 echo "Done"


### PR DESCRIPTION
# Summary

Fix this bug:
https://github.com/mongodb/mongodb-atlas-kubernetes/actions/runs/30828713858
> [Invalid workflow file: .github/workflows/update-sdk.yml#L1](https://github.com/mongodb/mongodb-atlas-kubernetes/actions/runs/30828713858/workflow)
> (Line: 71, Col: 1): Unexpected value 'If this PR does not merge cleanly (build/test failures) or the bump touches public API behavior, follow the runbook'

By turning the buggy multiline text into a single line with `\n`markers.

Also:
- Uses a more precise extraction of the SDK in go.mod.
- Renames the wf task internally.
- Fixes a sed compatibility issue.

## Proof of Work

✅ [Weekly Atlas SDK Update work on branch](https://github.com/mongodb/mongodb-atlas-kubernetes/actions/workflows/update-sdk.yml)](https://github.com/mongodb/mongodb-atlas-kubernetes/actions/runs/30831236422/job/91745420222)

## Checklist
- [X] Have you linked a jira ticket and/or is the ticket in the title?
- [X] Have you checked whether your jira ticket required DOCSP changes?
- [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?


