### PR TITLE
Fixed compare method to support _GEN_2 instances

### DIFF
--- a/internal/controller/validate/deployment.go
+++ b/internal/controller/validate/deployment.go
@@ -214,6 +214,16 @@ func advancedInstanceSizeInRange(currentInstanceSize, minInstanceSize, maxInstan
 		return err
 	}
 
+	if !currentSize.Generation.CompatibleWith(minSize.Generation) {
+		return fmt.Errorf("min instance size %s has a hardware generation incompatible with instance size %s",
+			minInstanceSize, currentInstanceSize)
+	}
+
+	if !currentSize.Generation.CompatibleWith(maxSize.Generation) {
+		return fmt.Errorf("max instance size %s has a hardware generation incompatible with instance size %s",
+			maxInstanceSize, currentInstanceSize)
+	}
+
 	if CompareInstanceSizes(currentSize, minSize) == -1 {
 		return errors.New("the instance size is below the minimum autoscaling configuration")
 	}

--- a/internal/controller/validate/deployment_test.go
+++ b/internal/controller/validate/deployment_test.go
@@ -622,6 +622,71 @@ func TestInstanceSizeRangeForAdvancedDeployment(t *testing.T) {
 			},
 			expectedError: "",
 		},
+		"Gen2 instance size with Gen1 minimum": {
+			regionConfig: &akov2.AdvancedRegionConfig{
+				AutoScaling: &akov2.AdvancedAutoScalingSpec{
+					Compute: &akov2.ComputeSpec{
+						Enabled:         new(true),
+						MinInstanceSize: "M30",
+						MaxInstanceSize: "M60_GEN_2",
+					},
+				},
+				ElectableSpecs: &akov2.Specs{InstanceSize: "M30_GEN_2"},
+			},
+			expectedError: "min instance size M30 has a hardware generation incompatible with instance size M30_GEN_2",
+		},
+		"Gen2 instance size with Gen1 maximum": {
+			regionConfig: &akov2.AdvancedRegionConfig{
+				AutoScaling: &akov2.AdvancedAutoScalingSpec{
+					Compute: &akov2.ComputeSpec{
+						Enabled:         new(true),
+						MinInstanceSize: "M30_GEN_2",
+						MaxInstanceSize: "M60",
+					},
+				},
+				ElectableSpecs: &akov2.Specs{InstanceSize: "M30_GEN_2"},
+			},
+			expectedError: "max instance size M60 has a hardware generation incompatible with instance size M30_GEN_2",
+		},
+		"Gen2 specs within a Gen2 range": {
+			regionConfig: &akov2.AdvancedRegionConfig{
+				AutoScaling: &akov2.AdvancedAutoScalingSpec{
+					Compute: &akov2.ComputeSpec{
+						Enabled:         new(true),
+						MinInstanceSize: "M30_GEN_2",
+						MaxInstanceSize: "M60_GEN_2",
+					},
+				},
+				ElectableSpecs: &akov2.Specs{InstanceSize: "M40_GEN_2"},
+			},
+			expectedError: "",
+		},
+		"Gen2 instance size below a Gen2 minimum": {
+			regionConfig: &akov2.AdvancedRegionConfig{
+				AutoScaling: &akov2.AdvancedAutoScalingSpec{
+					Compute: &akov2.ComputeSpec{
+						Enabled:         new(true),
+						MinInstanceSize: "M40_GEN_2",
+						MaxInstanceSize: "M60_GEN_2",
+					},
+				},
+				ElectableSpecs: &akov2.Specs{InstanceSize: "M30_GEN_2"},
+			},
+			expectedError: "the instance size is below the minimum autoscaling configuration",
+		},
+		"Gen2 instance size with a generation agnostic minimum": {
+			regionConfig: &akov2.AdvancedRegionConfig{
+				AutoScaling: &akov2.AdvancedAutoScalingSpec{
+					Compute: &akov2.ComputeSpec{
+						Enabled:         new(true),
+						MinInstanceSize: "M10",
+						MaxInstanceSize: "M60_GEN_2",
+					},
+				},
+				ElectableSpecs: &akov2.Specs{InstanceSize: "M30_GEN_2"},
+			},
+			expectedError: "",
+		},
 	}
 
 	for name, tt := range tests {

--- a/internal/controller/validate/instance_size.go
+++ b/internal/controller/validate/instance_size.go
@@ -21,18 +21,44 @@ import (
 	"strings"
 )
 
+const gen2Suffix = "_GEN_2"
+
+// Generation is the hardware generation an instance size belongs to. Sizes of different
+// generations are not interchangeable, but they are not ordered relative to each other
+// either, so generation is a compatibility dimension rather than a comparable one.
+type Generation int
+
+const (
+	// GenerationAny covers the sizes offered on every generation, so it is compatible
+	// with all of them. Atlas treats M10 and M20 this way.
+	GenerationAny Generation = iota
+	Generation1
+	Generation2
+)
+
+func (g Generation) CompatibleWith(other Generation) bool {
+	return g == GenerationAny || other == GenerationAny || g == other
+}
+
 type InstanceSize struct {
-	Family string
-	Size   int
-	IsNVME bool
+	Family     string
+	Size       int
+	IsNVME     bool
+	Generation Generation
 }
 
 func (i *InstanceSize) String() string {
+	name := fmt.Sprintf("%s%d", i.Family, i.Size)
+
 	if i.IsNVME {
-		return fmt.Sprintf("%s%d_NVME", i.Family, i.Size)
+		name += "_NVME"
 	}
 
-	return fmt.Sprintf("%s%d", i.Family, i.Size)
+	if i.Generation == Generation2 {
+		name += gen2Suffix
+	}
+
+	return name
 }
 
 func CompareInstanceSizes(is1 InstanceSize, is2 InstanceSize) int {
@@ -68,7 +94,17 @@ func NewFromInstanceSizeName(instanceSizeName string) (InstanceSize, error) {
 		return InstanceSize{}, errors.New("instance size is invalid")
 	}
 
-	pieces := strings.Split(instanceSizeName, "_")
+	// The generation suffix is stripped first because NVMe sizes carry both suffixes,
+	// as in M40_NVME_GEN_2.
+	generation := Generation1
+	base := instanceSizeName
+
+	if strings.HasSuffix(base, gen2Suffix) {
+		generation = Generation2
+		base = strings.TrimSuffix(base, gen2Suffix)
+	}
+
+	pieces := strings.Split(base, "_")
 
 	if pieces[0][0] != 'M' && pieces[0][0] != 'R' {
 		return InstanceSize{}, errors.New("instance size is invalid. instance family should be M or R")
@@ -79,9 +115,14 @@ func NewFromInstanceSizeName(instanceSizeName string) (InstanceSize, error) {
 		return InstanceSize{}, fmt.Errorf("instance size is invalid. %w", err)
 	}
 
+	if generation == Generation1 && pieces[0][0] == 'M' && (number == 10 || number == 20) {
+		generation = GenerationAny
+	}
+
 	return InstanceSize{
-		Family: string(pieces[0][0]),
-		Size:   number,
-		IsNVME: len(pieces) == 2 && pieces[1] == "NVME",
+		Family:     string(pieces[0][0]),
+		Size:       number,
+		IsNVME:     len(pieces) == 2 && pieces[1] == "NVME",
+		Generation: generation,
 	}, nil
 }

--- a/internal/controller/validate/instance_size_test.go
+++ b/internal/controller/validate/instance_size_test.go
@@ -71,6 +71,36 @@ func TestNewFromInstanceSizeName(t *testing.T) {
 			is,
 		)
 	})
+
+	t.Run("should parse generations", func(t *testing.T) {
+		for name, expected := range map[string]InstanceSize{
+			"M30":            {Family: "M", Size: 30, Generation: Generation1},
+			"M30_GEN_2":      {Family: "M", Size: 30, Generation: Generation2},
+			"R40_GEN_2":      {Family: "R", Size: 40, Generation: Generation2},
+			"M40_NVME":       {Family: "M", Size: 40, IsNVME: true, Generation: Generation1},
+			"M40_NVME_GEN_2": {Family: "M", Size: 40, IsNVME: true, Generation: Generation2},
+			// M10 and M20 are offered on every generation.
+			"M10": {Family: "M", Size: 10, Generation: GenerationAny},
+			"M20": {Family: "M", Size: 20, Generation: GenerationAny},
+		} {
+			is, err := NewFromInstanceSizeName(name)
+
+			assert.NoError(t, err, name)
+			assert.Equal(t, expected, is, name)
+			assert.Equal(t, name, is.String(), name)
+		}
+	})
+}
+
+func TestGenerationCompatibleWith(t *testing.T) {
+	t.Run("should only be compatible within a generation or with the agnostic sizes", func(t *testing.T) {
+		assert.True(t, Generation2.CompatibleWith(Generation2))
+		assert.True(t, Generation1.CompatibleWith(Generation1))
+		assert.True(t, Generation2.CompatibleWith(GenerationAny))
+		assert.True(t, GenerationAny.CompatibleWith(Generation1))
+		assert.False(t, Generation1.CompatibleWith(Generation2))
+		assert.False(t, Generation2.CompatibleWith(Generation1))
+	})
 }
 
 func TestCompareInstanceSizes(t *testing.T) {
@@ -176,6 +206,17 @@ func TestCompareInstanceSizes(t *testing.T) {
 				},
 			),
 		)
+	})
+
+	t.Run("should order a Gen2 NVME size above its non-NVME counterpart", func(t *testing.T) {
+		nvme, err := NewFromInstanceSizeName("M40_NVME_GEN_2")
+		assert.NoError(t, err)
+
+		plain, err := NewFromInstanceSizeName("M40_GEN_2")
+		assert.NoError(t, err)
+
+		assert.Equal(t, 1, CompareInstanceSizes(nvme, plain))
+		assert.Equal(t, -1, CompareInstanceSizes(plain, nvme))
 	})
 
 	t.Run("should return 0 when instance 1 and 2 are equal", func(t *testing.T) {


### PR DESCRIPTION
# Summary

Fixed compare method to support _GEN_2 instances for `AtlasDeployment` resource