### PR TITLE
KUBE-412: test: simplify complex deployment int test update step

### DIFF
--- a/test/int/deployment_test.go
+++ b/test/int/deployment_test.go
@@ -477,47 +477,8 @@ var _ = Describe("AtlasDeployment", Label("int", "AtlasDeployment", "focus-deplo
 			By("Updating the deployment (multiple operations)", func() {
 				var legacySpec *akov2.AdvancedDeploymentSpec
 				createdDeployment = performUpdate(ctx, DeploymentUpdateTimeout, client.ObjectKeyFromObject(createdDeployment), func(deployment *akov2.AtlasDeployment) {
-					deployment.Spec.DeploymentSpec.ReplicationSpecs[0].RegionConfigs = []*akov2.AdvancedRegionConfig{
-						{
-							AutoScaling: &akov2.AdvancedAutoScalingSpec{
-								DiskGB: &akov2.DiskGB{
-									Enabled: new(true),
-								},
-								Compute: &akov2.ComputeSpec{
-									Enabled:          new(true),
-									ScaleDownEnabled: new(true),
-									MinInstanceSize:  "M10",
-									MaxInstanceSize:  "M30",
-								},
-							},
-							ElectableSpecs: &akov2.Specs{
-								InstanceSize: "M10",
-								NodeCount:    new(2),
-							},
-							Priority:     new(7),
-							ProviderName: "AWS",
-							RegionName:   "US_EAST_1",
-						},
-						{
-							ElectableSpecs: &akov2.Specs{
-								InstanceSize: "M10",
-								NodeCount:    new(1),
-							},
-							Priority:     new(6),
-							ProviderName: "AWS",
-							RegionName:   "US_WEST_1",
-							AutoScaling: &akov2.AdvancedAutoScalingSpec{
-								DiskGB: &akov2.DiskGB{
-									Enabled: new(true),
-								},
-								Compute: &akov2.ComputeSpec{
-									Enabled:          new(true),
-									ScaleDownEnabled: new(true),
-									MinInstanceSize:  "M10",
-									MaxInstanceSize:  "M30",
-								},
-							},
-						},
+					for _, rc := range deployment.Spec.DeploymentSpec.ReplicationSpecs[0].RegionConfigs {
+						rc.AutoScaling.Compute.MaxInstanceSize = "M30"
 					}
 
 					legacySpec = deployment.Spec.DeploymentSpec


### PR DESCRIPTION
# Summary

The "Create/Update the deployment (more complex scenario)" test performed two mutations in a single update (MaxInstanceSize M20->M30 and region US_WEST_2->US_WEST_1), which has been flaky in the QA test environment. The individual scenarios are already covered by other tests, so the combined update is unnecessary.

Reduce the Update 1 step to only change MaxInstanceSize in-place on the existing region configs, keeping the region and other fields unchanged.

## Proof of Work

The **int** tests must pass all now.

## Checklist
- [X] Have you linked a jira ticket and/or is the ticket in the title?
- [X] Have you checked whether your jira ticket required DOCSP changes?
- [X] Have you checked for release_note changes?
- [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
