### PR TITLE
fix: propagate reconciliation context when reaping connection secrets

### DIFF
--- a/internal/controller/atlasdatabaseuser/connectionsecrets.go
+++ b/internal/controller/atlasdatabaseuser/connectionsecrets.go
@@ -39,7 +39,7 @@ const ConnectionSecretsEnsuredEvent = "ConnectionSecretsEnsured"
 func ReapOrphanConnectionSecrets(ctx context.Context, k8sClient client.Client, projectID, namespace string, projectDeploymentNames []string) ([]string, error) {
 	secretList := &corev1.SecretList{}
 	labelSelector := labels.SelectorFromSet(labels.Set{secretservice.TypeLabelKey: secretservice.CredLabelVal, secretservice.ProjectLabelKey: projectID})
-	err := k8sClient.List(context.Background(), secretList, &client.ListOptions{
+	err := k8sClient.List(ctx, secretList, &client.ListOptions{
 		LabelSelector: labelSelector,
 		Namespace:     namespace,
 	})


### PR DESCRIPTION
## Summary

Propagate the reconciliation context through the Kubernetes `List` call in `ReapOrphanConnectionSecrets`.

The function already receives the reconciliation context and uses it for deleting orphaned secrets, but the list operation was using `context.Background()`, preventing cancellation and deadline propagation.

## Validation

- `go test ./internal/controller/atlasdatabaseuser/...`
- `gci` formatting check
- `go vet`
- `git diff --check`