### PR TITLE
CLOUDP-433229: Set limit for numShards to max 1000 as in Atlas

### DIFF
--- a/api/v1/atlasdeployment_types.go
+++ b/api/v1/atlasdeployment_types.go
@@ -312,6 +312,10 @@ type AdvancedReplicationSpec struct {
 	// If you set this value to 1 and clusterType is SHARDED, MongoDB Cloud deploys a single-shard sharded cluster.
 	// Don't create a sharded cluster with a single shard for production environments.
 	// Single-shard sharded clusters don't provide the same benefits as multi-shard configurations
+	// The upper bound is the hard limit Atlas enforces on shards per cluster. The limit
+	// effective for a project may be lower (80 by default) and is validated by Atlas.
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Maximum=1000
 	NumShards int `json:"numShards,omitempty"`
 	// Human-readable label that identifies the zone in a Global Cluster.
 	ZoneName string `json:"zoneName,omitempty"`

--- a/docs/api-docs.md
+++ b/docs/api-docs.md
@@ -3658,7 +3658,12 @@ MongoDB Cloud distributes data based on the defined zones and zone ranges for th
           Positive integer that specifies the number of shards to deploy in each specified zone.
 If you set this value to 1 and clusterType is SHARDED, MongoDB Cloud deploys a single-shard sharded cluster.
 Don't create a sharded cluster with a single shard for production environments.
-Single-shard sharded clusters don't provide the same benefits as multi-shard configurations<br/>
+Single-shard sharded clusters don't provide the same benefits as multi-shard configurations
+The upper bound is the hard limit Atlas enforces on shards per cluster. The limit
+effective for a project may be lower (80 by default) and is validated by Atlas.<br/>
+          <br/>
+            <i>Minimum</i>: 0<br/>
+            <i>Maximum</i>: 1000<br/>
         </td>
         <td>false</td>
       </tr><tr>


### PR DESCRIPTION
# Summary

Set limit for `numShards` in AtlasDeployment to max `1000` as in Atlas

## Proof of Work

## Checklist
- [ ] Have you linked a jira ticket and/or is the ticket in the title?
- [ ] Have you checked whether your jira ticket required DOCSP changes?
- [ ] Have you checked for release_note changes?
- [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?

## Reminder (Please remove this when merging)
- Please try to Approve or Reject Changes the PR, keep PRs in review as short as possible
- Remember the following Communication Standards - use comment prefixes for clarity:
  * **blocking**: Must be addressed before approval.
  * **follow-up**: Can be addressed in a later PR or ticket.
  * **q**: Clarifying question.
  * **nit**: Non-blocking suggestions.
  * **note**: Side-note, non-actionable. Example: Praise 
  * --> no prefix is considered a question

