### PR TITLE
CLOUDP-439411: Removed validations on frequencyType for AtlasBackupSchedule resource

### DIFF
--- a/api/v1/atlasbackupschedule_types.go
+++ b/api/v1/atlasbackupschedule_types.go
@@ -74,8 +74,8 @@ type AtlasBackupExportSpec struct {
 	// Unique Atlas identifier of the AWS bucket which was granted access to export backup snapshot.
 	ExportBucketID string `json:"exportBucketId"`
 	// Human-readable label that indicates the rate at which the export policy item occurs.
-	// +kubebuilder:validation:Enum:=monthly;yearly
-	// +kubebuilder:default:=monthly
+	// See the https://www.mongodb.com/docs/api/doc/atlas-admin-api-v2/operation/operation-updategroupclusterbackupschedule#operation-updategroupclusterbackupschedule-body-application-vnd-atlas-2024-08-05-json-export-frequencytype
+	// for available values
 	FrequencyType string `json:"frequencyType"`
 }
 

--- a/docs/api-docs.md
+++ b/docs/api-docs.md
@@ -878,12 +878,11 @@ Export policy for automatically exporting cloud backup snapshots to AWS bucket.
         <td>true</td>
       </tr><tr>
         <td><b>frequencyType</b></td>
-        <td>enum</td>
+        <td>string</td>
         <td>
-          Human-readable label that indicates the rate at which the export policy item occurs.<br/>
-          <br/>
-            <i>Enum</i>: monthly, yearly<br/>
-            <i>Default</i>: monthly<br/>
+          Human-readable label that indicates the rate at which the export policy item occurs.
+See the https://www.mongodb.com/docs/api/doc/atlas-admin-api-v2/operation/operation-updategroupclusterbackupschedule#operation-updategroupclusterbackupschedule-body-application-vnd-atlas-2024-08-05-json-export-frequencytype
+for available values<br/>
         </td>
         <td>true</td>
       </tr></tbody>


### PR DESCRIPTION
# Summary

CLOUDP-439411: Removed validations on frequencyType for AtlasBackupSchedule resource. The reason is, there are additional values controlled by feature flags in Atlas, so we shift validations back to Atlas API